### PR TITLE
Fix/pass secret when execution

### DIFF
--- a/services/tasks/local_executor.go
+++ b/services/tasks/local_executor.go
@@ -154,7 +154,6 @@ func (t *LocalExecutor) getEnvironmentExtraVars(username string, incomingVersion
 		if err = json.Unmarshal([]byte(t.Secret), &extraSecretVars); err != nil {
 			return
 		}
-		t.Secret = "{}"
 		maps.Copy(extraVars, extraSecretVars)
 	}
 

--- a/services/tasks/local_executor.go
+++ b/services/tasks/local_executor.go
@@ -145,6 +145,19 @@ func (t *LocalExecutor) getEnvironmentExtraVars(username string, incomingVersion
 		}
 	}
 
+	// Merge Survey Secret variables. They arrive via the Secret field (kept
+	// separate from Environment.JSON so they can be masked in logs and the
+	// re-run dialog) but must still be passed to the task, including Shell and
+	// Terraform tasks.
+	if t.Secret != "" {
+		extraSecretVars := make(map[string]any)
+		if err = json.Unmarshal([]byte(t.Secret), &extraSecretVars); err != nil {
+			return
+		}
+		t.Secret = "{}"
+		maps.Copy(extraVars, extraSecretVars)
+	}
+
 	vars := make(map[string]any)
 	vars["task_details"] = t.getTaskDetails(username, incomingVersion)
 	extraVars["semaphore_vars"] = vars
