### PR TITLE
Fix stopping Terraform tasks in waiting_confirmation stage

### DIFF
--- a/db_lib/TerraformApp.go
+++ b/db_lib/TerraformApp.go
@@ -374,7 +374,8 @@ func (t *TerraformApp) Run(args LocalAppRunningArgs) error {
 		time.Sleep(time.Second * 3)
 		if t.reader.status.IsFinished() ||
 			t.reader.status == task_logger.TaskConfirmed ||
-			t.reader.status == task_logger.TaskRejected {
+			t.reader.status == task_logger.TaskRejected ||
+			t.reader.status == task_logger.TaskStoppingStatus {
 			break
 		}
 	}

--- a/services/runners/job_pool.go
+++ b/services/runners/job_pool.go
@@ -208,7 +208,11 @@ func (p *JobPool) Run() {
 						runningJob.SetStatus(task_logger.TaskFailStatus)
 					}
 				} else {
-					runningJob.SetStatus(task_logger.TaskSuccessStatus)
+					if runningJob.status == task_logger.TaskStoppingStatus {
+						runningJob.SetStatus(task_logger.TaskStoppedStatus)
+					} else {
+						runningJob.SetStatus(task_logger.TaskSuccessStatus)
+					}
 				}
 
 				logger.TaskInfo("Task finished", runningJob.job.Task.ID, string(runningJob.status))

--- a/services/tasks/TaskRunner_logging.go
+++ b/services/tasks/TaskRunner_logging.go
@@ -94,7 +94,7 @@ func (t *TaskRunner) SetStatus(status task_logger.TaskStatus) {
 			return
 		}
 	case task_logger.TaskStoppingStatus:
-		if status == task_logger.TaskWaitingStatus || status == task_logger.TaskRunningStatus {
+		if status == task_logger.TaskWaitingStatus || status == task_logger.TaskRunningStatus || status == task_logger.TaskWaitingConfirmation {
 			//panic("stopping TaskRunner cannot be " + status)
 			return
 		}


### PR DESCRIPTION
## PR Title

Fix task stopping behavior for terraform tasks in **`waiting_confirmation`** state 

## Description

This PR fixes incorrect task status handling when attempting to stop tasks that are in the **`waiting_confirmation`** state.
Additionally, a bug was fixed where tasks would fail to stop at the **`waiting_confirmation`** stage (except in force stop mode).

## Observed problem

When trying to stop a task that is waiting for confirmation (for example during Terraform workflows), the task could not be stopped normally.

### UI behavior

When clicking **Stop** for a task in `waiting_confirmation`:

1. The task briefly transitioned to **`stopping`**.
2. For about 1–2 seconds the **Force Stop** button appeared.
3. After that the task returned back to **`waiting_confirmation`** and the original confirmation buttons reappeared.

As a result, the normal stop operation did not work.
The only reliable way to stop the task was - quickly pressing **Force Stop** in the UI before the status reverted.

## Root cause (Issue 1)

The runner periodically sends task statuses to the server.

When a user attempted to stop a task:

1. The server changed the task status to **`stopping`**.
2. Before the stopping logic was processed, the runner sent its current task status **`waiting_confirmation`**.
3. This status overwrote the **`stopping`** state on the server.

As a result, the task reverted back to **`waiting_confirmation`**, making normal stopping impossible.

## Root cause (Issue 2 – Terraform specific)

At the **`waiting_confirmation`** stage, when a task transitioned to the **stopping** status, the infinite loop of waiting for confirmation or aborting the task execution was not exited.

As a result, the task at the **`stopping`**  stage could not transition to the **`stopped`** status.

## Solution

This PR fixes both issues:

1. Prevents the runner from overwriting the **`stopping`** state with `waiting_confirmation`.
2. Correctly handles stopping logic for tasks that are waiting for confirmation, especially for Terraform workflows where no active process exists at that stage.

## Result

* Tasks in `waiting_confirmation` can now be stopped normally
* The `stopping` state is no longer overwritten by runner status updates
* UI behavior is now consistent and predictable