### PR TITLE
Adds support for JSON survey variables so task templates can define survey inputs whose values are stored and submitted as structured JSON instead of plain strings.

### DIFF
--- a/api-docs.yml
+++ b/api-docs.yml
@@ -1047,10 +1047,12 @@ definitions:
         type: string
       type:
         type: string
-        enum: ["", int, enum, secret] # String => "", Integer => "int"
+        enum: ["", int, enum, secret, json] # String => "", Integer => "int", JSON => "json"
         example: int
       required:
         type: boolean
+      default_value:
+        description: Default survey value. JSON survey variables may use any valid JSON value.
       values:
         type: array
         items:

--- a/db/Template.go
+++ b/db/Template.go
@@ -62,9 +62,10 @@ func (t TemplateApp) IsTerraform() bool {
 type SurveyVarType string
 
 const (
-	SurveyVarStr  TemplateType = ""
-	SurveyVarInt  TemplateType = "int"
-	SurveyVarEnum TemplateType = "enum"
+	SurveyVarStr  SurveyVarType = ""
+	SurveyVarInt  SurveyVarType = "int"
+	SurveyVarEnum SurveyVarType = "enum"
+	SurveyVarJSON SurveyVarType = "json"
 )
 
 type AnsibleTemplateParams struct {
@@ -98,7 +99,7 @@ type SurveyVar struct {
 	Type         SurveyVarType        `json:"type,omitempty" backup:"type"`
 	Description  string               `json:"description,omitempty" backup:"description"`
 	Values       []SurveyVarEnumValue `json:"values,omitempty" backup:"values"`
-	DefaultValue string               `json:"default_value,omitempty" backup:"default_value"`
+	DefaultValue any                  `json:"default_value,omitempty" backup:"default_value"`
 }
 
 type TemplateFilter struct {

--- a/web/src/components/SurveyVars.vue
+++ b/web/src/components/SurveyVars.vue
@@ -115,6 +115,17 @@
               v-model="editedVar.default_value"
             />
 
+            <v-textarea
+              v-else-if="editedVar.type === 'json'"
+              :label="$t('default_value')"
+              v-model="editedDefaultValue"
+              :rules="[validateJSON]"
+              auto-grow
+              rows="4"
+              outlined
+              dense
+            />
+
             <v-text-field
               v-else-if="editedVar.type !== 'secret'"
               :label="$t('default_value')"
@@ -218,6 +229,7 @@ export default {
     return {
       editDialog: null,
       editedVar: null,
+      editedDefaultValue: '',
       editedValues: [],
       editedVarIndex: null,
       modifiedVars: null,
@@ -233,6 +245,9 @@ export default {
       }, {
         id: 'enum',
         name: 'Enum',
+      }, {
+        id: 'json',
+        name: 'JSON',
       }],
       formError: null,
     };
@@ -258,6 +273,9 @@ export default {
       this.editedValues = [];
       this.editedValues.push(...(this.editedVar.values || []));
       this.editedVar.values = this.editedValues;
+      this.editedDefaultValue = this.editedVar.default_value == null
+        ? ''
+        : JSON.stringify(this.editedVar.default_value, null, 2);
 
       this.editedVarIndex = index;
 
@@ -301,6 +319,22 @@ export default {
         this.editedVar.values = [];
       }
 
+      if (this.editedVar.type === 'json') {
+        if (this.editedDefaultValue.trim() === '') {
+          delete this.editedVar.default_value;
+        } else {
+          try {
+            this.editedVar.default_value = JSON.parse(this.editedDefaultValue);
+          } catch (e) {
+            this.formError = this.$t('invalidJson');
+            return;
+          }
+        }
+      } else if (this.editedVar.default_value != null
+        && typeof this.editedVar.default_value === 'object') {
+        delete this.editedVar.default_value;
+      }
+
       if (this.editedVarIndex != null) {
         this.modifiedVars[this.editedVarIndex] = this.editedVar;
       } else {
@@ -319,6 +353,18 @@ export default {
 
     onDragEnd() {
       this.$emit('change', this.modifiedVars);
+    },
+
+    validateJSON(val) {
+      if (val == null || val.trim() === '') {
+        return true;
+      }
+      try {
+        JSON.parse(val);
+        return true;
+      } catch (e) {
+        return this.$t('invalidJson');
+      }
     },
   },
 };

--- a/web/src/components/TaskForm.vue
+++ b/web/src/components/TaskForm.vue
@@ -95,6 +95,22 @@
         dense
       />
 
+      <v-textarea
+        v-else-if="v.type === 'json'"
+        :label="v.title + (v.required ? ' *' : '')"
+        :hint="v.description"
+        v-model="editedJsonEnvironment[v.name]"
+        :required="v.required"
+        :rules="[
+          val => !v.required || !!(val || '').trim() || v.title + ' ' + $t('isRequired'),
+          validateJSON,
+        ]"
+        outlined
+        dense
+        auto-grow
+        rows="4"
+      />
+
       <v-text-field
         v-else
         :label="v.title + (v.required ? ' *' : '')"
@@ -196,6 +212,7 @@ export default {
       hasCommit: null,
       editedEnvironment: null,
       editedSecretEnvironment: null,
+      editedJsonEnvironment: {},
       cmOptions: {
         tabSize: 2,
         mode: 'application/json',
@@ -316,6 +333,7 @@ export default {
 
       this.editedEnvironment = JSON.parse(v.environment || '{}');
       this.editedSecretEnvironment = JSON.parse(v.secret || '{}');
+      this.syncJsonEnvironment();
       this.hasCommit = v.commit_hash != null;
     },
 
@@ -324,6 +342,9 @@ export default {
     },
 
     beforeSave() {
+      if (!this.applyJsonEnvironment()) {
+        throw new Error(this.$t('invalidJson'));
+      }
       this.item.environment = JSON.stringify(this.editedEnvironment);
       this.item.secret = JSON.stringify(this.editedSecretEnvironment);
     },
@@ -378,7 +399,7 @@ export default {
       });
 
       const defaultVars = (this.template.survey_vars || [])
-        .filter((s) => s.default_value)
+        .filter((s) => this.hasDefaultValue(s))
         .reduce((res, curr) => ({
           ...res,
           [curr.name]: curr.default_value,
@@ -388,6 +409,53 @@ export default {
         ...defaultVars,
         ...this.editedEnvironment,
       };
+      this.syncJsonEnvironment();
+    },
+
+    syncJsonEnvironment() {
+      const res = {};
+      (this.template?.survey_vars || [])
+        .filter((v) => v.type === 'json')
+        .forEach((v) => {
+          const value = this.editedEnvironment?.[v.name];
+          res[v.name] = value == null ? '' : JSON.stringify(value, null, 2);
+        });
+      this.editedJsonEnvironment = res;
+    },
+
+    applyJsonEnvironment() {
+      try {
+        (this.template?.survey_vars || [])
+          .filter((v) => v.type === 'json')
+          .forEach((v) => {
+            const val = this.editedJsonEnvironment[v.name];
+            if (val == null || val.trim() === '') {
+              delete this.editedEnvironment[v.name];
+            } else {
+              this.editedEnvironment[v.name] = JSON.parse(val);
+            }
+          });
+      } catch (e) {
+        this.formError = this.$t('invalidJson');
+        return false;
+      }
+      return true;
+    },
+
+    validateJSON(val) {
+      if (val == null || val.trim() === '') {
+        return true;
+      }
+      try {
+        JSON.parse(val);
+        return true;
+      } catch (e) {
+        return this.$t('invalidJson');
+      }
+    },
+
+    hasDefaultValue(surveyVar) {
+      return surveyVar.default_value != null && surveyVar.default_value !== '';
     },
 
     getInventoryUrl() {

--- a/web/src/components/TaskParamsForm.vue
+++ b/web/src/components/TaskParamsForm.vue
@@ -40,6 +40,22 @@
           dense
       />
 
+      <v-textarea
+          v-else-if="v.type === 'json'"
+          :label="v.title + (v.required ? ' *' : '')"
+          :hint="v.description"
+          v-model="editedJsonEnvironment[v.name]"
+          :required="v.required"
+          :rules="[
+          val => !v.required || !!(val || '').trim() || v.title + ' ' + $t('isRequired'),
+          validateJSON,
+        ]"
+          outlined
+          dense
+          auto-grow
+          rows="4"
+      />
+
       <v-text-field
           v-else
           :label="v.title + (v.required ? ' *' : '')"
@@ -137,6 +153,7 @@ export default {
       item: null,
       editedEnvironment: null,
       editedSecretEnvironment: null,
+      editedJsonEnvironment: {},
       inventory: null,
     };
   },
@@ -191,6 +208,20 @@ export default {
         }
         this.item.environment = JSON.stringify(this.editedEnvironment);
         this.$emit('input', this.item);
+      },
+      deep: true,
+      immediate: true,
+    },
+
+    editedJsonEnvironment: {
+      handler(newVal, oldVal) {
+        if (oldVal == null) {
+          return;
+        }
+        if (this.applyJsonEnvironment()) {
+          this.item.environment = JSON.stringify(this.editedEnvironment);
+          this.$emit('input', this.item);
+        }
       },
       deep: true,
       immediate: true,
@@ -254,6 +285,7 @@ export default {
 
       this.editedEnvironment = JSON.parse(v.environment || '{}');
       this.editedSecretEnvironment = JSON.parse(v.secret || '{}');
+      this.syncJsonEnvironment();
     },
 
     isLoaded() {
@@ -302,7 +334,7 @@ export default {
       });
 
       const defaultVars = (this.template.survey_vars || [])
-        .filter((s) => s.default_value)
+        .filter((s) => this.hasDefaultValue(s))
         .reduce((res, curr) => ({
           ...res,
           [curr.name]: curr.default_value,
@@ -312,6 +344,52 @@ export default {
         ...defaultVars,
         ...this.editedEnvironment,
       };
+      this.syncJsonEnvironment();
+    },
+
+    syncJsonEnvironment() {
+      const res = {};
+      (this.template?.survey_vars || [])
+        .filter((v) => v.type === 'json')
+        .forEach((v) => {
+          const value = this.editedEnvironment?.[v.name];
+          res[v.name] = value == null ? '' : JSON.stringify(value, null, 2);
+        });
+      this.editedJsonEnvironment = res;
+    },
+
+    applyJsonEnvironment() {
+      try {
+        (this.template?.survey_vars || [])
+          .filter((v) => v.type === 'json')
+          .forEach((v) => {
+            const val = this.editedJsonEnvironment[v.name];
+            if (val == null || val.trim() === '') {
+              delete this.editedEnvironment[v.name];
+            } else {
+              this.editedEnvironment[v.name] = JSON.parse(val);
+            }
+          });
+      } catch (e) {
+        return false;
+      }
+      return true;
+    },
+
+    validateJSON(val) {
+      if (val == null || val.trim() === '') {
+        return true;
+      }
+      try {
+        JSON.parse(val);
+        return true;
+      } catch (e) {
+        return this.$t('invalidJson');
+      }
+    },
+
+    hasDefaultValue(surveyVar) {
+      return surveyVar.default_value != null && surveyVar.default_value !== '';
     },
 
     getInventoryUrl() {

--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -145,6 +145,7 @@ export default {
   title: 'Title *',
   description: 'Description',
   required: 'Required',
+  invalidJson: 'Invalid JSON',
   key: '{expr}',
   surveyVariables: 'Survey Variables',
   addVariable: 'Add variable',

--- a/web/src/lang/es.js
+++ b/web/src/lang/es.js
@@ -129,6 +129,7 @@ export default {
   title: 'Título *',
   description: 'Descripción',
   required: 'Requerido',
+  invalidJson: 'JSON inválido',
   key: '{expr}',
   surveyVariables: 'Variables de Encuesta',
   addVariable: 'Agregar variable',


### PR DESCRIPTION
  ## Changes
  - Adds a new `json` survey variable type.
  - Allows `survey_vars[].default_value` to contain any valid JSON value.
  - Adds JSON editors and validation when editing survey variables and launching tasks.
  - Updates the API documentation for the new survey variable type.
  - Keeps existing string, integer, enum, and secret survey variables compatible.

  ## Compatibility
  No database migration is required because survey variables are already stored as a JSON blob in the existing `project__template.survey_vars` text column. Existing string defaults remain valid and deserialize
  unchanged.

  ## Testing
  - Ran `git diff --check`.
  - Built successfully through the local Docker image build.