### PR TITLE
Fix runner executor error logging

### DIFF
--- a/services/runners/job_pool.go
+++ b/services/runners/job_pool.go
@@ -992,7 +992,7 @@ func (p *JobPool) checkNewJobs() {
 		if execErr != nil {
 			log.WithError(execErr).WithFields(log.Fields{
 				"context":    "checking_new_jobs",
-				"project_id": *response.CacheCleanProjectID,
+				"project_id": newJob.Task.ProjectID,
 				"task_id":    newJob.Task.ID,
 			}).Error("cannot construct executor for task")
 			continue

--- a/services/runners/job_pool_test.go
+++ b/services/runners/job_pool_test.go
@@ -1,8 +1,12 @@
 package runners
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/semaphoreui/semaphore/db"
 	"github.com/semaphoreui/semaphore/pkg/task_logger"
@@ -122,6 +126,42 @@ func TestJobPool_ApplyTerminatedJobs(t *testing.T) {
 	assert.False(t, lj2.IsKilled())
 
 	assert.Equal(t, 0, p.runningJobsCount())
+}
+
+func TestJobPool_CheckNewJobsExecutorErrorUsesTaskProjectID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		err := json.NewEncoder(w).Encode(RunnerState{
+			NewJobs: []JobData{{
+				Task: db.Task{
+					ID:        42,
+					ProjectID: 7,
+				},
+			}},
+		})
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	previousConfig := util.Config
+	util.Config = &util.ConfigType{
+		WebHost: server.URL,
+		Runner: &util.RunnerConfig{
+			Token:      "test-token",
+			Connection: &util.RunnerConnectionConfig{},
+		},
+	}
+	defer func() {
+		util.Config = previousConfig
+	}()
+
+	p := &JobPool{
+		runningJobs: make(map[int]*runningJob),
+		queue:       make([]*job, 0),
+		startedAt:   time.Now(),
+	}
+
+	require.NotPanics(t, p.checkNewJobs)
+	assert.Equal(t, 0, p.queueLen())
 }
 
 // TestJobPool_ConcurrentAccess models the three actors that touch the pool


### PR DESCRIPTION
### Motivation

- Prevent a nil-pointer panic when logging executor construction failures caused by dereferencing `response.CacheCleanProjectID` which can be `nil` during normal polls.
- Ensure the runner rejects tasks cleanly when `newExecutor` fails (e.g. when provider is nil) instead of crashing the process.

### Description

- Replace the unsafe dereference of `response.CacheCleanProjectID` with the task-scoped `newJob.Task.ProjectID` in `checkNewJobs` to avoid panics (`services/runners/job_pool.go`).
- Add a regression test `TestJobPool_CheckNewJobsExecutorErrorUsesTaskProjectID` that returns a `RunnerState` with a `NewJobs` entry and no `cache_clean_project_id` to assert `checkNewJobs` does not panic and does not enqueue the job (`services/runners/job_pool_test.go`).
- Run `gofmt` formatting on the modified files.

### Testing

- Ran `gofmt -w services/runners/job_pool.go services/runners/job_pool_test.go` which completed successfully.
- Attempted to run `go test ./services/runners` but the run was blocked because the Go 1.26 toolchain download from `proxy.golang.org` returned `403 Forbidden`, so automated tests could not be completed in this environment.
- The added test uses `require.NotPanics` to validate the nil-provider/error path and is included in the test suite for CI to execute when the Go toolchain is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d24fd5ce48325a4f392f1b036ba2c)