### PR TITLE
fix(bolt): prevent nil pointer panic during project restore (#3580)

### DIFF
--- a/db/bolt/BoltDb.go
+++ b/db/bolt/BoltDb.go
@@ -331,7 +331,11 @@ func createObjectType(t reflect.Type) reflect.Type {
 }
 
 func unmarshalObject(data []byte, obj any, fields []string) error {
-	newType := createObjectType(reflect.TypeOf(obj))
+	objType := reflect.TypeOf(obj)
+	if objType == nil {
+		return fmt.Errorf("unmarshalObject: destination object is nil")
+	}
+	newType := createObjectType(objType)
 	ptr := reflect.New(newType).Interface()
 
 	err := json.Unmarshal(data, ptr)

--- a/db/bolt/public_alias.go
+++ b/db/bolt/public_alias.go
@@ -39,10 +39,16 @@ func (d *publicAlias) createAlias(aliasObj any) (newAlias any, err error) {
 
 	alias := aliasObj.(db.Aliasable).ToAlias()
 
-	err = d.getPublicAlias(alias.Alias, newAlias)
+	// Allocate a typed receiver so unmarshalObject can populate it via reflection.
+	// Passing the uninitialized `newAlias` (a nil interface) caused a nil pointer
+	// dereference inside createObjectType when the public alias bucket already
+	// contained an entry. See semaphoreui/semaphore#3580.
+	existing := reflect.New(d.publicAliasProps.Type).Interface()
+	err = d.getPublicAlias(alias.Alias, existing)
 
 	if err == nil {
 		err = fmt.Errorf("alias already exists")
+		return
 	}
 
 	if !errors.Is(err, db.ErrNotFound) {

--- a/db/bolt/public_alias_test.go
+++ b/db/bolt/public_alias_test.go
@@ -1,0 +1,49 @@
+package bolt
+
+import (
+	"testing"
+
+	"github.com/semaphoreui/semaphore/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression test for semaphoreui/semaphore#3580.
+//
+// When a project was restored more than once (or whenever an integration alias
+// happened to collide with one already stored in the global public alias bucket),
+// publicAlias.createAlias passed an uninitialised `any` to getPublicAlias. That
+// nil destination propagated into unmarshalObject -> createObjectType, where
+// reflect.TypeOf(nil) yielded a nil reflect.Type and the call panicked with a
+// nil pointer dereference. The expected behaviour is a normal duplicate-alias
+// error, not a server-killing panic.
+func TestCreateIntegrationAlias_DuplicateDoesNotPanic(t *testing.T) {
+	store := CreateTestStore()
+
+	proj, err := store.CreateProject(db.Project{Name: "p"})
+	require.NoError(t, err)
+
+	_, err = store.CreateIntegrationAlias(db.IntegrationAlias{
+		Alias:     "shared-alias",
+		ProjectID: proj.ID,
+	})
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, err = store.CreateIntegrationAlias(db.IntegrationAlias{
+			Alias:     "shared-alias",
+			ProjectID: proj.ID,
+		})
+	})
+	assert.Error(t, err, "duplicate alias must surface as an error")
+}
+
+// TestUnmarshalObject_NilDestinationReturnsError guards the defensive check
+// added to unmarshalObject so that any future caller that forgets to allocate
+// a destination object gets a clean error instead of a panic.
+func TestUnmarshalObject_NilDestinationReturnsError(t *testing.T) {
+	require.NotPanics(t, func() {
+		err := unmarshalObject([]byte(`{}`), nil, nil)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
Fixes #3580. `publicAlias.createAlias` checked for duplicate aliases by passing an uninitialised `any` to `getPublicAlias`, which propagated a nil destination into `unmarshalObject` and crashed the server in `createObjectType` whenever the global public-alias bucket already held an entry. Allocates a typed receiver for the duplicate lookup, adds a belt-and-braces nil guard in `unmarshalObject`, and includes a regression test that panics on `develop` and passes here.