### PR TITLE
Fix setup SQL connect panic and add startup retries

### DIFF
--- a/cli/cmd/setup.go
+++ b/cli/cmd/setup.go
@@ -39,8 +39,8 @@ func doSetup() int {
 	fmt.Println(" Pinging db..")
 
 	store := factory.CreateStore()
-	defer store.Close("setup")
 	store.Connect("setup")
+	defer store.Close("setup")
 
 	fmt.Println("Running db Migrations..")
 	if err := db.Migrate(store, nil); err != nil {

--- a/db/sql/SqlDb.go
+++ b/db/sql/SqlDb.go
@@ -31,34 +31,58 @@ type SqlDb struct {
 	connection SqlDbConnection
 }
 
+const (
+	connectMaxAttempts  = 12
+	connectRetryBackoff = 5 * time.Second
+)
+
 func (d *SqlDb) Sql() *gorp.DbMap {
 	return d.connection.sql
 }
 
 func (d *SqlDbConnection) Connect() {
-	sqlDb, err := connect()
-	if err != nil {
-		panic(err)
+	var (
+		sqlDb   *sql.DB
+		err     error
+		lastErr error
+	)
+
+	for i := 0; i < connectMaxAttempts; i++ {
+		sqlDb, err = connect()
+		if err == nil {
+			err = sqlDb.Ping()
+		}
+
+		if err == nil {
+			break
+		}
+
+		lastErr = err
+
+		if sqlDb != nil {
+			if closeErr := sqlDb.Close(); closeErr != nil {
+				log.Warn("Cannot close database connection: " + closeErr.Error())
+			}
+		}
+
+		if createErr := createDb(); createErr != nil {
+			log.Warn("Cannot create database: " + createErr.Error())
+		}
+
+		if i < connectMaxAttempts-1 {
+			log.Warnf(
+				"Cannot connect to database (attempt %d/%d): %v. Retrying in %s",
+				i+1,
+				connectMaxAttempts,
+				lastErr,
+				connectRetryBackoff,
+			)
+			time.Sleep(connectRetryBackoff)
+		}
 	}
 
-	err = sqlDb.Ping()
-	if err != nil {
-		if err = sqlDb.Close(); err != nil {
-			log.Warn("Cannot close database connection: " + err.Error())
-		}
-
-		if err = createDb(); err != nil {
-			panic(err)
-		}
-
-		sqlDb, err = connect()
-		if err != nil {
-			panic(err)
-		}
-
-		if err = sqlDb.Ping(); err != nil {
-			panic(err)
-		}
+	if lastErr != nil {
+		panic(fmt.Errorf("cannot connect to database after %d attempts: %w", connectMaxAttempts, lastErr))
 	}
 
 	cfg, err := util.Config.GetDBConfig()
@@ -105,10 +129,15 @@ func (d *SqlDbConnection) Connect() {
 }
 
 func (d *SqlDbConnection) Close() {
+	if d.sql == nil || d.sql.Db == nil {
+		return
+	}
 	err := d.sql.Db.Close()
 	if err != nil {
 		panic(err)
 	}
+
+	d.sql = nil
 }
 
 func CreateTestStore() *SqlDb {

--- a/db/sql/SqlDb_test.go
+++ b/db/sql/SqlDb_test.go
@@ -13,3 +13,9 @@ func TestValidatePort(t *testing.T) {
 		t.Error("invalid postgres query")
 	}
 }
+
+func TestCloseWithoutConnect(t *testing.T) {
+	d := SqlDb{}
+
+	d.connection.Close()
+}


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #1653

When running Semaphore with MySQL in Docker Compose, startup can fail during early database initialization windows.

Two concrete failures were reported:

1. Setup panic after DB auth/connect failure due to deferred close on an uninitialized SQL connection.
2. Setup failing too early while MySQL/user/database readiness is still converging.

### What changed and how does it work?
This PR hardens SQL setup/startup behavior:

1. Safe setup close ordering (`cli/cmd/setup.go`)
   - In setup flow, connect first, then defer close.
   - Prevents deferred close from running against a not-yet-initialized SQL store after connect failure.

2. Nil-safe SQL close (`db/sql/SqlDb.go`)
   - `SqlDbConnection.Close()` now safely no-ops when SQL handles are not initialized.
   - Clears internal SQL handle map after close (`d.sql = nil`).

3. SQL connect retry/backoff for container startup race (`db/sql/SqlDb.go`)
   - `Connect()` now retries ping/connect with bounded attempts and backoff.
   - On failed attempts, transient handles are closed and DB creation/readiness path is retried.
   - Final failure includes wrapped context about attempts/errors.

4. Regression test (`db/sql/SqlDb_test.go`)
   - Adds test coverage to validate close-on-uninitialized-connection does not panic.

### Why this approach?
- Fixes the reported panic directly with minimal behavioral risk.
- Makes startup robust to common containerized DB readiness timing.
- Keeps logic centralized in SQL connection handling so both setup and runtime paths benefit.

### Check List
Tests
- [x] Unit test
- [ ] Integration test
- [x] Manual test
  - `go -C /home/calelin/dev/semaphore test ./db/sql`
  - `go -C /home/calelin/dev/semaphore test ./cli/setup`
- [ ] No need to test

Documentation
- [x] Affects user behaviors
- [ ] Additional docs required

### Release note
Improve MySQL startup reliability in Docker Compose by adding retry/backoff during SQL connect and fixing a setup panic caused by closing uninitialized SQL connections.