### PR TITLE
fix(bolt): return empty slice for templates list with no rows (#3245)

### DIFF
--- a/db/bolt/template.go
+++ b/db/bolt/template.go
@@ -76,6 +76,10 @@ func (d *BoltDb) GetTemplatesWithPermissions(projectID int, userID int, filter d
 		return
 	}
 
+	// Initialize as a non-nil slice so an empty result marshals to `[]` rather than `null`.
+	// The web UI's templates page hangs when the API returns `null` (issue #3245).
+	templates = make([]db.TemplateWithPerms, 0, len(res))
+
 	for _, tpl := range res {
 		var tplWithPerms db.TemplateWithPerms
 		tplWithPerms.Template = tpl

--- a/db/bolt/template_test.go
+++ b/db/bolt/template_test.go
@@ -40,3 +40,31 @@ func Test_SetTemplateDescription(t *testing.T) {
 		t.Fatalf("expected description to be 'New description', got '%s'", *tpl.Description)
 	}
 }
+
+// Regression test for #3245: GetTemplatesWithPermissions used to return a nil
+// slice when no templates matched, which JSON-marshals to `null` and wedges
+// the web UI's templates page. The API contract is an array; an empty result
+// must serialize to `[]`.
+func Test_GetTemplatesWithPermissions_EmptyReturnsNonNilSlice(t *testing.T) {
+	store := CreateTestStore()
+
+	proj, err := store.CreateProject(db.Project{
+		Created: tz.Now(),
+		Name:    "TestProject",
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	templates, err := store.GetTemplatesWithPermissions(proj.ID, 0, db.TemplateFilter{}, db.RetrieveQueryParams{})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if templates == nil {
+		t.Fatal("expected empty (non-nil) slice for project with no templates, got nil")
+	}
+	if len(templates) != 0 {
+		t.Fatalf("expected zero templates, got %d", len(templates))
+	}
+}


### PR DESCRIPTION
## Summary

`BoltDb.GetTemplatesWithPermissions` returns a nil `[]db.TemplateWithPerms` when no templates match — the named-return slice stays nil because the loop over an empty `GetTemplates` result never appends. Nil marshals to JSON `null` instead of `[]`, and the web UI's templates page hangs on a perpetual loading spinner because the frontend tries to iterate over the response.

The bug is BoltDB-specific. sqlx-backed dialects (SQLite/MySQL/Postgres) return non-nil slices because of how `Scan` populates them, which matches multiple user reports in #3245 noting the issue disappears after switching off Bolt.

## The fix

One line in `GetTemplatesWithPermissions`:

```go
templates = make([]db.TemplateWithPerms, 0, len(res))
```

before the append loop. Guarantees a non-nil slice for the empty case.

## Test plan

- [x] Added `Test_GetTemplatesWithPermissions_EmptyReturnsNonNilSlice` regression test in `db/bolt/template_test.go`
- [x] `go test ./db/bolt/...` passes locally (Go 1.24)
- [x] Verified bug reproduces against `v2.17.39` BoltDB deployment: `/api/project/N/templates` returns the literal string `null` for empty projects

## Related

Fixes #3245. Multiple users (@codewest, @bearyjd, @SandraCHC, @vaemarr, @the-hotmann, @J-Bland) report this on BoltDB across v2.17.0 → v2.17.39.

There may be similar nil-slice bugs in other BoltDB list endpoints (inventory, repositories, environment, keys), but this PR is intentionally scoped to the symptom that wedges the UI. Happy to follow up with a broader sweep if reviewers want it in a separate PR.