### PR TITLE
Potential fix for code scanning alert no. 115: Clear-text logging of sensitive information

### DIFF
--- a/services/tasks/LocalJob.go
+++ b/services/tasks/LocalJob.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/semaphoreui/semaphore/pkg/ssh"
@@ -56,8 +57,14 @@ func (t *LocalJob) Kill() {
 	}
 }
 
+var httpURLCredentialsRe = regexp.MustCompile(`(https?://)([^/\s@]+)@`)
+
+func (t *LocalJob) sanitizeLogMessage(msg string) string {
+	return httpURLCredentialsRe.ReplaceAllString(msg, `${1}***@`)
+}
+
 func (t *LocalJob) Log(msg string) {
-	t.Logger.Log(msg)
+	t.Logger.Log(t.sanitizeLogMessage(msg))
 }
 
 func (t *LocalJob) SetStatus(status task_logger.TaskStatus) {


### PR DESCRIPTION
Potential fix for [https://github.com/semaphoreui/semaphore/security/code-scanning/115](https://github.com/semaphoreui/semaphore/security/code-scanning/115)

General fix: ensure all log messages are sanitized before emission so secrets (especially credentials embedded in URLs like `https://user:pass@host/...`) are redacted.

Best single fix without changing functionality: update `services/tasks/LocalJob.go` so `Log(msg string)` passes a sanitized message to `t.Logger.Log`. Add a helper that redacts userinfo in `http://` / `https://` URLs from `user[:password]@` to `***@`. This preserves operational logging context while removing sensitive data. No behavior change outside log content redaction.

Changes needed:
- **File:** `services/tasks/LocalJob.go`
  - Add import: `regexp`
  - Add helper method on `LocalJob` (or private function) to sanitize log message.
  - Update `Log(msg string)` to call sanitizer before logging.
- No changes are required in `db/Repository.go` for this alert, since the sink-side sanitization addresses both variants centrally.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
