### PR TITLE
Make user ID configurable in Dockerfiles

### DIFF
--- a/deployment/docker/runner/Dockerfile
+++ b/deployment/docker/runner/Dockerfile
@@ -48,11 +48,12 @@ RUN wget -O /tmp/terragrunt https://github.com/gruntwork-io/terragrunt/releases/
 FROM alpine:3.21
 
 ARG TARGETARCH="amd64"
+ARG USER_ID=1001
 
 RUN apk add --no-cache -U \
     bash curl git gnupg mysql-client openssh-client-default python3 python3-dev py3-pip rsync sshpass tar tini tzdata unzip wget zip && \
     rm -rf /var/cache/apk/* && \
-    adduser -D -u 1001 -G root semaphore && \
+    adduser -D -u ${USER_ID} -G root semaphore && \
     mkdir -p /tmp/semaphore && \
     mkdir -p /etc/semaphore && \
     mkdir -p /var/lib/semaphore && \
@@ -63,7 +64,7 @@ RUN apk add --no-cache -U \
     chown -R semaphore:0 /opt/semaphore && \
     find /usr/lib/python* -iname __pycache__ | xargs rm -rf
 
-COPY --chown=1001:0 ./deployment/docker/runner/ansible.cfg /etc/ansible/ansible.cfg
+COPY --chown=${USER_ID}:0 ./deployment/docker/runner/ansible.cfg /etc/ansible/ansible.cfg
 COPY --from=builder /go/src/semaphore/deployment/docker/runner/runner-wrapper /usr/local/bin/
 COPY --from=builder /go/src/semaphore/bin/semaphore /usr/local/bin/
 COPY --from=builder /tmp/tofu /usr/local/bin/
@@ -94,7 +95,7 @@ RUN apk add --no-cache -U python3-dev build-base openssl-dev libffi-dev cargo &&
 
 RUN echo 'Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile /dev/null' > /etc/ssh/ssh_config.d/semaphore.conf
 
-USER 1001
+USER ${USER_ID}
 
 ENV VIRTUAL_ENV="$ANSIBLE_VENV_PATH"
 ENV PATH="$ANSIBLE_VENV_PATH/bin:$PATH"

--- a/deployment/docker/server/Dockerfile
+++ b/deployment/docker/server/Dockerfile
@@ -49,6 +49,7 @@ RUN wget -O /tmp/terragrunt https://github.com/gruntwork-io/terragrunt/releases/
 FROM alpine:3.21
 
 ARG TARGETARCH="amd64"
+ARG USER_ID=1001
 # renovate: datasource=pypi depName=ansible
 ARG ANSIBLE_VERSION=13.5.0
 ENV ANSIBLE_VERSION=${ANSIBLE_VERSION}
@@ -57,7 +58,7 @@ ARG ANSIBLE_VENV_PATH=/opt/semaphore/apps/ansible/${ANSIBLE_VERSION}/venv
 RUN apk add --no-cache -U \
     bash curl git gnupg mysql-client openssh-client-default python3 py3-pip rsync sshpass tar tini tzdata unzip wget zip jq && \
     rm -rf /var/cache/apk/* && \
-    adduser -D -u 1001 -G root semaphore && \
+    adduser -D -u ${USER_ID} -G root semaphore && \
     mkdir -p /tmp/semaphore && \
     mkdir -p /etc/semaphore && \
     mkdir -p /var/lib/semaphore && \
@@ -70,7 +71,7 @@ RUN apk add --no-cache -U \
 
 RUN echo $'Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile /dev/null' > /etc/ssh/ssh_config.d/semaphore.conf
 
-COPY --chown=1001:0 ./deployment/docker/server/ansible.cfg /etc/ansible/ansible.cfg
+COPY --chown=${USER_ID}:0 ./deployment/docker/server/ansible.cfg /etc/ansible/ansible.cfg
 COPY --from=builder /go/src/semaphore/deployment/docker/server/server-wrapper /usr/local/bin/
 COPY --from=builder /go/src/semaphore/bin/semaphore /usr/local/bin/
 COPY --from=builder /tmp/tofu /usr/local/bin/
@@ -94,7 +95,7 @@ RUN apk add --no-cache -U python3-dev build-base openssl-dev libffi-dev cargo &&
      find ${ANSIBLE_VENV_PATH} -iname __pycache__ | xargs rm -rf && \
      chown -R semaphore:0 /opt/semaphore
 
-USER 1001
+USER ${USER_ID}
 EXPOSE 3000
 
 ENV VIRTUAL_ENV="$ANSIBLE_VENV_PATH"


### PR DESCRIPTION
### Description

This PR makes the UID of the `semaphore` user inside the Docker container configurable at build time.

**Why?**  
Many users run Semaphore on Linux hosts and want to avoid permission issues with mounted volumes (`/var/lib/semaphore`, Ansible venv, etc.) by matching the container UID with their host user UID.

### Changes

- Added `ARG USER_ID=1001` in the final Docker stage
- Updated `adduser` to use `${USER_ID}`
- Updated `COPY --chown=` instruction
- Changed final `USER` instruction to `USER ${USER_ID}`
- Kept full backward compatibility (default remains 1001)

### Usage

**Build with custom UID:**
```bash
docker build --build-arg USER_ID=1000 -t semaphore:custom .
```

**Run with custom UID:**
```yaml
---
# docker-compose.yml

services:
  semaphore:
    image: semaphoreui/semaphore:latest
    user: "1000"          # or "${UID:-1001}"
    volumes:
      - ./data:/var/lib/semaphore
```