### PR TITLE
Fix OSS executor startup errors

### DIFF
--- a/pro/services/tasks/docker/config.go
+++ b/pro/services/tasks/docker/config.go
@@ -12,10 +12,12 @@
 package docker
 
 import (
+	"errors"
+
 	"github.com/semaphoreui/semaphore/services/tasks"
 	"github.com/semaphoreui/semaphore/util"
 )
 
 func NewProvider(_ util.RunnerDockerConfig) (tasks.ExecutorProvider, error) {
-	return nil, nil
+	return nil, errors.New("docker executor is only available in the proprietary build")
 }

--- a/pro/services/tasks/k8s/config.go
+++ b/pro/services/tasks/k8s/config.go
@@ -12,10 +12,12 @@
 package k8s
 
 import (
+	"errors"
+
 	"github.com/semaphoreui/semaphore/services/tasks"
 	"github.com/semaphoreui/semaphore/util"
 )
 
 func NewProvider(_ util.RunnerK8sConfig) (tasks.ExecutorProvider, error) {
-	return nil, nil
+	return nil, errors.New("k8s executor is only available in the proprietary build")
 }

--- a/services/runners/job_pool.go
+++ b/services/runners/job_pool.go
@@ -992,7 +992,7 @@ func (p *JobPool) checkNewJobs() {
 		if execErr != nil {
 			log.WithError(execErr).WithFields(log.Fields{
 				"context":    "checking_new_jobs",
-				"project_id": *response.CacheCleanProjectID,
+				"project_id": newJob.Task.ProjectID,
 				"task_id":    newJob.Task.ID,
 			}).Error("cannot construct executor for task")
 			continue


### PR DESCRIPTION
### Motivation
- The open-source Docker and Kubernetes executor provider stubs returned `(nil, nil)`, which caused `NewJobPool` to accept a nil provider and deferred failures to the first job instead of surfacing a startup error. 
- An error logging path dereferenced the optional `response.CacheCleanProjectID` and could panic the runner when executor construction failed, enabling a denial-of-service crash loop.

### Description
- Make the OSS Docker stub return an explicit error by returning `errors.New("docker executor is only available in the proprietary build")` instead of `(nil, nil)` (file: `pro/services/tasks/docker/config.go`).
- Make the OSS Kubernetes stub return an explicit error by returning `errors.New("k8s executor is only available in the proprietary build")` instead of `(nil, nil)` (file: `pro/services/tasks/k8s/config.go`).
- Fix executor-construction error logging to use `newJob.Task.ProjectID` rather than dereferencing `response.CacheCleanProjectID`, avoiding nil pointer panics when `CacheCleanProjectID` is unset (file: `services/runners/job_pool.go`).

### Testing
- `git diff --check` ran and reported no whitespace/patch issues (success).
- `go test ./pro/services/tasks/docker ./pro/services/tasks/k8s ./services/runners` was attempted but blocked because the CI attempted to download Go 1.26 and the proxy returned `403 Forbidden` (blocked).
- `GOTOOLCHAIN=local go test ./pro/services/tasks/docker ./pro/services/tasks/k8s ./services/runners` was attempted but blocked because the local Go version is `1.25.1` while the module requires Go `>= 1.26.0` (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d25109f2c8325a932111533f97b85)