### PR TITLE
fix(runners): leaks TCP connections

### DIFF
--- a/services/runners/job_pool.go
+++ b/services/runners/job_pool.go
@@ -32,11 +32,12 @@ func derefString(s *string) string {
 
 func newHTTPClient() *http.Client {
 	tlsConfig := &tls.Config{}
-	if util.Config.Runner.Connection.SkipTLSVerify {
+	conn := util.Config.Runner.Connection
+	if conn.SkipTLSVerify {
 		tlsConfig.InsecureSkipVerify = true
 	}
-	if util.Config.Runner.Connection.ServerCACertFile != "" {
-		caCert, err := os.ReadFile(util.Config.Runner.Connection.ServerCACertFile)
+	if conn.ServerCACertFile != "" {
+		caCert, err := os.ReadFile(conn.ServerCACertFile)
 		if err == nil {
 			pool := x509.NewCertPool()
 			pool.AppendCertsFromPEM(caCert)
@@ -69,6 +70,12 @@ type JobPool struct {
 	// (X-Runner-Started-At header). It changes on every restart, letting the
 	// server detect that this runner lost its in-memory job pool.
 	startedAt time.Time
+
+	// client is the shared HTTP client for all runner→server requests. It is
+	// created once so the transport's keep-alive pool reuses connections —
+	// creating a client per request leaks one ESTABLISHED connection per poll
+	// cycle (~2/sec) until the runner exhausts ephemeral ports (issue #3941).
+	client *http.Client
 }
 
 // NewJobPool wires a runner-side job pool. The ExecutorProvider is materialised
@@ -80,6 +87,7 @@ func NewJobPool(keyInstaller db_lib.AccessKeyInstaller) *JobPool {
 		queue:       make([]*job, 0),
 		processing:  0,
 		startedAt:   tz.Now(),
+		client:      newHTTPClient(),
 	}
 
 	provider, err := newExecutorProvider(util.Config.Runner.Executor, keyInstaller)
@@ -213,8 +221,6 @@ func (p *JobPool) Unregister() (err error) {
 		return fmt.Errorf("runner is not registered")
 	}
 
-	client := newHTTPClient()
-
 	url := util.Config.WebHost + "/api/internal/runners"
 
 	req, err := http.NewRequest("DELETE", url, nil)
@@ -227,10 +233,11 @@ func (p *JobPool) Unregister() (err error) {
 		"url":     url,
 	}).Debug("Sending unregistration request to the server")
 
-	resp, err := client.Do(req)
+	resp, err := p.client.Do(req)
 	if err != nil {
 		return
 	}
+	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode >= 400 && resp.StatusCode != 404 {
 		err = fmt.Errorf("encountered error while unregistering runner; server returned code %d", resp.StatusCode)
@@ -404,8 +411,6 @@ func (p *JobPool) Run() {
 
 func (p *JobPool) sendProgress() (ok bool) {
 
-	client := newHTTPClient()
-
 	url := util.Config.WebHost + "/api/internal/runners"
 
 	body := RunnerProgress{
@@ -455,7 +460,7 @@ func (p *JobPool) sendProgress() (ok bool) {
 
 	p.setCommonHeaders(req)
 
-	resp, err := client.Do(req)
+	resp, err := p.client.Do(req)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"context": "sending_progress",
@@ -588,8 +593,6 @@ func (p *JobPool) tryRegisterRunner(configFilePath *string) (ok bool) {
 		return
 	}
 
-	client := newHTTPClient()
-
 	url := util.Config.WebHost + "/api/internal/runners"
 
 	jsonBytes, err := json.Marshal(RunnerRegistration{
@@ -623,7 +626,7 @@ func (p *JobPool) tryRegisterRunner(configFilePath *string) (ok bool) {
 		"url":         url,
 	}).Debug("Sending registration request to the server")
 
-	resp, err := client.Do(req)
+	resp, err := p.client.Do(req)
 
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{
@@ -631,6 +634,7 @@ func (p *JobPool) tryRegisterRunner(configFilePath *string) (ok bool) {
 		}).Error("failed to send registration request to the server")
 		return
 	}
+	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != 200 {
 		log.WithError(fmt.Errorf("invalid status code")).WithFields(log.Fields{
@@ -707,8 +711,6 @@ func (p *JobPool) tryRegisterRunner(configFilePath *string) (ok bool) {
 		}
 	}
 
-	defer resp.Body.Close() //nolint:errcheck
-
 	log.WithFields(log.Fields{
 		"context":     "registration",
 		"runner_name": util.Config.Runner.Name,
@@ -727,8 +729,6 @@ func (p *JobPool) checkNewJobs() {
 		}).Error("runner token is empty")
 		return
 	}
-
-	client := newHTTPClient()
 
 	url := util.Config.WebHost + "/api/internal/runners"
 
@@ -749,7 +749,7 @@ func (p *JobPool) checkNewJobs() {
 		"queued_jobs":  p.queueLen(),
 	}).Debug("Fetching new jobs from the server")
 
-	resp, err := client.Do(req)
+	resp, err := p.client.Do(req)
 
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{
@@ -757,6 +757,7 @@ func (p *JobPool) checkNewJobs() {
 		}).Error("failed to fetch new jobs from the server")
 		return
 	}
+	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode >= 400 {
 
@@ -766,8 +767,6 @@ func (p *JobPool) checkNewJobs() {
 		}).Error("server returned an error while fetching new jobs: " + p.getResponseErrorMessage(resp))
 		return
 	}
-
-	defer resp.Body.Close() //nolint:errcheck
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/services/runners/job_pool_test.go
+++ b/services/runners/job_pool_test.go
@@ -249,8 +249,9 @@ func TestJobPool_ReusesConnections(t *testing.T) {
 	util.Config = &util.ConfigType{
 		WebHost: srv.URL,
 		Runner: &util.RunnerConfig{
-			Token:    "test-token",
-			Executor: &util.ExecutorConfig{},
+			Token:      "test-token",
+			Executor:   &util.ExecutorConfig{},
+			Connection: &util.RunnerConnectionConfig{},
 		},
 	}
 

--- a/services/runners/job_pool_test.go
+++ b/services/runners/job_pool_test.go
@@ -2,9 +2,11 @@ package runners
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,7 +28,8 @@ func newTestJob(id int) *job {
 func TestJobPool_QueueOrder(t *testing.T) {
 	util.Config = &util.ConfigType{
 		Runner: &util.RunnerConfig{
-			Executor: &util.ExecutorConfig{},
+			Executor:   &util.ExecutorConfig{},
+			Connection: &util.RunnerConnectionConfig{},
 		},
 	}
 
@@ -159,6 +162,7 @@ func TestJobPool_CheckNewJobsExecutorErrorUsesTaskProjectID(t *testing.T) {
 		runningJobs: make(map[int]*runningJob),
 		queue:       make([]*job, 0),
 		startedAt:   time.Now(),
+		client:      newHTTPClient(),
 	}
 
 	require.NotPanics(t, p.checkNewJobs)
@@ -220,6 +224,44 @@ func TestJobPool_ConcurrentAccess(t *testing.T) {
 
 	close(start)
 	wg.Wait()
+}
+
+// TestJobPool_ReusesConnections guards against the TCP connection leak from
+// issue #3941: creating a new http.Client (and transport) per poll cycle left
+// one ESTABLISHED connection behind per request until ephemeral ports ran out.
+// With the shared client, many poll cycles must reuse a single connection.
+func TestJobPool_ReusesConnections(t *testing.T) {
+	prevCfg := util.Config
+	t.Cleanup(func() { util.Config = prevCfg })
+
+	var newConns int32
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("{}"))
+	}))
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			atomic.AddInt32(&newConns, 1)
+		}
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	util.Config = &util.ConfigType{
+		WebHost: srv.URL,
+		Runner: &util.RunnerConfig{
+			Token:    "test-token",
+			Executor: &util.ExecutorConfig{},
+		},
+	}
+
+	p := NewJobPool(nil)
+
+	for i := 0; i < 10; i++ {
+		require.True(t, p.sendProgress())
+		p.checkNewJobs()
+	}
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&newConns))
 }
 
 func TestJobPool_checkNewJobs_ExecutorErrorWithoutCacheCleanProjectID(t *testing.T) {

--- a/services/runners/job_pool_test.go
+++ b/services/runners/job_pool_test.go
@@ -26,6 +26,9 @@ func newTestJob(id int) *job {
 }
 
 func TestJobPool_QueueOrder(t *testing.T) {
+	prevCfg := util.Config
+	t.Cleanup(func() { util.Config = prevCfg })
+
 	util.Config = &util.ConfigType{
 		Runner: &util.RunnerConfig{
 			Executor:   &util.ExecutorConfig{},


### PR DESCRIPTION
https://github.com/semaphoreui/semaphore/issues/3941


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced repeated network connections between runners and the server by reusing a single HTTP connection across polling, progress updates, registration, and unregistration, improving reliability and efficiency.
  * Improved secure connection configuration to use the configured runner connection settings more consistently.
* **Tests**
  * Added coverage to verify TCP connection reuse across multiple job-polling cycles, and updated existing job pool tests for the new HTTP client behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->