### PR TITLE
Upgrade Ansible from 11.1.0 to 13.5.0 (ansible-core 2.20.4)

### DIFF
--- a/deployment/docker/runner/Dockerfile
+++ b/deployment/docker/runner/Dockerfile
@@ -78,7 +78,7 @@ RUN chown -R semaphore:0 /usr/local/bin/runner-wrapper && \
 WORKDIR /home/semaphore
 
 # renovate: datasource=pypi depName=ansible
-ARG ANSIBLE_VERSION=11.1.0
+ARG ANSIBLE_VERSION=13.5.0
 ENV ANSIBLE_VERSION=${ANSIBLE_VERSION}
 ARG ANSIBLE_VENV_PATH=/opt/semaphore/apps/ansible/${ANSIBLE_VERSION}/venv
 

--- a/deployment/docker/server/Dockerfile
+++ b/deployment/docker/server/Dockerfile
@@ -50,7 +50,7 @@ FROM alpine:3.21
 
 ARG TARGETARCH="amd64"
 # renovate: datasource=pypi depName=ansible
-ARG ANSIBLE_VERSION=11.1.0
+ARG ANSIBLE_VERSION=13.5.0
 ENV ANSIBLE_VERSION=${ANSIBLE_VERSION}
 ARG ANSIBLE_VENV_PATH=/opt/semaphore/apps/ansible/${ANSIBLE_VERSION}/venv
 


### PR DESCRIPTION
Ansible 11.1.0 is EOL, hence this upgrade.

Closes #3683