### PR TITLE
Fix JWT config schema nesting

### DIFF
--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -165,28 +165,7 @@ properties:
   # ==========================================================================
   # JWT issuance for task executions
   # ==========================================================================
-  jwt_enabled:
-    type: boolean
-    description: >
-      When true, Semaphore mints a short-lived JWT for each task run and exposes
-      its public key via /.well-known/jwks.json.
-  jwt_issuer:
-    type: string
-    description: Value emitted in the `iss` claim of issued JWTs.
-  jwt_default_ttl:
-    type: string
-    pattern: "^[0-9]+(|s|m|h)$"
-    default: "1h"
-    description: >
-      Default lifetime of an issued task JWT, as a Go duration (e.g. 30m, 1h).
-      Overridden per-template by `jwt_params.ttl`.
-  jwt_max_ttl:
-    type: string
-    pattern: "^[0-9]+(s|m|h)$"
-    default: "24h"
-    description: >
-      Hard upper bound on per-template JWT TTL, as a Go duration. Any
-      configured `jwt_params.ttl` above this is rejected.
+  jwt: { $ref: "#/$defs/JWTConfig" }
 
   # ==========================================================================
   # Feature toggles
@@ -246,6 +225,34 @@ $defs:
         description: >-
           How often keys_file is polled for changes (a Go duration like "15s").
           "0" disables polling (a SIGHUP still forces a reload).
+
+  JWTConfig:
+    type: object
+    description: JWT issuance settings for task executions.
+    properties:
+      enabled:
+        type: boolean
+        description: >
+          When true, Semaphore mints a short-lived JWT for each task run and
+          exposes its public key via /.well-known/jwks.json.
+      issuer:
+        type: string
+        description: Value emitted in the `iss` claim of issued JWTs.
+      default_ttl:
+        type: string
+        pattern: "^[0-9]+(|s|m|h)$"
+        default: "1h"
+        description: >
+          Default lifetime of an issued task JWT, as a Go duration (e.g. 30m,
+          1h). Overridden per-template by `jwt_params.ttl`.
+      max_ttl:
+        type: string
+        pattern: "^[0-9]+(s|m|h)$"
+        default: "24h"
+        description: >
+          Hard upper bound on per-template JWT TTL, as a Go duration. Any
+          configured `jwt_params.ttl` above this is rejected.
+
   KeySource:
     type: object
     description: >-


### PR DESCRIPTION
### Motivation
- The runtime `ConfigType` exposes JWT settings under `JWT`/`jwt` but the schema kept top-level `jwt_*` properties, which caused valid `jwt: { ... }` configs to be ignored by consumers of the schema.
- Move the schema to match the runtime shape so users can author `jwt` configuration that is actually validated and recognized.

### Description
- Replace top-level `jwt_enabled`, `jwt_issuer`, `jwt_default_ttl`, and `jwt_max_ttl` schema entries with a single `jwt: { $ref: "#/$defs/JWTConfig" }` property in `config.schema.yaml`.
- Add a `$defs.JWTConfig` object describing `enabled`, `issuer`, `default_ttl`, and `max_ttl` with the same patterns/defaults as the runtime `JWTConfig` struct.

### Testing
- Loaded the updated schema with `ruby -e 'require "yaml"; YAML.load_file("config.schema.yaml")'` which succeeded. 
- Ran `git diff --check -- config.schema.yaml` which reported no whitespace/errors. 
- Attempted to run a Python `yaml.safe_load` check but it failed in this environment due to a missing `yaml` module (non-code-enforced environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a392e7b58988325ae8b87594616f24c)