### PR TITLE
fix(api): prevent 404 after OIDC login when web_host is empty

### DIFF
--- a/api/login.go
+++ b/api/login.go
@@ -809,20 +809,40 @@ func oidcRedirect(w http.ResponseWriter, r *http.Request) {
 		redirectPath = mux.Vars(r)["redirect_path"]
 	}
 
-	if !strings.HasPrefix(redirectPath, "/") {
-		redirectPath = "/" + redirectPath
-	}
-
-	redirectURL, err := url.JoinPath(util.Config.WebHost, redirectPath)
+	redirectURL, err := buildOidcRedirectURL(util.Config.WebHost, redirectPath)
 	if err != nil {
 		log.Error(err)
 		http.Redirect(w, r, loginURL, http.StatusTemporaryRedirect)
 		return
 	}
 
+	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
+}
+
+// buildOidcRedirectURL builds the post-OIDC-login redirect target.
+//
+// When webHost is empty (Semaphore mounted at root, per docs), url.JoinPath
+// drops the leading slash from redirectPath, producing a relative URL that
+// the browser resolves against the current /api/auth/oidc/<id>/redirect URL,
+// resulting in a 404. In that case return an absolute path beginning with /.
+// See https://github.com/semaphoreui/semaphore/issues/2681.
+func buildOidcRedirectURL(webHost, redirectPath string) (string, error) {
+	if !strings.HasPrefix(redirectPath, "/") {
+		redirectPath = "/" + redirectPath
+	}
+
+	if webHost == "" {
+		return redirectPath, nil
+	}
+
+	redirectURL, err := url.JoinPath(webHost, redirectPath)
+	if err != nil {
+		return "", err
+	}
+
 	if redirectURL == "" {
 		redirectURL = "/"
 	}
 
-	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
+	return redirectURL, nil
 }

--- a/api/login_test.go
+++ b/api/login_test.go
@@ -174,3 +174,56 @@ func TestGenerateStateOauthCookieUniqueness(t *testing.T) {
 	// Verify states are different
 	assert.NotEqual(t, state1Str, state2Str, "Multiple calls should generate different state strings")
 }
+
+func TestBuildOidcRedirectURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		webHost      string
+		redirectPath string
+		want         string
+	}{
+		{
+			name:         "empty web_host returns absolute path (issue #2681)",
+			webHost:      "",
+			redirectPath: "/project/1/history",
+			want:         "/project/1/history",
+		},
+		{
+			name:         "empty web_host with empty path returns root",
+			webHost:      "",
+			redirectPath: "",
+			want:         "/",
+		},
+		{
+			name:         "empty web_host with path missing leading slash",
+			webHost:      "",
+			redirectPath: "project/1",
+			want:         "/project/1",
+		},
+		{
+			name:         "configured web_host joins absolute URL",
+			webHost:      "https://semaphore.example.com",
+			redirectPath: "/project/1",
+			want:         "https://semaphore.example.com/project/1",
+		},
+		{
+			name:         "configured web_host with subpath",
+			webHost:      "https://example.com/semaphore",
+			redirectPath: "/project/1",
+			want:         "https://example.com/semaphore/project/1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildOidcRedirectURL(tc.webHost, tc.redirectPath)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+			// Critical: result must never be an obviously-relative path
+			// that the browser would resolve under /api/auth/oidc/...
+			if tc.webHost == "" {
+				assert.True(t, len(got) > 0 && got[0] == '/',
+					"empty web_host must produce absolute path, got %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2681.

When `web_host` is unset (Semaphore mounted at root, per the [config docs](https://docs.semaphoreui.com/administration-guide/configuration/)), `url.JoinPath("", "/project/1")` returns `"project/1"`, the leading slash is stripped, producing a relative URL. The browser resolves it against the current `/api/auth/oidc/<id>/redirect` URL, landing the user at `/api/auth/oidc/<id>/project/1` and returning 404. The reporter's workaround of setting `web_host = "/"` confirms the cause.

Extracted the redirect-URL build into `buildOidcRedirectURL` and return an absolute path beginning with `/` when `web_host` is empty. Added table-driven tests for empty and configured `web_host` cases.

Tested with `go test ./api/... -run Login`.