### PR TITLE
api-docs: align spec with actual REST API behavior

### DIFF
--- a/.dredd/hooks/capabilities.go
+++ b/.dredd/hooks/capabilities.go
@@ -234,6 +234,10 @@ func alterRequestBody(t *trans.Transaction) {
 	if userKey != nil {
 		bodyFieldProcessor("ssh_key_id", userKey.ID, &request)
 		bodyFieldProcessor("become_key_id", userKey.ID, &request)
+		// IntegrationRequest.auth_secret_id references an access key for
+		// token/HMAC webhook verification. Without a valid key reference,
+		// integration POST/PUT fail on the access_key FK constraint.
+		bodyFieldProcessor("auth_secret_id", userKey.ID, &request)
 	}
 	if invite != nil {
 		bodyFieldProcessor("invite_id", 4, &request)

--- a/api-docs.yml
+++ b/api-docs.yml
@@ -376,6 +376,7 @@ definitions:
         type: boolean
       alert_chat:
         type: string
+        x-nullable: true
         example: Test
       max_parallel_tasks:
         type: integer
@@ -402,6 +403,7 @@ definitions:
         type: boolean
       alert_chat:
         type: string
+        x-nullable: true
         example: Test
       max_parallel_tasks:
         type: integer
@@ -609,12 +611,24 @@ definitions:
       template_id:
         type: integer
         minimum: 1
+      auth_method:
+        type: string
+        example: none
+      auth_secret_id:
+        type: integer
+        x-nullable: true
+      auth_header:
+        type: string
+      searchable:
+        type: boolean
       task_params:
         $ref: '#/definitions/TaskPrams'
 
   IntegrationRequest:
     type: object
     properties:
+      id:
+        type: integer
       name:
         type: string
         example: deploy
@@ -622,7 +636,17 @@ definitions:
         type: integer
       template_id:
         type: integer
-      params:
+      auth_method:
+        type: string
+        example: none
+      auth_secret_id:
+        type: integer
+        x-nullable: true
+      auth_header:
+        type: string
+      searchable:
+        type: boolean
+      task_params:
         $ref: '#/definitions/TaskPrams'
 
   IntegrationExtractValueRequest:
@@ -931,6 +955,8 @@ definitions:
         type: integer
       autorun:
         type: boolean
+      task_params:
+        $ref: '#/definitions/TaskPrams'
 
   Template:
     type: object
@@ -995,6 +1021,8 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/TemplateVault"
+      task_params:
+        $ref: '#/definitions/TaskPrams'
 
   TemplateSurveyVar:
     type: object
@@ -1095,6 +1123,9 @@ definitions:
   ViewRequest:
     type: object
     properties:
+      id:
+        type: integer
+        minimum: 1
       title:
         type: string
         example: Test

--- a/web/public/swagger/api-docs.yml
+++ b/web/public/swagger/api-docs.yml
@@ -376,6 +376,7 @@ definitions:
         type: boolean
       alert_chat:
         type: string
+        x-nullable: true
         example: Test
       max_parallel_tasks:
         type: integer
@@ -402,6 +403,7 @@ definitions:
         type: boolean
       alert_chat:
         type: string
+        x-nullable: true
         example: Test
       max_parallel_tasks:
         type: integer
@@ -609,12 +611,24 @@ definitions:
       template_id:
         type: integer
         minimum: 1
+      auth_method:
+        type: string
+        example: none
+      auth_secret_id:
+        type: integer
+        x-nullable: true
+      auth_header:
+        type: string
+      searchable:
+        type: boolean
       task_params:
         $ref: '#/definitions/TaskPrams'
 
   IntegrationRequest:
     type: object
     properties:
+      id:
+        type: integer
       name:
         type: string
         example: deploy
@@ -622,7 +636,17 @@ definitions:
         type: integer
       template_id:
         type: integer
-      params:
+      auth_method:
+        type: string
+        example: none
+      auth_secret_id:
+        type: integer
+        x-nullable: true
+      auth_header:
+        type: string
+      searchable:
+        type: boolean
+      task_params:
         $ref: '#/definitions/TaskPrams'
 
   IntegrationExtractValueRequest:
@@ -926,6 +950,8 @@ definitions:
         type: integer
       autorun:
         type: boolean
+      task_params:
+        $ref: '#/definitions/TaskPrams'
 
   Template:
     type: object
@@ -986,6 +1012,8 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/TemplateVault"
+      task_params:
+        $ref: '#/definitions/TaskPrams'
 
   TemplateSurveyVar:
     type: object
@@ -1086,6 +1114,9 @@ definitions:
   ViewRequest:
     type: object
     properties:
+      id:
+        type: integer
+        minimum: 1
       title:
         type: string
         example: Test


### PR DESCRIPTION
While building the CruGlobal/terraform-provider-semaphoreui Terraform provider against the v2.18.2 server I hit several spots where the generated client (from this api-docs.yml) didn't match what the API actually accepts/returns. Each was probed with curl against a live v2.18.2 docker-compose instance; the symptoms below describe what went wrong before patching.

Project.alert_chat and ProjectRequest.alert_chat — add x-nullable

  The server returns "alert_chat": null for projects without an alert
  chat ID. Without x-nullable, go-swagger generates a `string` field
  with `omitempty`, so consumers can't distinguish "field was sent as
  null" from "field was omitted". Adding x-nullable: true makes the
  generated field a *string so callers see null vs empty correctly.

IntegrationRequest.id — add field

  PUT /project/{project_id}/integrations/{integration_id} returns HTTP
  400 "Integration ID in body and URL must be the same" if the body
  doesn't include an id. The spec defines IntegrationRequest without
  id, so callers can't satisfy this requirement without hand-patching.
  Same pattern as ViewRequest below.

Integration / IntegrationRequest auth_method, auth_secret_id, auth_header, searchable — add fields

  The actual API persists and returns these on integration objects but
  the spec doesn't declare them. They cover the webhook auth modes
  (none / token / hmac / github / gitlab / bitbucket), the secret key
  reference used to verify incoming requests, the header carrying the
  auth payload, and a flag controlling whether the integration's task
  history is search-indexed. auth_secret_id is x-nullable because the
  API returns null when no secret is bound.

IntegrationRequest.params → task_params — rename

  The Integration response model uses task_params, but the
  IntegrationRequest spec called the same field params. Sending
  {"params": {...}} on POST/PUT is silently dropped by the server —
  only {"task_params": {...}} is read. Renaming aligns the request
  spec with both the response model and the actual server contract.

Template.task_params and TemplateRequest.task_params — add field

  Templates accept and persist a task_params blob (same TaskPrams
  union as integrations: top-level arguments/environment/git_branch/
  message plus Ansible-specific tags/skip_tags/limit/diff/debug/dry_run
  and Terraform-specific auto_approve/destroy/plan/upgrade) but
  the field isn't declared in the spec. Sending it works; the
  server stores it; GET returns it. Adding the $ref makes it
  reachable from the generated client.

ViewRequest.id — add field

  Same root cause as IntegrationRequest.id. PUT
  /project/{project_id}/views/{view_id} requires the id in the body
  matching the URL or returns HTTP 400. ViewRequest didn't have id,
  so generated clients couldn't satisfy the contract.

Both api-docs.yml at the repo root and the duplicated copy at web/public/swagger/api-docs.yml are updated identically — the two files have other unrelated drift that I deliberately left alone to keep this change focused.