### PR TITLE
fix(tasks): serialize git operations on shared repo dirs for parallel tasks

### DIFF
--- a/services/tasks/TaskPool.go
+++ b/services/tasks/TaskPool.go
@@ -62,6 +62,10 @@ type TaskPool struct {
 	keyInstallationService server.AccessKeyInstallationService
 	signer                 jwt.Signer
 
+	// repoLock serializes git operations on shared repository directories
+	// across parallel tasks of the same template.
+	repoLock *KeyLock
+
 	queueEvents chan PoolEvent
 
 	// state provides pluggable storage for Queue, active projects, running tasks and aliases
@@ -107,6 +111,7 @@ func CreateTaskPool(
 		logWriteService:        logWriteService,
 		keyInstallationService: keyInstallationService,
 		signer:                 signer,
+		repoLock:               &KeyLock{},
 		stop:                   make(chan struct{}),
 		reconcileDone:          make(chan struct{}),
 	}
@@ -547,6 +552,7 @@ func (p *TaskPool) hydrateTaskRunner(taskID int, projectID int) (*TaskRunner, er
 			Logger:       app.SetLogger(tr),
 			App:          app,
 			KeyInstaller: p.keyInstallationService,
+			RepoLock:     p.repoLock,
 		}
 	}
 	tr.job = job
@@ -1033,6 +1039,7 @@ func (p *TaskPool) AddTask(
 			Logger:       app.SetLogger(taskRunner),
 			App:          app,
 			KeyInstaller: p.keyInstallationService,
+			RepoLock:     p.repoLock,
 		}
 	}
 

