### PR TITLE
Adds a search field to the Task Templates page so users can filter templates in the current view.

### DIFF
--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -145,6 +145,7 @@ export default {
   title: 'Title *',
   description: 'Description',
   required: 'Required',
+  search: 'Search',
   key: '{expr}',
   surveyVariables: 'Survey Variables',
   addVariable: 'Add variable',

--- a/web/src/lang/es.js
+++ b/web/src/lang/es.js
@@ -129,6 +129,7 @@ export default {
   title: 'Título *',
   description: 'Descripción',
   required: 'Requerido',
+  search: 'Buscar',
   key: '{expr}',
   surveyVariables: 'Variables de Encuesta',
   addVariable: 'Agregar variable',

--- a/web/src/views/project/Templates.vue
+++ b/web/src/views/project/Templates.vue
@@ -356,13 +356,34 @@ export default {
         && this.isAppsLoaded;
     },
 
+    inventoryNameById() {
+      return this.getResourceNameMap(this.inventory);
+    },
+
+    repositoryNameById() {
+      return this.getResourceNameMap(this.repositories);
+    },
+
+    environmentNameById() {
+      return this.getResourceNameMap(this.environment);
+    },
+
+    templateSearchIndex() {
+      return (this.items || []).map((item) => ({
+        item,
+        searchText: this.getTemplateSearchText(item),
+      }));
+    },
+
     searchedItems() {
       const search = (this.search || '').trim().toLowerCase();
       if (!search) {
         return this.items;
       }
 
-      return (this.items || []).filter((item) => this.getTemplateSearchText(item).includes(search));
+      return this.templateSearchIndex
+        .filter(({ searchText }) => searchText.includes(search))
+        .map(({ item }) => item);
     },
   },
   watch: {
@@ -505,12 +526,16 @@ export default {
       this.newTaskDialog = true;
     },
 
+    getResourceNameMap(resources) {
+      return new Map((resources || []).map(({ id, name }) => [id, name]));
+    },
+
     getTemplateSearchText(item) {
-      const inventory = this.inventory?.find((x) => x.id === item.inventory_id)?.name || '';
-      const repository = this.repositories?.find((x) => x.id === item.repository_id)?.name || '';
+      const inventory = this.inventoryNameById.get(item.inventory_id) || '';
+      const repository = this.repositoryNameById.get(item.repository_id) || '';
       const environments = Array.isArray(item.environment_ids)
         ? item.environment_ids
-          .map((id) => this.environment?.find((x) => x.id === id)?.name || '')
+          .map((id) => this.environmentNameById.get(id) || '')
           .join(' ')
         : '';
 

--- a/web/src/views/project/Templates.vue
+++ b/web/src/views/project/Templates.vue
@@ -51,6 +51,18 @@
       </v-toolbar-title>
       <v-spacer></v-spacer>
 
+      <v-text-field
+        v-model="search"
+        :label="$t('search')"
+        prepend-inner-icon="mdi-magnify"
+        clearable
+        hide-details
+        dense
+        outlined
+        single-line
+        class="templates-search mr-3"
+      />
+
       <v-menu
         offset-y
       >
@@ -136,7 +148,7 @@
       single-expand
       show-expand
       :headers="filteredHeaders"
-      :items="items"
+      :items="searchedItems"
       :items-per-page="Number.MAX_VALUE"
       :expanded.sync="openedItems"
       :style="{
@@ -257,6 +269,10 @@
   padding-right: 0 !important;
 }
 
+.templates-search {
+  max-width: 260px;
+}
+
 @media #{map-get($display-breakpoints, 'sm-and-down')} {
   .templates-table .v-data-table__mobile-row:first-child {
     display: none !important;
@@ -311,6 +327,7 @@ export default {
       viewTab: null,
       apps: null,
       itemApp: '',
+      search: '',
     };
   },
 
@@ -337,6 +354,15 @@ export default {
         && this.repositories
         && this.views
         && this.isAppsLoaded;
+    },
+
+    searchedItems() {
+      const search = (this.search || '').trim().toLowerCase();
+      if (!search) {
+        return this.items;
+      }
+
+      return (this.items || []).filter((item) => this.getTemplateSearchText(item).includes(search));
     },
   },
   watch: {
@@ -477,6 +503,25 @@ export default {
     createTask(itemId) {
       this.itemId = itemId;
       this.newTaskDialog = true;
+    },
+
+    getTemplateSearchText(item) {
+      const inventory = this.inventory?.find((x) => x.id === item.inventory_id)?.name || '';
+      const repository = this.repositories?.find((x) => x.id === item.repository_id)?.name || '';
+      const environments = Array.isArray(item.environment_ids)
+        ? item.environment_ids
+          .map((id) => this.environment?.find((x) => x.id === id)?.name || '')
+          .join(' ')
+        : '';
+
+      return [
+        item.name,
+        item.playbook,
+        item.description,
+        inventory,
+        repository,
+        environments,
+      ].filter(Boolean).join(' ').toLowerCase();
     },
 
     getHeaders() {


### PR DESCRIPTION
## Changes
  - Adds a search input to the task templates toolbar.
  - Filters templates locally by name, playbook, description, inventory, repository, and variable groups.
  - Adds English and Spanish translations for the search label.

  ## Testing
  - Ran `git diff --check`.
  - Built successfully through the local Docker image build.