### PR TITLE
Feat/UI notification improvements

### DIFF
--- a/api/projects/notification.go
+++ b/api/projects/notification.go
@@ -3,6 +3,7 @@ package projects
 import (
 	"fmt"
 	"net/http"
+	"errors"
 
 	"github.com/semaphoreui/semaphore/api/helpers"
 	"github.com/semaphoreui/semaphore/db"
@@ -114,6 +115,14 @@ func RemoveNotification(w http.ResponseWriter, r *http.Request) {
 	notification := helpers.GetFromContext(r, "notification").(db.Notification)
 	
 	err := helpers.Store(r).DeleteNotification(notification.ProjectID, notification.ID)
+	if errors.Is(err, db.ErrInvalidOperation) {
+		helpers.WriteJSON(w, http.StatusBadRequest, map[string]any{
+			"error": "Notification is in use by one or more templates",
+			"inUse": true,
+		})
+		return
+	}
+
 	if err != nil {
 		helpers.WriteError(w, err)
 		return
@@ -122,10 +131,22 @@ func RemoveNotification(w http.ResponseWriter, r *http.Request) {
 	helpers.EventLog(r, helpers.EventLogDelete, helpers.EventLogItem{
 		UserID:      helpers.UserFromContext(r).ID,
 		ProjectID:   notification.ProjectID,
-		ObjectType:  db.EventInventory,
+		ObjectType:  db.EventNotification,
 		ObjectID:    notification.ID,
 		Description: fmt.Sprintf("Notification %s deleted", notification.Name),
 	})
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func GetNotificationRefs(w http.ResponseWriter, r *http.Request) {
+	notification := helpers.GetFromContext(r, "notification").(db.Notification)
+	
+	refs, err := helpers.Store(r).GetNotificationRefs(notification.ProjectID, notification.ID)
+	if err != nil {
+		helpers.WriteError(w, err)
+		return
+	}
+
+	helpers.WriteJSON(w, http.StatusOK, refs)
 }

--- a/api/projects/notification.go
+++ b/api/projects/notification.go
@@ -1,0 +1,131 @@
+package projects
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/semaphoreui/semaphore/api/helpers"
+	"github.com/semaphoreui/semaphore/db"
+)
+
+func NotificationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		project := helpers.GetFromContext(r, "project").(db.Project)
+		notificationID, err := helpers.GetIntParam("notification_id", w, r)
+		if err != nil {
+			return
+		}
+
+		notification, err := helpers.Store(r).GetNotification(project.ID, notificationID)
+		if err != nil {
+			helpers.WriteError(w, err)
+			return
+		}
+
+		r = helpers.SetContextValue(r, "notification", notification)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func GetNotifications(w http.ResponseWriter, r *http.Request) {
+	if notification := helpers.GetFromContext(r, "notification"); notification != nil {
+		helpers.WriteJSON(w, http.StatusOK, notification.(db.Notification))
+		return
+	}
+
+	project := helpers.GetFromContext(r, "project").(db.Project)
+	
+	notifications, err := helpers.Store(r).GetNotifications(project.ID, db.RetrieveQueryParams{})
+	if err != nil {
+		helpers.WriteError(w, err)
+		return
+	}
+
+	helpers.WriteJSON(w, http.StatusOK, notifications)
+}
+
+func AddNotification(w http.ResponseWriter, r *http.Request) {
+	project := helpers.GetFromContext(r, "project").(db.Project)
+
+	var notification db.Notification
+	if !helpers.Bind(w, r, &notification) {
+		return
+	}
+
+	if notification.ProjectID != project.ID {
+		helpers.WriteJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "Project ID in body and URL must be the same",
+		})
+		return
+	}
+
+	newNotification, err := helpers.Store(r).CreateNotification(notification)
+	if err != nil {
+		helpers.WriteError(w, err)
+		return
+	}
+
+	helpers.EventLog(r, helpers.EventLogCreate, helpers.EventLogItem{
+		UserID:      helpers.UserFromContext(r).ID,
+		ProjectID:   project.ID,
+		ObjectType:  db.EventInventory,
+		ObjectID:    newNotification.ID,
+		Description: fmt.Sprintf("Notification %s created", notification.Name),
+	})
+
+	helpers.WriteJSON(w, http.StatusCreated, newNotification)
+}
+
+func UpdateNotification(w http.ResponseWriter, r *http.Request) {
+	oldNotification := helpers.GetFromContext(r, "notification").(db.Notification)
+
+	var notification db.Notification
+	if !helpers.Bind(w, r, &notification) {
+		return
+	}
+
+	if notification.ID != oldNotification.ID {
+		helpers.WriteErrorStatus(w, "Notification ID in body and URL must be the same", http.StatusBadRequest)
+		return
+	}
+
+	if notification.ProjectID != oldNotification.ProjectID {
+		helpers.WriteErrorStatus(w, "Project ID in body and URL must be the same", http.StatusBadRequest)
+		return
+	}
+
+	if err := helpers.Store(r).UpdateNotification(notification); err != nil {
+		helpers.WriteError(w, err)
+		return
+	}
+
+	helpers.EventLog(r, helpers.EventLogUpdate, helpers.EventLogItem{
+		UserID:      helpers.UserFromContext(r).ID,
+		ProjectID:   oldNotification.ProjectID,
+		ObjectType:  db.EventInventory,
+		ObjectID:    oldNotification.ID,
+		Description: fmt.Sprintf("Notification %s updated", notification.Name),
+	})
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func RemoveNotification(w http.ResponseWriter, r *http.Request) {
+	notification := helpers.GetFromContext(r, "notification").(db.Notification)
+	
+	err := helpers.Store(r).DeleteNotification(notification.ProjectID, notification.ID)
+	if err != nil {
+		helpers.WriteError(w, err)
+		return
+	}
+
+	helpers.EventLog(r, helpers.EventLogDelete, helpers.EventLogItem{
+		UserID:      helpers.UserFromContext(r).ID,
+		ProjectID:   notification.ProjectID,
+		ObjectType:  db.EventInventory,
+		ObjectID:    notification.ID,
+		Description: fmt.Sprintf("Notification %s deleted", notification.Name),
+	})
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/api/projects/notification.go
+++ b/api/projects/notification.go
@@ -69,7 +69,7 @@ func AddNotification(w http.ResponseWriter, r *http.Request) {
 	helpers.EventLog(r, helpers.EventLogCreate, helpers.EventLogItem{
 		UserID:      helpers.UserFromContext(r).ID,
 		ProjectID:   project.ID,
-		ObjectType:  db.EventInventory,
+		ObjectType:  db.EventNotification,
 		ObjectID:    newNotification.ID,
 		Description: fmt.Sprintf("Notification %s created", notification.Name),
 	})
@@ -103,7 +103,7 @@ func UpdateNotification(w http.ResponseWriter, r *http.Request) {
 	helpers.EventLog(r, helpers.EventLogUpdate, helpers.EventLogItem{
 		UserID:      helpers.UserFromContext(r).ID,
 		ProjectID:   oldNotification.ProjectID,
-		ObjectType:  db.EventInventory,
+		ObjectType:  db.EventNotification,
 		ObjectID:    oldNotification.ID,
 		Description: fmt.Sprintf("Notification %s updated", notification.Name),
 	})

--- a/api/router.go
+++ b/api/router.go
@@ -423,6 +423,7 @@ func Route(
 	projectNotificationManagement.Use(projects.NotificationMiddleware)
 
 	projectNotificationManagement.HandleFunc("/{notification_id}", projects.GetNotifications).Methods("GET", "HEAD")
+	projectNotificationManagement.HandleFunc("/{notification_id}/refs", projects.GetNotificationRefs).Methods("GET", "HEAD")
 	projectNotificationManagement.HandleFunc("/{notification_id}", projects.UpdateNotification).Methods("PUT")
 	projectNotificationManagement.HandleFunc("/{notification_id}", projects.RemoveNotification).Methods("DELETE")
 

--- a/api/router.go
+++ b/api/router.go
@@ -306,6 +306,9 @@ func Route(
 	projectUserAPI.Path("/inventory").HandlerFunc(projects.GetInventory).Methods("GET", "HEAD")
 	projectUserAPI.Path("/inventory").HandlerFunc(projects.AddInventory).Methods("POST")
 
+	projectUserAPI.Path("/notifications").HandlerFunc(projects.GetNotifications).Methods("GET", "HEAD")
+	projectUserAPI.Path("/notifications").HandlerFunc(projects.AddNotification).Methods("POST")
+
 	projectUserAPI.Path("/environment").HandlerFunc(projects.GetEnvironment).Methods("GET", "HEAD")
 	projectUserAPI.Path("/environment").HandlerFunc(environmentController.AddEnvironment).Methods("POST")
 
@@ -415,6 +418,13 @@ func Route(
 	projectInventoryManagement.HandleFunc("/{inventory_id}/refs", projects.GetInventoryRefs).Methods("GET", "HEAD")
 	projectInventoryManagement.HandleFunc("/{inventory_id}", projects.UpdateInventory).Methods("PUT")
 	projectInventoryManagement.HandleFunc("/{inventory_id}", projects.RemoveInventory).Methods("DELETE")
+
+	projectNotificationManagement := projectUserAPI.PathPrefix("/notifications").Subrouter()
+	projectNotificationManagement.Use(projects.NotificationMiddleware)
+
+	projectNotificationManagement.HandleFunc("/{notification_id}", projects.GetNotifications).Methods("GET", "HEAD")
+	projectNotificationManagement.HandleFunc("/{notification_id}", projects.UpdateNotification).Methods("PUT")
+	projectNotificationManagement.HandleFunc("/{notification_id}", projects.RemoveNotification).Methods("DELETE")
 
 	projectInventoryManagement.HandleFunc("/{inventory_id}/terraform/aliases", terraformInventoryController.GetTerraformInventoryAliases).Methods("GET", "HEAD")
 	projectInventoryManagement.HandleFunc("/{inventory_id}/terraform/aliases", terraformInventoryController.AddTerraformInventoryAlias).Methods("POST")

--- a/db/Event.go
+++ b/db/Event.go
@@ -56,6 +56,7 @@ const (
 	EventTask                    EventObjectType = "task"
 	EventEnvironment             EventObjectType = "environment"
 	EventInventory               EventObjectType = "inventory"
+	EventNotification            EventObjectType = "notification"
 	EventKey                     EventObjectType = "key"
 	EventProject                 EventObjectType = "project"
 	EventRepository              EventObjectType = "repository"

--- a/db/Migration.go
+++ b/db/Migration.go
@@ -127,6 +127,7 @@ func GetMigrations(dialect string) []Migration {
 		{Version: "2.18.4"},
 		{Version: "2.18.5"},
 		{Version: "2.18.7"},
+		{Version: "2.18.8"},
 	}
 
 	return append(initScripts, commonScripts...)

--- a/db/Notification.go
+++ b/db/Notification.go
@@ -1,0 +1,9 @@
+package db
+
+type Notification struct {
+	ID        int    `db:"id" json:"id"`
+	ProjectID int    `db:"project_id" json:"project_id"`
+	Name      string `db:"name" json:"name"`
+	Type      string `db:"type" json:"type"`
+	Config    string `db:"config" json:"config"`
+}

--- a/db/Store.go
+++ b/db/Store.go
@@ -285,6 +285,8 @@ type TemplateManager interface {
 	GetTemplateEnvironments(projectID int, templateID int) ([]int, error)
 	UpdateTemplateEnvironments(projectID int, templateID int, environmentIDs []int) error
 
+	GetTemplateNotifications(projectID int, templateID int) ([]int, error)
+
 	GetTemplatePermission(projectID int, templateID int, userID int) (ProjectUserPermission, error)
 	GetTemplateRoles(projectID int, templateID int) ([]TemplateRolePerm, error)
 	CreateTemplateRole(role TemplateRolePerm) (TemplateRolePerm, error)

--- a/db/Store.go
+++ b/db/Store.go
@@ -333,6 +333,7 @@ type NotificationManager interface {
 	CreateNotification(notification Notification) (Notification, error)
 	UpdateNotification(notification Notification) error
 	DeleteNotification(projectID int, notificationID int) error
+	GetNotificationRefs(projectID int, notificationID int) (ObjectReferrers, error)
 }
 
 type GetAccessKeyOptions struct {

--- a/db/Store.go
+++ b/db/Store.go
@@ -324,6 +324,15 @@ type EnvironmentManager interface {
 	GetEnvironmentSecrets(projectID int, environmentID int) ([]AccessKey, error)
 }
 
+// NotificationManager handles notification-related operations
+type NotificationManager interface {
+	GetNotifications(projectID int, params RetrieveQueryParams) ([]Notification, error)
+	GetNotification(projectID int, notificationID int) (Notification, error)
+	CreateNotification(notification Notification) (Notification, error)
+	UpdateNotification(notification Notification) error
+	DeleteNotification(projectID int, notificationID int) error
+}
+
 type GetAccessKeyOptions struct {
 	Owner           AccessKeyOwner
 	IgnoreOwner     bool
@@ -530,6 +539,7 @@ type Store interface {
 	InventoryManager
 	RepositoryManager
 	EnvironmentManager
+	NotificationManager
 	AccessKeyManager
 	IntegrationManager
 	SessionManager

--- a/db/Template.go
+++ b/db/Template.go
@@ -153,6 +153,8 @@ type Template struct {
 
 	ViewID *int `db:"view_id" json:"view_id,omitempty" backup:"-"`
 
+	NotificationIDs []int `db:"-" json:"notification_ids"`
+
 	LastTask *TaskWithTpl `db:"-" json:"last_task,omitempty" backup:"-"`
 
 	Autorun bool `db:"autorun" json:"autorun,omitempty"`
@@ -265,6 +267,13 @@ func FillTemplate(d Store, template *Template) (err error) {
 		return
 	}
 	template.EnvironmentIDs = envIDs
+
+	var notificationIDs []int
+	notificationIDs, err = d.GetTemplateNotifications(template.ProjectID, template.ID)
+	if err != nil {
+		return
+	}
+	template.NotificationIDs = notificationIDs
 
 	var tasks []TaskWithTpl
 	tasks, err = d.GetTemplateTasks(template.ProjectID, template.ID, RetrieveQueryParams{Count: 1})

--- a/db/sql/migrations/v2.18.8.sql
+++ b/db/sql/migrations/v2.18.8.sql
@@ -1,0 +1,8 @@
+CREATE TABLE project__notification (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id INTEGER NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    config TEXT NOT NULL,
+    FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE CASCADE
+);

--- a/db/sql/migrations/v2.18.8.sql
+++ b/db/sql/migrations/v2.18.8.sql
@@ -6,3 +6,10 @@ CREATE TABLE project__notification (
     config TEXT NOT NULL,
     FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE CASCADE
 );
+
+CREATE TABLE project__template_notification (
+    project_id INTEGER NOT NULL,
+    template_id INTEGER NOT NULL,
+    notification_id INTEGER NOT NULL,
+    PRIMARY KEY (project_id, template_id, notification_id)
+);

--- a/db/sql/notification.go
+++ b/db/sql/notification.go
@@ -65,6 +65,44 @@ func (d *SqlDb) UpdateNotification(notification db.Notification) error {
 }
 
 func (d *SqlDb) DeleteNotification(projectID int, notificationID int) (err error) {
+	refs, err := d.GetNotificationRefs(projectID, notificationID)
+	if err != nil {
+		return err
+	}
+	if len(refs.Templates) > 0 {
+		return db.ErrInvalidOperation
+	}
+
 	_, err = d.exec("DELETE FROM project__notification WHERE project_id = ? AND id = ?", projectID, notificationID)
+	return
+}
+
+func (d *SqlDb) GetNotificationRefs(projectID int, notificationID int) (refs db.ObjectReferrers, err error) {
+	var templates []db.Template
+	templates, err = d.GetTemplates(projectID, db.TemplateFilter{}, db.RetrieveQueryParams{})
+	if err != nil {
+		return
+	}
+
+	// Initialize slices to avoid null values in JSON responses
+	refs.Templates = make([]db.ObjectReferrer, 0)
+	refs.Inventories = make([]db.ObjectReferrer, 0)
+	refs.Repositories = make([]db.ObjectReferrer, 0)
+	refs.Integrations = make([]db.ObjectReferrer, 0)
+	refs.Schedules = make([]db.ObjectReferrer, 0)
+	refs.AccessKeys = make([]db.ObjectReferrer, 0)
+
+	for _, tpl := range templates {
+		for _, id := range tpl.NotificationIDs {
+			if id == notificationID {
+				refs.Templates = append(refs.Templates, db.ObjectReferrer{
+					ID:   tpl.ID,
+					Name: tpl.Name,
+				})
+				break
+			}
+		}
+	}
+
 	return
 }

--- a/db/sql/notification.go
+++ b/db/sql/notification.go
@@ -1,0 +1,70 @@
+package sql
+
+import (
+	"github.com/Masterminds/squirrel"
+	"github.com/semaphoreui/semaphore/db"
+)
+
+func (d *SqlDb) GetNotifications(projectID int, params db.RetrieveQueryParams) (notifications []db.Notification, err error) {
+	q := squirrel.Select("*").
+		From("project__notification").
+		Where("project_id = ?", projectID).
+		OrderBy("name")
+
+	query, args, err := q.ToSql()
+	if err != nil {
+		return
+	}
+
+	_, err = d.selectAll(&notifications, query, args...)
+	return
+}
+
+func (d *SqlDb) GetNotification(projectID int, notificationID int) (notification db.Notification, err error) {
+	q := squirrel.Select("*").
+		From("project__notification").
+		Where("project_id = ? AND id = ?", projectID, notificationID)
+
+	query, args, err := q.ToSql()
+	if err != nil {
+		return
+	}
+
+	err = d.selectOne(&notification, query, args...)
+	return
+}
+
+func (d *SqlDb) CreateNotification(notification db.Notification) (db.Notification, error) {
+	insertID, err := d.insert(
+		"id",
+		"insert into project__notification (project_id, name, type, config) values (?, ?, ?, ?)",
+		notification.ProjectID,
+		notification.Name,
+		notification.Type,
+		notification.Config,
+	)
+
+	if err != nil {
+		return db.Notification{}, err
+	}
+
+	notification.ID = insertID
+	return notification, nil
+}
+
+func (d *SqlDb) UpdateNotification(notification db.Notification) error {
+	_, err := d.exec(
+		"update project__notification set name=?, type=?, config=? where project_id=? and id=?",
+		notification.Name,
+		notification.Type,
+		notification.Config,
+		notification.ProjectID,
+		notification.ID,
+	)
+	return err
+}
+
+func (d *SqlDb) DeleteNotification(projectID int, notificationID int) (err error) {
+	_, err = d.exec("DELETE FROM project__notification WHERE project_id = ? AND id = ?", projectID, notificationID)
+	return
+}

--- a/db/sql/template.go
+++ b/db/sql/template.go
@@ -74,6 +74,11 @@ func (d *SqlDb) CreateTemplate(template db.Template) (newTemplate db.Template, e
 		return
 	}
 
+	err = d.UpdateTemplateNotifications(template.ProjectID, insertID, template.NotificationIDs)
+	if err != nil {
+		return
+	}
+
 	err = db.FillTemplate(d, &newTemplate)
 
 	if err != nil {
@@ -152,6 +157,8 @@ func (d *SqlDb) UpdateTemplate(template db.Template) error {
 
 	err = d.UpdateTemplateEnvironments(template.ProjectID, template.ID, template.EnvironmentIDs)
 
+	err = d.UpdateTemplateNotifications(template.ProjectID, template.ID, template.NotificationIDs)
+
 	return err
 }
 
@@ -203,6 +210,63 @@ func (d *SqlDb) UpdateTemplateEnvironments(projectID int, templateID int, enviro
 			projectID,
 			templateID,
 			envID,
+		)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func (d *SqlDb) GetTemplateNotifications(projectID int, templateID int) (notificationIDs []int, err error) {
+	notificationIDs = make([]int, 0)
+
+	var rows []struct {
+		NotificationID int `db:"notification_id"`
+	}
+
+	_, err = d.selectAll(
+		&rows,
+		"select notification_id from project__template_notification "+
+			"where project_id=? and template_id=? order by notification_id",
+		projectID,
+		templateID,
+	)
+
+	if err != nil {
+		return
+	}
+
+	for _, r := range rows {
+		notificationIDs = append(notificationIDs, r.NotificationID)
+	}
+
+	return
+}
+
+func (d *SqlDb) UpdateTemplateNotifications(projectID int, templateID int, notificationIDs []int) (err error) {
+	_, err = d.exec(
+		"delete from project__template_notification where project_id=? and template_id=?",
+		projectID,
+		templateID,
+	)
+	if err != nil {
+		return
+	}
+
+	seen := make(map[int]bool)
+	for _, notificationID := range notificationIDs {
+		if seen[notificationID] {
+			continue
+		}
+		seen[notificationID] = true
+
+		_, err = d.exec(
+			"insert into project__template_notification (project_id, template_id, notification_id) values (?, ?, ?)",
+			projectID,
+			templateID,
+			notificationID,
 		)
 		if err != nil {
 			return
@@ -406,6 +470,11 @@ func (d *SqlDb) getTemplates(
 		}
 
 		template.EnvironmentIDs, err = d.GetTemplateEnvironments(projectID, template.ID)
+		if err != nil {
+			return
+		}
+
+		template.NotificationIDs, err = d.GetTemplateNotifications(projectID, template.ID)
 		if err != nil {
 			return
 		}

--- a/services/tasks/TaskRunner_logging.go
+++ b/services/tasks/TaskRunner_logging.go
@@ -130,6 +130,10 @@ func (t *TaskRunner) SetStatus(status task_logger.TaskStatus) {
 		t.sendGotifyAlert()
 	}
 
+	if status == task_logger.TaskSuccessStatus || status == task_logger.TaskFailStatus || status == task_logger.TaskStoppedStatus {
+		t.sendTemplateNotifications()
+	}
+
 	for _, l := range t.statusListeners {
 		l(status)
 	}

--- a/services/tasks/alert.go
+++ b/services/tasks/alert.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"bytes"
 	"embed"
+	"encoding/json"
 	"fmt"
 	htmltemplate "html/template"
 	"net/http"
@@ -582,4 +583,122 @@ func (t *TaskRunner) taskLink() string {
 		t.Template.ID,
 		t.Task.ID,
 	)
+}
+
+func (t *TaskRunner) sendCustomMailAlert(notification db.Notification) {
+	body := bytes.NewBufferString("")
+	author, version := t.alertInfos()
+
+	alert := Alert{
+		Name:   t.Template.Name,
+		Author: author,
+		Color:  t.alertColor("email"),
+		Task: alertTask{
+			ID:      strconv.Itoa(t.Task.ID),
+			URL:     t.taskLink(),
+			Result:  t.Task.Status.Format(),
+			Version: version,
+			Desc:    t.Task.Message,
+		},
+	}
+
+	tpl, err := htmltemplate.ParseFS(templates, "templates/email.tmpl")
+	if err != nil {
+		t.Log("Can't parse custom email alert template!")
+		panic(err)
+	}
+
+	if err := tpl.Execute(body, alert); err != nil {
+		t.Log("Can't generate custom email alert template!")
+		panic(err)
+	}
+
+	if body.Len() == 0 {
+		t.Log("Buffer for custom email alert is empty")
+		return
+	}
+
+	var config struct {
+		EmailSender        string `json:"email_sender"`
+		EmailHost          string `json:"email_host"`
+		EmailPort          string `json:"email_port"`
+		EmailPasswordKeyID *int   `json:"email_password_key_id"`
+		EmailSecure        bool   `json:"email_secure"`
+		EmailTls           bool   `json:"email_tls"`
+	}
+
+	if err := json.Unmarshal([]byte(notification.Config), &config); err != nil {
+		t.Logf("Failed to parse config JSON for notification %d: %s", notification.ID, err.Error())
+		return
+	}
+
+	username := ""
+	password := ""
+
+	if config.EmailPasswordKeyID != nil {
+		key, err := t.pool.store.GetAccessKey(t.Template.ProjectID, *config.EmailPasswordKeyID)
+		if err != nil {
+			t.Logf("Warning: Could not load SMTP credentials from Key Store (ID: %d): %s", *config.EmailPasswordKeyID, err.Error())
+		} else {
+			if err := t.pool.encryptionService.DeserializeSecret(&key); err != nil {
+				t.Logf("Warning: Could not decrypt SMTP credentials: %s", err.Error())
+			}
+
+			if key.Type == db.AccessKeyLoginPassword {
+				username = key.LoginPassword.Login
+				password = key.LoginPassword.Password
+			} else if key.Type == db.AccessKeyString {
+				username = config.EmailSender
+				password = key.String
+			}
+
+		}
+	}
+
+	t.Logf("Attempting to send alert via SMTP Host: %s to %s", config.EmailHost, config.EmailSender)
+
+	str := body.String()
+	if err := mailer.Send(
+		config.EmailSecure,
+		config.EmailTls,
+		config.EmailHost,
+		config.EmailPort,
+		username,
+		password,
+		config.EmailSender,
+		config.EmailSender,
+		fmt.Sprintf("Task '%s' - %s", t.Template.Name, t.Task.Status.Format()),
+		str,
+	); err != nil {
+		util.LogError(err)
+		t.Logf("Failed to send email alert: %s", err.Error())
+		return
+	}
+
+	t.Logf("Successfully sent email alert via %s", config.EmailHost)
+}
+
+func (t *TaskRunner) sendTemplateNotifications() {
+	if t.Template.SuppressSuccessAlerts && t.Task.Status == task_logger.TaskSuccessStatus {
+		return
+	}
+
+	if len(t.Template.NotificationIDs) == 0 {
+		return
+	}
+
+	for _, notificationID := range t.Template.NotificationIDs {
+		notification, err := t.pool.store.GetNotification(t.Template.ProjectID, notificationID)
+		if err != nil {
+			t.Logf("Can't load template notification %d: %s", notificationID, err.Error())
+			continue
+		}
+
+		switch notification.Type {
+		case "email":
+			t.sendCustomMailAlert(notification)
+		default:
+			t.Logf("Notification type '%s' not yet supported for custom template templates", notification.Type)
+		}
+	}
 }

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1152,6 +1152,13 @@ export default {
             to: `${base}/integrations`,
             testId: 'sidebar-integrations',
           },
+          {
+            key: 'notifications',
+            icon: 'mdi-bell-ring-outline',
+            title: this.$t('notifications'),
+            to: `${base}/notifications`,
+            testId: 'sidebar-integrations',
+          },
         );
       }
 

--- a/web/src/components/NotificationForm.vue
+++ b/web/src/components/NotificationForm.vue
@@ -108,18 +108,6 @@ export default {
             },
           ],
         },
-        slack: {
-          name: 'Slack',
-          fields: [
-            {
-              key: 'slack_url',
-              label: 'Slack Webhook URL',
-              placeholder:
-              'https://hooks.slack.com/services/...',
-              required: true,
-            },
-          ],
-        },
       },
     };
   },
@@ -165,7 +153,8 @@ export default {
         if (this.currentFields) {
           this.currentFields.forEach((field) => {
             if (this.configData[field.key] === undefined) {
-              this.$set(this.configData, field.key, '');
+              const defaultValue = field.type === 'checkbox' ? false : '';
+              this.$set(this.configData, field.key, defaultValue);
             }
           });
         }

--- a/web/src/components/NotificationForm.vue
+++ b/web/src/components/NotificationForm.vue
@@ -1,0 +1,146 @@
+<template>
+  <v-skeleton-loader
+    v-if="!isLoaded"
+    type="table-heading, list-item-two-line, list-item-two-line, list-item-two-line"
+  ></v-skeleton-loader>
+
+  <v-form
+    v-else
+    ref="form"
+    lazy-validation
+    v-model="formValid"
+  >
+    <v-alert
+      :value="formError"
+      color="error"
+      class="pb-2"
+    >{{ formError }}
+    </v-alert>
+
+    <v-text-field
+      v-model="item.name"
+      :label="$t('name')"
+      :rules="[v => !!v || $t('name_required')]"
+      required
+      :disabled="formSaving"
+      outlined
+      dense
+    ></v-text-field>
+
+    <div v-for="field in currentFields" :key="field.key">
+      <v-checkbox
+        v-if="field.type === 'checkbox'"
+        v-model="configData[field.key]"
+        :label="field.label"
+        :disabled="formSaving"
+        dense
+      ></v-checkbox>
+
+      <v-text-field
+        v-else
+        v-model="configData[field.key]"
+        :label="field.label"
+        :type="field.type || 'text'"
+        :placeholder="field.placeholder"
+        :rules="field.required ? [v => !!v || `${field.label} is required`] : []"
+        :disabled="formSaving"
+        outlined
+        dense
+      ></v-text-field>
+    </div>
+
+  </v-form>
+</template>
+
+<script>
+import ItemFormBase from '@/components/ItemFormBase';
+
+export default {
+  mixins: [ItemFormBase],
+
+  props: {
+    itemApp: String,
+  },
+
+  data() {
+    return {
+      configData: {},
+      providerSchemas: {
+        email: {
+          name: 'Email',
+          fields: [
+            { key: 'email_sender', label: 'Sender Address', placeholder: 'noreply@example.com', required: true },
+            { key: 'email_host', label: 'SMTP Host', placeholder: 'smtp.example.com', required: true },
+            { key: 'email_port', label: 'SMTP Port', placeholder: '587', type: 'number', required: true },
+            { key: 'email_username', label: 'SMTP Username', required: false },
+            { key: 'email_password', label: 'SMTP Password', type: 'password', required: false },
+            { key: 'email_secure', label: 'Secure Connection (SSL/TLS)', type: 'checkbox', required: false },
+            { key: 'email_tls', label: 'Force TLS', type: 'checkbox', required: false },
+            { key: 'email_tls_min_version', label: 'Min TLS Version', placeholder: '1.2', required: false }
+          ]
+        },
+        slack: {
+          name: 'Slack',
+          fields: [
+            { key: 'slack_url', label: 'Slack Webhook URL', placeholder: 'https://hooks.slack.com/services/...', required: true }
+          ]
+        },
+      }
+    };
+  },
+
+  computed: {
+    isLoaded() {
+      return this.item != null;
+    },
+    currentFields() {
+      const provider = this.providerSchemas[this.itemApp];
+      return provider ? provider.fields : [];
+    }
+  },
+
+  watch: {
+    item: {
+      handler(newItem) {
+        this.configData = {};
+        if (newItem && newItem.config) {
+          try {
+            const parsedConfig = typeof newItem.config === 'string'
+              ? JSON.parse(newItem.config)
+              : newItem.config;
+
+            Object.keys(parsedConfig).forEach(key => {
+              this.$set(this.configData, key, parsedConfig[key]);
+            });
+          } catch (e) {}
+        }
+
+        if (this.currentFields) {
+          this.currentFields.forEach(field => {
+            if (this.configData[field.key] === undefined) {
+              this.$set(this.configData, field.key, '');
+            }
+          });
+        }
+      },
+      immediate: true,
+      deep: true,
+    },
+  },
+
+  methods: {
+    getItemsUrl() {
+      return `/api/project/${this.projectId}/notifications`;
+    },
+
+    getSingleItemUrl() {
+      return `/api/project/${this.projectId}/notifications/${this.itemId}`;
+    },
+
+    beforeSave() {
+      this.item.type = this.itemApp;
+      this.item.config = JSON.stringify(this.configData);
+    },
+  },
+};
+</script>

--- a/web/src/components/NotificationForm.vue
+++ b/web/src/components/NotificationForm.vue
@@ -69,23 +69,39 @@ export default {
         email: {
           name: 'Email',
           fields: [
-            { key: 'email_sender', label: 'Sender Address', placeholder: 'noreply@example.com', required: true },
-            { key: 'email_host', label: 'SMTP Host', placeholder: 'smtp.example.com', required: true },
-            { key: 'email_port', label: 'SMTP Port', placeholder: '587', type: 'number', required: true },
+            {
+              key: 'email_sender', label: 'Sender Address', placeholder: 'noreply@example.com', required: true,
+            },
+            {
+              key: 'email_host', label: 'SMTP Host', placeholder: 'smtp.example.com', required: true,
+            },
+            {
+              key: 'email_port', label: 'SMTP Port', placeholder: '587', type: 'number', required: true,
+            },
             { key: 'email_username', label: 'SMTP Username', required: false },
-            { key: 'email_password', label: 'SMTP Password', type: 'password', required: false },
-            { key: 'email_secure', label: 'Secure Connection (SSL/TLS)', type: 'checkbox', required: false },
-            { key: 'email_tls', label: 'Force TLS', type: 'checkbox', required: false },
-            { key: 'email_tls_min_version', label: 'Min TLS Version', placeholder: '1.2', required: false }
-          ]
+            {
+              key: 'email_password', label: 'SMTP Password', type: 'password', required: false,
+            },
+            {
+              key: 'email_secure', label: 'Secure Connection (SSL/TLS)', type: 'checkbox', required: false,
+            },
+            {
+              key: 'email_tls', label: 'Force TLS', type: 'checkbox', required: false,
+            },
+            {
+              key: 'email_tls_min_version', label: 'Min TLS Version', placeholder: '1.2', required: false,
+            },
+          ],
         },
         slack: {
           name: 'Slack',
           fields: [
-            { key: 'slack_url', label: 'Slack Webhook URL', placeholder: 'https://hooks.slack.com/services/...', required: true }
-          ]
+            {
+              key: 'slack_url', label: 'Slack Webhook URL', placeholder: 'https://hooks.slack.com/services/...', required: true,
+            },
+          ],
         },
-      }
+      },
     };
   },
 
@@ -96,7 +112,7 @@ export default {
     currentFields() {
       const provider = this.providerSchemas[this.itemApp];
       return provider ? provider.fields : [];
-    }
+    },
   },
 
   watch: {
@@ -109,14 +125,16 @@ export default {
               ? JSON.parse(newItem.config)
               : newItem.config;
 
-            Object.keys(parsedConfig).forEach(key => {
+            Object.keys(parsedConfig).forEach((key) => {
               this.$set(this.configData, key, parsedConfig[key]);
             });
-          } catch (e) {}
+          } catch (e) {
+            // Ignore JSON-parsing-Error
+          }
         }
 
         if (this.currentFields) {
-          this.currentFields.forEach(field => {
+          this.currentFields.forEach((field) => {
             if (this.configData[field.key] === undefined) {
               this.$set(this.configData, field.key, '');
             }

--- a/web/src/components/NotificationForm.vue
+++ b/web/src/components/NotificationForm.vue
@@ -28,8 +28,23 @@
     ></v-text-field>
 
     <div v-for="field in currentFields" :key="field.key">
+      <v-autocomplete
+        v-if="field.type === 'key'"
+        v-model="configData[field.key]"
+        :label="field.label"
+        :items="loginPasswordKeys"
+        item-value="id"
+        item-text="name"
+        :rules="field.required ? [v => !!v || `${field.label} is required`] : []"
+        :required="field.required"
+        :disabled="formSaving"
+        outlined
+        dense
+        clearable
+      ></v-autocomplete>
+
       <v-checkbox
-        v-if="field.type === 'checkbox'"
+        v-else-if="field.type === 'checkbox'"
         v-model="configData[field.key]"
         :label="field.label"
         :disabled="formSaving"
@@ -65,6 +80,7 @@ export default {
   data() {
     return {
       configData: {},
+      keys: null,
       providerSchemas: {
         email: {
           name: 'Email',
@@ -78,9 +94,8 @@ export default {
             {
               key: 'email_port', label: 'SMTP Port', placeholder: '587', type: 'number', required: true,
             },
-            { key: 'email_username', label: 'SMTP Username', required: false },
             {
-              key: 'email_password', label: 'SMTP Password', type: 'password', required: false,
+              key: 'email_password_key_id', label: 'SMTP Credentials', type: 'key', required: false,
             },
             {
               key: 'email_secure', label: 'Secure Connection (SSL/TLS)', type: 'checkbox', required: false,
@@ -97,7 +112,11 @@ export default {
           name: 'Slack',
           fields: [
             {
-              key: 'slack_url', label: 'Slack Webhook URL', placeholder: 'https://hooks.slack.com/services/...', required: true,
+              key: 'slack_url',
+              label: 'Slack Webhook URL',
+              placeholder:
+              'https://hooks.slack.com/services/...',
+              required: true,
             },
           ],
         },
@@ -106,13 +125,23 @@ export default {
   },
 
   computed: {
-    isLoaded() {
-      return this.item != null;
+    loginPasswordKeys() {
+      if (this.keys == null) return null;
+      return this.keys.filter((key) => key.type === 'login_password');
     },
+
+    isLoaded() {
+      return this.item != null && this.keys != null;
+    },
+
     currentFields() {
       const provider = this.providerSchemas[this.itemApp];
       return provider ? provider.fields : [];
     },
+  },
+
+  async created() {
+    this.keys = await this.loadProjectResources('keys');
   },
 
   watch: {

--- a/web/src/components/TemplateForm.vue
+++ b/web/src/components/TemplateForm.vue
@@ -274,6 +274,23 @@
           outlined
           dense
         ></v-autocomplete>
+
+        <v-select
+          v-model="item.notification_ids"
+          :items="notifications"
+          item-value="id"
+          item-text="name"
+          :label="$t('Notifications')"
+          placeholder="Select notification channels"
+          multiple
+          chips
+          deletable-chips
+          small-chips
+          clearable
+          :disabled="formSaving"
+          outlined
+          dense
+        ></v-select>
       </v-col>
 
       <v-col>
@@ -594,6 +611,7 @@ export default {
       },
       item: {
         task_params: {},
+        notification_ids: [],
       },
       inventory: null,
       repositories: null,
@@ -601,6 +619,7 @@ export default {
       views: null,
       schedules: null,
       buildTemplates: null,
+      notifications: null,
       cronFormat: '* * * * *',
       cronRepositoryId: null,
       cronVisible: false,
@@ -734,7 +753,8 @@ export default {
         && this.item != null
         && this.schedules != null
         && this.views != null
-        && this.runnerTags != null;
+        && this.runnerTags != null
+        && this.notifications != null;
     },
 
   },
@@ -795,6 +815,7 @@ export default {
       return {
         task_params: {},
         environment_ids: [],
+        notification_ids: [],
       };
     },
 
@@ -812,6 +833,7 @@ export default {
         this.environment,
         templates,
         this.runnerTags,
+        this.notifications,
       ] = await Promise.all([
         this.loadProjectResources('repositories'),
         this.loadProjectEndpoint(`/inventory?app=${this.app}&template_id=${this.itemId}`),
@@ -821,6 +843,7 @@ export default {
         this.loadProjectResources('environment'),
         this.loadProjectResources('templates'),
         this.loadProjectResources('runner_tags'),
+        this.loadProjectResources('notifications'),
       ]);
 
       this.inventory = [...inventory1, ...inventory2];
@@ -883,6 +906,10 @@ export default {
 
       if (!Array.isArray(this.item.environment_ids)) {
         this.$set(this.item, 'environment_ids', []);
+      }
+
+      if (!Array.isArray(this.item.notification_ids)) {
+        this.$set(this.item, 'notification_ids', []);
       }
 
       this.args = JSON.parse(this.item.arguments || '[]');

--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -494,4 +494,5 @@ export default {
   unlimited: 'Unlimited',
   featureFlags: 'Feature Flags',
   nonAdminCanCreateProject: 'Non-admin Can Create Project',
+  newNotification: 'New Notification',
 };

--- a/web/src/router/index.js
+++ b/web/src/router/index.js
@@ -31,6 +31,7 @@ import Stats from '../views/project/Stats.vue';
 import Tokens from '../views/Tokens.vue';
 import AcceptInvite from '../views/AcceptInvite.vue';
 import SecretStorage from '../views/project/SecretStorages.vue';
+import Notifications from '../views/project/Notifications.vue';
 
 Vue.use(VueRouter);
 
@@ -130,6 +131,10 @@ const routes = [
   {
     path: '/project/:projectId/integrations',
     component: Integrations,
+  },
+  {
+    path: '/project/:projectId/notifications',
+    component: Notifications,
   },
   {
     path: '/project/:projectId/integrations/:integrationId',

--- a/web/src/views/project/Notifications.vue
+++ b/web/src/views/project/Notifications.vue
@@ -1,0 +1,162 @@
+<template xmlns:v-slot="http://www.w3.org/1999/XSL/Transform">
+  <div v-if="items != null">
+
+    <EditDialog
+      v-model="editDialog"
+      :save-button-text="itemId === 'new' ? $t('create') : $t('save')"
+      :title="itemId === 'new' ? 'New Notification' : 'Edit Notification'"
+      :max-width="500"
+      @save="loadItems"
+    >
+      <template v-slot:form="{ onSave, onError, needSave, needReset }">
+        <NotificationForm
+          :project-id="projectId"
+          :item-id="itemId"
+          :item-app="itemApp"
+          @save="onSave"
+          @error="onError"
+          :need-save="needSave"
+          :need-reset="needReset"
+        />
+      </template>
+    </EditDialog>
+
+    <YesNoDialog
+      title="Delete Notification"
+      text="Are you sure you want to delete this notification?"
+      v-model="deleteItemDialog"
+      @yes="deleteItem(itemId)"
+    />
+
+    <v-toolbar flat>
+      <v-app-bar-nav-icon @click="showDrawer()"></v-app-bar-nav-icon>
+      <v-toolbar-title>{{ $t('notifications') }}</v-toolbar-title>
+      <v-spacer></v-spacer>
+
+      <v-menu offset-y>
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            class="pr-2"
+            v-bind="attrs"
+            v-on="on"
+            color="primary"
+            v-if="can(USER_PERMISSIONS.manageProjectResources)"
+          >
+            {{ $t('newNotification') }}
+            <v-icon>mdi-chevron-down</v-icon>
+          </v-btn>
+        </template>
+        <v-list>
+          <v-list-item
+            v-for="provider in notificationProviders"
+            :key="provider.id"
+            link
+            @click="itemApp = provider.id; editItem('new');"
+          >
+            <v-list-item-icon>
+              <v-icon>{{ provider.icon }}</v-icon>
+            </v-list-item-icon>
+            <v-list-item-title>{{ provider.name }}</v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+    </v-toolbar>
+
+    <v-divider />
+
+    <v-data-table
+      :headers="headers"
+      :items="items"
+      hide-default-footer
+      class="mt-4"
+      :items-per-page="Number.MAX_VALUE"
+      style="max-width: calc(var(--breakpoint-xl) - var(--nav-drawer-width) - 200px); margin: auto;"
+    >
+      <template v-slot:item.name="{ item }">
+        <v-icon class="mr-3" small>
+          {{ getProviderIcon(item.type) }}
+        </v-icon>
+        {{ item.name }}
+      </template>
+
+      <template v-slot:item.type="{ item }">
+        <code>{{ item.type }}</code>
+      </template>
+
+      <template v-slot:item.actions="{ item }">
+        <v-btn-toggle dense :value-comparator="() => false">
+          <v-btn @click="askDeleteItem(item.id)">
+            <v-icon>mdi-delete</v-icon>
+          </v-btn>
+          <v-btn @click="itemApp = item.type; editItem(item.id)">
+            <v-icon>mdi-pencil</v-icon>
+          </v-btn>
+        </v-btn-toggle>
+      </template>
+    </v-data-table>
+  </div>
+</template>
+
+<script>
+import ItemListPageBase from '@/components/ItemListPageBase';
+import AppsMixin from '@/components/AppsMixin';
+import NotificationForm from '@/components/NotificationForm.vue';
+
+export default {
+  mixins: [ItemListPageBase, AppsMixin],
+  components: { NotificationForm },
+
+  props: {
+    features: Object,
+  },
+
+  data() {
+    return {
+      itemApp: '',
+      item: {},
+      notificationProviders: [
+        { id: 'email', name: 'Email', icon: 'mdi-email' },
+        { id: 'slack', name: 'Slack', icon: 'mdi-slack' },
+      ],
+    };
+  },
+
+  methods: {
+    getProviderIcon(type) {
+      if (!type) return 'mdi-bell';
+      const provider = this.notificationProviders.find(p => p.id === type.toLowerCase());
+      return provider ? provider.icon : 'mdi-bell';
+    },
+
+    getHeaders() {
+      return [
+        {
+          text: this.$i18n.t('name'),
+          value: 'name',
+          width: '50%',
+        },
+        {
+          text: this.$i18n.t('type'),
+          value: 'type',
+          width: '30%',
+        },
+        {
+          value: 'actions',
+          sortable: false,
+          width: '20%',
+        },
+      ];
+    },
+
+    getItemsUrl() {
+      return `/api/project/${this.projectId}/notifications`;
+    },
+    getSingleItemUrl() {
+      return `/api/project/${this.projectId}/notifications/${this.itemId}`;
+    },
+    getEventName() {
+      return 'i-notifications';
+    },
+  },
+};
+</script>

--- a/web/src/views/project/Notifications.vue
+++ b/web/src/views/project/Notifications.vue
@@ -28,6 +28,13 @@
       @yes="deleteItem(itemId)"
     />
 
+    <ObjectRefsDialog
+      v-model="itemRefsDialog"
+      :object-refs="itemRefs"
+      :project-id="projectId"
+      object-title="notification"
+    />
+
     <v-toolbar flat>
       <v-app-bar-nav-icon @click="showDrawer()"></v-app-bar-nav-icon>
       <v-toolbar-title>{{ $t('notifications') }}</v-toolbar-title>
@@ -101,10 +108,11 @@
 import ItemListPageBase from '@/components/ItemListPageBase';
 import AppsMixin from '@/components/AppsMixin';
 import NotificationForm from '@/components/NotificationForm.vue';
+import ObjectRefsDialog from '@/components/ObjectRefsDialog.vue';
 
 export default {
   mixins: [ItemListPageBase, AppsMixin],
-  components: { NotificationForm },
+  components: { NotificationForm, ObjectRefsDialog },
 
   props: {
     features: Object,

--- a/web/src/views/project/Notifications.vue
+++ b/web/src/views/project/Notifications.vue
@@ -124,7 +124,6 @@ export default {
       item: {},
       notificationProviders: [
         { id: 'email', name: 'Email', icon: 'mdi-email' },
-        { id: 'slack', name: 'Slack', icon: 'mdi-slack' },
       ],
     };
   },

--- a/web/src/views/project/Notifications.vue
+++ b/web/src/views/project/Notifications.vue
@@ -124,7 +124,7 @@ export default {
   methods: {
     getProviderIcon(type) {
       if (!type) return 'mdi-bell';
-      const provider = this.notificationProviders.find(p => p.id === type.toLowerCase());
+      const provider = this.notificationProviders.find((p) => p.id === type.toLowerCase());
       return provider ? provider.icon : 'mdi-bell';
     },
 


### PR DESCRIPTION
### Description
This PR introduces a dedicated Notification Management system within the Project Settings UI and backend API. Currently, notification configurations in Semaphore are rigid and historically constrained. This change implements a clean, multi-service architecture per project, initially focusing on **Email** alerts. It provides an easily extendable foundation for adding more notification providers in future standalone updates.

### What was done:
* **Database & Migrations (`db/`):**
  * Added database schema version `2.18.8` containing tables for custom `project__notification` profiles and their respective connections to template alerts (`project__template_notification`).
  * Defined structural models and interface patterns for `NotificationManager` methods (`Create`, `Get`, `Update`, `Delete`, and `GetRefs`).
* **Web-Backend (API / Services):**
  * Created `NotificationMiddleware` for parameter extraction and contextual validation.
  * Added structured CRUD controllers for handling notification objects via the API.
  * Integrated notification events (`Create`, `Update`, `Delete`) into the project's internal `EventLog` with type `db.EventNotification`.
  * Hooked `sendTemplateNotifications()` into the core task runner logging loop (`TaskRunner_logging.go`) to dynamically trigger active alerting when tasks succeed, fail, or stop.
  * Implemented secure SMTP configurations leveraging the credential storage (`AccessKey` manager) to pull encrypted username/password values seamlessly.
* **Routing & Interfaces:**
  * Configured sub-routing boundaries within `router.go` to securely parse and update user notification policies per individual project scope.
  
<img width="3072" height="1694" alt="immagine" src="https://github.com/user-attachments/assets/f10f2388-2cbc-4bc4-ae2e-4cb531b12deb" />
<img width="1612" height="1402" alt="immagine" src="https://github.com/user-attachments/assets/68b84ae1-a688-4299-a37a-5fc172fcde19" />


---

### Future Extensibility
> *Note for Reviewers:* This feature is designed with modularity in mind. 
> 
> To add any alternative messaging service downstream (e.g., *Slack*, *Discord*, or *Webhooks*), developers only need to:
> 1. Append the configuration payload mappings and its corresponding icon identifier into the frontend state components.
> 2. Add an explicit routing branch inside the backend task runner service (`alert.go`) to redirect the structured json configs payload toward the targeted third-party APIs.

### Impact
Improves user experience significantly by making alerting granularly adjustable across distinct automated playbooks.

### Related / Fixes
Addresses parts of the long-standing community request regarding modular alerting structures.
Fixes #3387 