@@ -153,28 +166,10 @@ func (t *LocalExecutor) getEnvironmentExtraVars(username string, incomingVersion
 }
 
 func (t *LocalExecutor) getEnvironmentExtraVarsJSON(username string, incomingVersion *string) (str string, err error) {
-	extraVars := make(map[string]any)
-	extraSecretVars := make(map[string]any)
-
-	if t.Environment.JSON != "" {
-		err = json.Unmarshal([]byte(t.Environment.JSON), &extraVars)
-		if err != nil {
-			return
-		}
+	extraVars, err := t.getEnvironmentExtraVars(username, incomingVersion)
+	if err != nil {
+		return
 	}
-	if t.Secret != "" {
-		err = json.Unmarshal([]byte(t.Secret), &extraSecretVars)
-		if err != nil {
-			return
-		}
-	}
-	t.Secret = "{}"
-
-	maps.Copy(extraVars, extraSecretVars)
-
-	vars := make(map[string]any)
-	vars["task_details"] = t.getTaskDetails(username, incomingVersion)
-	extraVars["semaphore_vars"] = vars
 
 	ev, err := json.Marshal(extraVars)
 	if err != nil {

--- a/services/tasks/local_executor_test.go
+++ b/services/tasks/local_executor_test.go
@@ -1,0 +1,36 @@
+package db
+
+import (
+	"path"
+	"strings"
+)
+
+// ValidatePlaybookPath checks that a playbook (or script/subdirectory for
+// non-Ansible apps) path is relative and stays inside the repository bound
+// to the template. Absolute paths and paths escaping the repository via ".."
+// are rejected to prevent execution of arbitrary files on the host.
+func ValidatePlaybookPath(playbook string, objectName string) error {
+	if playbook == "" {
+		return nil
+	}
+
+	// Treat backslashes as path separators so Windows-style paths
+	// (C:\..., ..\..\evil.ps1) can not bypass the checks below.
+	p := strings.ReplaceAll(playbook, "\\", "/")
+
+	if path.IsAbs(p) {
+		return NewValidationError(objectName + " playbook must be a relative path inside the repository")
+	}
+
+	// Windows absolute paths like "C:/..." are not caught by path.IsAbs.
+	if len(p) >= 2 && p[1] == ':' {
+		return NewValidationError(objectName + " playbook must be a relative path inside the repository")
+	}
+
+	cleaned := path.Clean(p)
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return NewValidationError(objectName + " playbook must not point outside the repository")
+	}
+
+	return nil
+}

--- a/services/tasks/local_executor_test.go
+++ b/services/tasks/local_executor_test.go
@@ -22,7 +22,7 @@ func setupExecutorConfig(t *testing.T) {
 // "Secret" (delivered via LocalExecutor.Secret) are passed to Bash/Shell tasks,
 // alongside plain survey vars that arrive in Environment.JSON.
 func TestGetShellArgs_PassesSurveySecretVar(t *testing.T) {
-	setupExecutorConfig()
+	setupExecutorConfig(t)
 
 	exec := &LocalExecutor{
 		Template: db.Template{
@@ -45,7 +45,7 @@ func TestGetShellArgs_PassesSurveySecretVar(t *testing.T) {
 // TestGetEnvironmentExtraVars_MergesSecret checks the shared helper merges the
 // Secret field into the extra vars map used by Shell and Terraform tasks.
 func TestGetEnvironmentExtraVars_MergesSecret(t *testing.T) {
-	setupExecutorConfig()
+	setupExecutorConfig(t)
 
 	exec := &LocalExecutor{
 		Environment: db.Environment{JSON: `{"PLAIN_VAR":"hello"}`},

--- a/services/tasks/local_executor_test.go
+++ b/services/tasks/local_executor_test.go
@@ -1,36 +1,57 @@
-package db
+package tasks
 
 import (
-	"path"
-	"strings"
+	"testing"
+
+	"github.com/semaphoreui/semaphore/db"
+	"github.com/semaphoreui/semaphore/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// ValidatePlaybookPath checks that a playbook (or script/subdirectory for
-// non-Ansible apps) path is relative and stays inside the repository bound
-// to the template. Absolute paths and paths escaping the repository via ".."
-// are rejected to prevent execution of arbitrary files on the host.
-func ValidatePlaybookPath(playbook string, objectName string) error {
-	if playbook == "" {
-		return nil
+func setupExecutorConfig() {
+	if util.Config == nil {
+		util.Config = &util.ConfigType{}
+	}
+}
+
+// TestGetShellArgs_PassesSurveySecretVar verifies that Survey variables of type
+// "Secret" (delivered via LocalExecutor.Secret) are passed to Bash/Shell tasks,
+// alongside plain survey vars that arrive in Environment.JSON.
+func TestGetShellArgs_PassesSurveySecretVar(t *testing.T) {
+	setupExecutorConfig()
+
+	exec := &LocalExecutor{
+		Template: db.Template{
+			Type:     db.TemplateTask,
+			Playbook: "date.sh",
+		},
+		Environment: db.Environment{
+			JSON: `{"PLAIN_VAR":"hello"}`,
+		},
+		Secret: `{"MY_VAR":"s3cr3t"}`,
 	}
 
-	// Treat backslashes as path separators so Windows-style paths
-	// (C:\..., ..\..\evil.ps1) can not bypass the checks below.
-	p := strings.ReplaceAll(playbook, "\\", "/")
+	args, err := exec.getShellArgs("admin", nil)
+	require.NoError(t, err)
 
-	if path.IsAbs(p) {
-		return NewValidationError(objectName + " playbook must be a relative path inside the repository")
+	assert.Contains(t, args, "PLAIN_VAR=hello", "plain survey var must be passed")
+	assert.Contains(t, args, "MY_VAR=s3cr3t", "secret survey var must be passed")
+}
+
+// TestGetEnvironmentExtraVars_MergesSecret checks the shared helper merges the
+// Secret field into the extra vars map used by Shell and Terraform tasks.
+func TestGetEnvironmentExtraVars_MergesSecret(t *testing.T) {
+	setupExecutorConfig()
+
+	exec := &LocalExecutor{
+		Environment: db.Environment{JSON: `{"PLAIN_VAR":"hello"}`},
+		Secret:      `{"MY_VAR":"s3cr3t"}`,
 	}
 
-	// Windows absolute paths like "C:/..." are not caught by path.IsAbs.
-	if len(p) >= 2 && p[1] == ':' {
-		return NewValidationError(objectName + " playbook must be a relative path inside the repository")
-	}
+	extraVars, err := exec.getEnvironmentExtraVars("admin", nil)
+	require.NoError(t, err)
 
-	cleaned := path.Clean(p)
-	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
-		return NewValidationError(objectName + " playbook must not point outside the repository")
-	}
-
-	return nil
+	assert.Equal(t, "hello", extraVars["PLAIN_VAR"])
+	assert.Equal(t, "s3cr3t", extraVars["MY_VAR"])
 }

--- a/services/tasks/local_executor_test.go
+++ b/services/tasks/local_executor_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupExecutorConfig() {
+func setupExecutorConfig(t *testing.T) {
+	t.Helper()
+	prevCfg := util.Config
+	t.Cleanup(func() { util.Config = prevCfg })
 	if util.Config == nil {
 		util.Config = &util.ConfigType{}
 	}


### PR DESCRIPTION
fix issue #3994 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured Survey secret variables are consistently merged into task extra-vars output and shell execution arguments.
  * Removed behavior where secret data could be unintentionally cleared during extra-vars JSON generation.
* **Tests**
  * Added unit tests covering inclusion of secret survey variables in generated shell args.
  * Added unit tests verifying secret variables are merged into the resulting extra-vars map.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->