### PR TITLE
Potential fix for code scanning alert no. 102: Email content injection

### DIFF
--- a/util/mailer/mailer.go
+++ b/util/mailer/mailer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
+	"html"
 	"net"
 	"net/smtp"
 	"strings"
@@ -78,7 +79,7 @@ func Send(
 		To:      r.Replace(to),
 		From:    r.Replace(from),
 		Subject: r.Replace(subject),
-		Body:    content,
+		Body:    html.EscapeString(content),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Potential fix for [https://github.com/semaphoreui/semaphore/security/code-scanning/102](https://github.com/semaphoreui/semaphore/security/code-scanning/102)

The safest fix without changing behavior significantly is to HTML-escape email body content at the mailer boundary before templating/sending. This preserves plain text semantics while neutralizing injected HTML tags/attributes from untrusted fields.

Best single fix:
- In `util/mailer/mailer.go`, import Go’s standard `html` package.
- In `Send(...)`, replace `Body: content` with `Body: html.EscapeString(content)` when executing `mailerBase`.

This keeps existing flow and SMTP logic intact, and centrally protects all callers of `mailer.Send` from HTML body injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