--- a/services/tasks/TaskPool.go
+++ b/services/tasks/TaskPool.go
@@ -64,6 +64,9 @@ type TaskPool struct {
 
 	// repoLock serializes git operations on shared repository directories
 	// across parallel tasks of the same template.
+	// Intentionally separate from LocalExecutorProvider.repoLock: TaskPool
+	// (server process) and LocalExecutorProvider (runner process) never
+	// operate on the same directories, so they need no shared lock.
 	repoLock *KeyLock
 
 	queueEvents chan PoolEvent

--- a/services/tasks/TaskRunner_test.go
+++ b/services/tasks/TaskRunner_test.go
@@ -157,6 +157,7 @@ func TestTaskRunnerRun(t *testing.T) {
 		Environment:  taskRunner.Environment,
 		Logger:       &taskRunner,
 		KeyInstaller: keyInstaller,
+		RepoLock:     &KeyLock{},
 		App: &db_lib.AnsibleApp{
 			Template:   taskRunner.Template,
 			Repository: taskRunner.Repository,

--- a/services/tasks/key_lock.go
+++ b/services/tasks/key_lock.go
@@ -1,0 +1,35 @@
+package tasks
+
+import "sync"
+
+// KeyLock serializes work on a shared resource identified by a string key.
+// It exists to prevent concurrent git operations (pull/clone/checkout) on the
+// same repository directory when a template allows parallel tasks: all such
+// tasks share one working copy on disk, and concurrent `git pull` corrupts it.
+//
+// The zero value is ready to use.
+type KeyLock struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+// Lock blocks until the mutex for the given key is acquired and returns the
+// unlock function.
+//
+// ponytail: entries are never removed — the map is bounded by the number of
+// repository directories (repos × templates), which is negligible.
+func (l *KeyLock) Lock(key string) func() {
+	l.mu.Lock()
+	if l.locks == nil {
+		l.locks = make(map[string]*sync.Mutex)
+	}
+	m, ok := l.locks[key]
+	if !ok {
+		m = &sync.Mutex{}
+		l.locks[key] = m
+	}
+	l.mu.Unlock()
+
+	m.Lock()
+	return m.Unlock
+}

--- a/services/tasks/key_lock_test.go
+++ b/services/tasks/key_lock_test.go
@@ -1,0 +1,75 @@
+package tasks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyLock_SameKeySerializes(t *testing.T) {
+	l := &KeyLock{}
+
+	unlock := l.Lock("repo_1")
+
+	acquired := make(chan struct{})
+	go func() {
+		u := l.Lock("repo_1")
+		close(acquired)
+		u()
+	}()
+
+	select {
+	case <-acquired:
+		assert.Fail(t, "second Lock acquired while first is held")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	unlock()
+
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		assert.Fail(t, "second Lock not acquired after unlock")
+	}
+}
+
+func TestKeyLock_DifferentKeysIndependent(t *testing.T) {
+	l := &KeyLock{}
+
+	unlockA := l.Lock("repo_1")
+	defer unlockA()
+
+	acquired := make(chan struct{})
+	go func() {
+		u := l.Lock("repo_2")
+		u()
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		assert.Fail(t, "different key must not block")
+	}
+}
+
+func TestKeyLock_ReuseAfterUnlock(t *testing.T) {
+	l := &KeyLock{}
+
+	unlock := l.Lock("repo_1")
+	unlock()
+
+	done := make(chan struct{})
+	go func() {
+		u := l.Lock("repo_1")
+		u()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		assert.Fail(t, "key must be lockable again after unlock")
+	}
+}

--- a/services/tasks/local_executor.go
+++ b/services/tasks/local_executor.go
@@ -39,6 +39,13 @@ type LocalExecutor struct {
 
 	KeyInstaller db_lib.AccessKeyInstaller
 
+	// RepoLock serializes git operations on the shared per-template repository
+	// directory. Tasks of the same template may run in parallel
+	// (AllowParallelTasks) but share one working copy — concurrent `git pull`
+	// on it is a race. Wired by TaskPool (local) and LocalExecutorProvider
+	// (runner). Must be non-nil when Prepare is called for a git repository.
+	RepoLock *KeyLock
+
 	WorkflowArtifacts map[string]any
 
 	// Prepared state — populated by Prepare(), consumed by Run(). Lifted out of Run()
@@ -923,12 +930,7 @@ func (t *LocalExecutor) prepareRun(installingArgs db_lib.LocalAppInstallingArgs)
 			return err
 		}
 	} else {
-		if err := t.updateRepository(); err != nil {
-			t.Log("Failed updating repository: " + err.Error())
-			return err
-		}
-		if err := t.checkoutRepository(); err != nil {
-			t.Log("Failed to checkout repository to required commit: " + err.Error())
+		if err := t.updateAndCheckoutRepository(); err != nil {
 			return err
 		}
 	}
@@ -980,12 +982,7 @@ func (t *LocalExecutor) prepareRunTerraform(tfApp *db_lib.TerraformApp, installi
 			return err
 		}
 	} else {
-		if err := t.updateRepository(); err != nil {
-			t.Log("Failed updating repository: " + err.Error())
-			return err
-		}
-		if err := t.checkoutRepository(); err != nil {
-			t.Log("Failed to checkout repository to required commit: " + err.Error())
+		if err := t.updateAndCheckoutRepository(); err != nil {
 			return err
 		}
 	}
@@ -1003,6 +1000,30 @@ func (t *LocalExecutor) prepareRunTerraform(tfApp *db_lib.TerraformApp, installi
 
 	if err := t.installVaultKeyFiles(); err != nil {
 		t.Log("Failed to install vault password files: " + err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// updateAndCheckoutRepository runs the pull/clone + checkout sequence as one
+// critical section per repository directory, so parallel tasks of the same
+// template cannot run concurrent git operations on the shared working copy.
+//
+// ponytail: the lock covers git operations only; parallel tasks pinned to
+// different commits still share the working tree afterwards — per-task
+// worktrees if that ever matters.
+func (t *LocalExecutor) updateAndCheckoutRepository() error {
+	unlock := t.RepoLock.Lock(t.Repository.GetFullPath(t.Template.ID))
+	defer unlock()
+
+	if err := t.updateRepository(); err != nil {
+		t.Log("Failed updating repository: " + err.Error())
+		return err
+	}
+
+	if err := t.checkoutRepository(); err != nil {
+		t.Log("Failed to checkout repository to required commit: " + err.Error())
 		return err
 	}
 

--- a/services/tasks/local_executor_inventory.go
+++ b/services/tasks/local_executor_inventory.go
@@ -73,6 +73,11 @@ func (t *LocalExecutor) cloneInventoryRepo(keyInstaller db_lib.AccessKeyInstalle
 		Client:     db_lib.CreateDefaultGitClient(keyInstaller),
 	}
 
+	// Parallel tasks of the same template share this inventory directory —
+	// serialize the pull/remove/clone sequence, same as the main repo.
+	unlock := t.RepoLock.Lock(repo.GetFullPath())
+	defer unlock()
+
 	// Try to pull the repo before trying to clone it
 	if repo.CanBePulled() {
 		err := repo.Pull()

--- a/services/tasks/local_executor_provider.go
+++ b/services/tasks/local_executor_provider.go
@@ -12,13 +12,20 @@ import (
 // cheap (no re-discovery of the installer on every dispatch).
 type LocalExecutorProvider struct {
 	keyInstaller db_lib.AccessKeyInstaller
+
+	// repoLock serializes git operations on shared repository directories
+	// across parallel tasks of the same template running on this runner.
+	repoLock *KeyLock
 }
 
 // NewLocalExecutorProvider takes the AccessKey installer the runner constructed at
 // startup. The Provider does not own the installer's lifecycle — it just references
 // it for every per-task Executor it produces.
 func NewLocalExecutorProvider(keyInstaller db_lib.AccessKeyInstaller) *LocalExecutorProvider {
-	return &LocalExecutorProvider{keyInstaller: keyInstaller}
+	return &LocalExecutorProvider{
+		keyInstaller: keyInstaller,
+		repoLock:     &KeyLock{},
+	}
 }
 
 // NewExecutor returns a freshly-wired *LocalExecutor. db_lib.CreateApp is called
@@ -34,5 +41,6 @@ func (p *LocalExecutorProvider) NewExecutor(task db.Task, template db.Template, 
 		KeyInstaller: p.keyInstaller,
 		App:          db_lib.CreateApp(template, repository, inventory, nil),
 		JWT:          jwt,
+		RepoLock:     p.repoLock,
 	}, nil
 }

--- a/services/tasks/local_executor_provider.go
+++ b/services/tasks/local_executor_provider.go
@@ -15,6 +15,9 @@ type LocalExecutorProvider struct {
 
 	// repoLock serializes git operations on shared repository directories
 	// across parallel tasks of the same template running on this runner.
+	// Intentionally separate from TaskPool.repoLock: LocalExecutorProvider
+	// (runner process) and TaskPool (server process) never operate on the
+	// same directories, so they need no shared lock.
 	repoLock *KeyLock
 }
 


### PR DESCRIPTION
## Problem

When a template has **Allow parallel tasks** enabled, tasks of the same template run concurrently but share one working copy on disk (`repository_{repoID}_template_{templateID}`). Each task's `Prepare()` runs `git pull`/`clone` + `checkout` on that directory with no locking, so parallel tasks corrupt the working copy (racing pulls, remove+re-clone under a running pull, etc.). The same race exists for git-backed inventories (`..._inventory_{invID}` dirs).

## Solution

- New `KeyLock` primitive (`services/tasks/key_lock.go`): a map of mutexes keyed by directory path; zero value ready to use.
- `LocalExecutor.RepoLock *KeyLock` — held around the pull/clone+checkout sequence (new `updateAndCheckoutRepository()`), keyed by `Repository.GetFullPath(templateID)`. The destructive remove+re-clone fallback is inside the critical section.
- `cloneInventoryRepo` takes the same lock keyed by the inventory directory.
- Lock instances live on the two long-lived owners — `TaskPool` (local execution) and `LocalExecutorProvider` (runner execution) — no globals. Both local and runner paths go through `LocalExecutor.Prepare()`, so one fix covers both.

## Known limitation (deliberate)

The lock covers git operations only: parallel tasks pinned to **different commits** still share the working tree afterwards. Marked with a `ponytail:` comment naming the upgrade path (per-task worktrees) if that ever matters.

## Tests

- `TestKeyLock_*`: same-key serialization, different-key independence, reuse after unlock — pass with `-race`.
- `go test ./services/tasks/ ./services/runners/ -count=1 -race` — pass; build + vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task **Prepare** git paths used by every local/runner execution; wrong locking could deadlock or serialize too broadly, but the change is narrowly scoped and covered by race tests.
> 
> **Overview**
> Fixes races when **Allow parallel tasks** is on: concurrent tasks share one on-disk repo (and git-backed inventory) working copy, so overlapping pull/clone/checkout could corrupt the tree.
> 
> Adds a **`KeyLock`** (mutex per directory path) and wires shared instances on **`TaskPool`** (local server execution) and **`LocalExecutorProvider`** (runner process), each with its own lock because they never touch the same dirs. **`LocalExecutor`** now takes **`RepoLock`** and runs main-repo git work through **`updateAndCheckoutRepository()`** (pull/clone + checkout, including remove-and-reclone) under one critical section keyed by **`GetFullPath(templateID)`**. Git inventory clone/pull/remove uses the same lock on the inventory path.
> 
> Unit tests cover **`KeyLock`** serialization behavior. Locking is scoped to git I/O only; parallel tasks on different commits still share the tree after checkout (noted in code).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0978f979873c0067a85d10d414f6d61cdcdde949. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple tasks access the same template or inventory repository concurrently.
  * Prevented conflicting repository updates, pulls, and checkouts from causing task failures or inconsistent working directories.
* **Tests**
  * Added coverage for repository locking, including same-key serialization, independent keys, and lock reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->