### PR TITLE
fix(web): make copy-to-clipboard icon visible in light mode (#3938)

### DIFF
--- a/web/src/components/CopyClipboardButton.vue
+++ b/web/src/components/CopyClipboardButton.vue
@@ -7,7 +7,7 @@
     ></textarea>
 
     <v-btn icon @click="copy()" :large="large">
-      <v-icon color="white">mdi-content-copy</v-icon>
+      <v-icon :color="color">mdi-content-copy</v-icon>
     </v-btn>
   </span>
 </template>


### PR DESCRIPTION
The CopyClipboardButton hard-coded the icon color to white, making it invisible against the light theme background (e.g. on the API Tokens page).