### PR TITLE
Gate secret sync scheduler to a single HA worker

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -137,6 +137,7 @@ func runService() {
 
 	if dedup := proHA.NewScheduleDeduplicator(); dedup != nil {
 		schedulePool.SetDeduplicator(dedup)
+		secretStorageSyncScheduler.SetTickDeduplicator(dedup)
 	}
 
 	// Each process holds its own in-memory cron table. Schedule CRUD handlers only

--- a/services/server/secret_storage_sync_scheduler.go
+++ b/services/server/secret_storage_sync_scheduler.go
@@ -16,6 +16,7 @@ const secretStorageSyncTickInterval = 60 * time.Second
 type SecretStorageSyncScheduler struct {
 	secretStorageRepo    db.SecretStorageRepository
 	secretStorageService SecretStorageService
+	tickDeduplicator     interface{ TryLockExecution(scheduleID int) bool }
 
 	stop chan struct{}
 	wg   sync.WaitGroup
@@ -30,6 +31,12 @@ func NewSecretStorageSyncScheduler(
 		secretStorageService: secretStorageService,
 		stop:                 make(chan struct{}),
 	}
+}
+
+const secretStorageSyncTickLockID = 0
+
+func (s *SecretStorageSyncScheduler) SetTickDeduplicator(d interface{ TryLockExecution(scheduleID int) bool }) {
+	s.tickDeduplicator = d
 }
 
 func (s *SecretStorageSyncScheduler) Start() {
@@ -59,6 +66,10 @@ func (s *SecretStorageSyncScheduler) run() {
 }
 
 func (s *SecretStorageSyncScheduler) tick() {
+	if s.tickDeduplicator != nil && !s.tickDeduplicator.TryLockExecution(secretStorageSyncTickLockID) {
+		return
+	}
+
 	storages, err := s.secretStorageRepo.GetSyncEnabledSecretStorages()
 	if err != nil {
 		log.WithError(err).Warn("secret storage sync: failed to list sync-enabled storages")


### PR DESCRIPTION
### Motivation
- In active-active HA mode every node was running the secret-sync ticker, causing duplicate sync calls and potential concurrent writes. 
- Reuse the existing schedule deduplicator so only one node executes secret-sync ticks cluster-wide.

### Description
- Added an optional `tickDeduplicator` hook and `SetTickDeduplicator` method to `SecretStorageSyncScheduler` and introduced a lock id constant `secretStorageSyncTickLockID` in `services/server/secret_storage_sync_scheduler.go`.
- Early-return from each scheduler tick when `tickDeduplicator.TryLockExecution(...)` indicates this node should not run the tick. 
- Wired the deduplicator into the scheduler in `cli/cmd/root.go` by calling `secretStorageSyncScheduler.SetTickDeduplicator(dedup)` when `proHA.NewScheduleDeduplicator()` is available.

### Testing
- Ran `go test ./services/server`, which passed successfully. 
- Ran `go test ./cli/cmd ./services/server`, which failed in this environment because `cli/cmd` setup expects embedded `public/*` assets (test environment missing those files), so the failure is environment-specific and unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f73f83448325bf3c0fd9e3a437c6)