### PR TITLE
truncate commit message by runes, not bytes

### DIFF
--- a/db_lib/CmdGitClient.go
+++ b/db_lib/CmdGitClient.go
@@ -155,9 +155,7 @@ func (c CmdGitClient) GetLastCommitMessage(r GitRepository) (msg string, err err
 		return
 	}
 
-	if len(msg) > 100 {
-		msg = msg[0:100]
-	}
+	msg = truncateCommitMessage(msg)
 
 	return
 }

--- a/db_lib/GoGitClient.go
+++ b/db_lib/GoGitClient.go
@@ -230,10 +230,7 @@ func (c GoGitClient) GetLastCommitMessage(r GitRepository) (msg string, err erro
 		return
 	}
 
-	msg = headCommit.Message
-	if len(msg) > 100 {
-		msg = msg[0:100]
-	}
+	msg = truncateCommitMessage(headCommit.Message)
 
 	r.Logger.Log("Message: " + msg)
 

--- a/db_lib/commit_message.go
+++ b/db_lib/commit_message.go
@@ -1,0 +1,13 @@
+package db_lib
+
+// Matches `commit_message VARCHAR(100)` in db/sql/migrations.
+const commitMessageMaxRunes = 100
+
+// Slice by runes — byte slicing can split a multi-byte UTF-8 sequence.
+func truncateCommitMessage(msg string) string {
+	runes := []rune(msg)
+	if len(runes) > commitMessageMaxRunes {
+		return string(runes[:commitMessageMaxRunes])
+	}
+	return msg
+}

--- a/db_lib/commit_message_test.go
+++ b/db_lib/commit_message_test.go
@@ -1,0 +1,52 @@
+package db_lib
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncateCommitMessage_KeepsFullString(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"short ASCII", "fix: short"},
+		{"100 ASCII", strings.Repeat("a", 100)},
+		{"100 Cyrillic", strings.Repeat("ы", 100)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.input, truncateCommitMessage(tt.input))
+		})
+	}
+}
+
+func TestTruncateCommitMessage_Truncates(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"101 ASCII", strings.Repeat("a", 101), strings.Repeat("a", 100)},
+		{"150 Cyrillic", strings.Repeat("ы", 150), strings.Repeat("ы", 100)},
+		{"150 emoji", strings.Repeat("🙂", 150), strings.Repeat("🙂", 100)},
+		{"99 ASCII + 3 Cyrillic", strings.Repeat("a", 99) + "ыыы", strings.Repeat("a", 99) + "ы"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, truncateCommitMessage(tt.input))
+		})
+	}
+}
+
+func TestLegacyByteSliceProducesInvalidUTF8(t *testing.T) {
+	msg := "Hello мир, γειά κόσμε, مرحبا بالعالم, שלום עולם, 你好世界, こんにちは 안녕하세요 🌍🎉"
+
+	require.Greater(t, len(msg), 100)
+	assert.False(t, utf8.ValidString(msg[:100]))
+}


### PR DESCRIPTION
Closes https://github.com/semaphoreui/semaphore/issues/3835

## Bug

`GetLastCommitMessage` truncates with `msg[0:100]` (byte index). Byte 100 splits a multi-byte UTF-8 sequence → invalid UTF-8. Postgres rejects (`pq: invalid byte sequence for encoding "UTF8"`), `TaskRunner.SetCommit` panics, every task on that branch crashes the worker until the offending commit stops being HEAD.

`task.commit_message VARCHAR(100)` counts characters, not bytes.

## Fix

- New helper `truncateCommitMessage` (`db_lib/commit_message.go`) slices by runes.
- Both call sites (`CmdGitClient`, `GoGitClient`) updated.

## Repro

```bash
git commit --allow-empty -m "$(printf '%.0sa' {1..99})ы"
```

99 ASCII bytes + 2-byte `ы`. Old code returns `aaaa...a\xd1` (cuts mid-rune). Trigger any task on this branch → worker panics with `pq: invalid byte sequence for encoding "UTF8": 0xd1`.