### PR TITLE
feat/survey vars target

### DIFF
--- a/AGENTS/plans/2_19/survey-var-target.md
+++ b/AGENTS/plans/2_19/survey-var-target.md
@@ -1,0 +1,443 @@
+# Survey Variable Target (env vs CLI) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `target` field to Survey Variables that controls how the variable is delivered to the task process: the current app-specific CLI way (default) or as a process environment variable.
+
+**Architecture:** `SurveyVar` gets a `Target` field (`""` = CLI, `"env"` = environment variable) stored in the existing `survey_vars` JSON column — no DB migration. At run time `LocalExecutor` (used by both server and remote runner) excludes env-target vars from the extra-vars map and appends them to the process environment instead. The env var name is the survey var name verbatim (users who need `TF_VAR_foo` name the variable `TF_VAR_foo`).
+
+**Tech Stack:** Go (backend), Vue 2 + Vuetify (frontend), testify for tests.
+
+## Global Constraints
+
+- Version: 2.19 (branch `2-19-stable`).
+- No global variables (project rule).
+- Tests use `github.com/stretchr/testify` `assert`/`require` (project rule, see `.claude/CLAUDE.md`).
+- No DB migration: survey vars are serialized JSON in the `survey_vars` column; a new optional JSON field is backward and forward compatible.
+- Empty string `""` must remain the default target and preserve current behavior exactly (extra-vars / -var / CLI args).
+- Do not touch `web/public/swagger/api-docs.yml` — only root `api-docs.yml` (matches how the concurrent `text` survey type change was done).
+
+## Background for the implementer (read before Task 1)
+
+Data flow of a survey variable value:
+
+1. Template stores definitions in `db.Template.SurveyVars` (`db/Template.go:103-111`), serialized to the `survey_vars` column as JSON via `SurveyVarsJSON`.
+2. At task start, values entered by the user live in `Task.Environment` (plain vars) and `Task.Secret` (secret-type vars).
+3. `TaskRunner.populateTaskEnvironment` (`services/tasks/TaskRunner.go:395`) merges `Task.Environment` into `Environment.JSON`.
+4. `TaskPool.AddTask` (`services/tasks/TaskPool.go:1035`) builds a `LocalExecutor` with `Template`, `Environment`, and `Secret`.
+5. `LocalExecutor.getEnvironmentExtraVars` (`services/tasks/local_executor.go:144`) merges `Environment.JSON` + `Secret` into one map, which then becomes:
+   - `--extra-vars <json>` for Ansible (`getPlaybookArgs`, line ~488),
+   - `-var name=value` for Terraform/Tofu/Terragrunt (`getTerraformArgs`, line ~320),
+   - `name=value` CLI arguments for shell apps (`getShellArgs`, line ~281).
+6. Process env vars are assembled in `LocalExecutor.Prepare` (line ~732) starting from `getEnvironmentENV()`.
+
+The remote runner receives the full `db.Template` as JSON (`services/runners/types.go:16` — `Template db.Template \`json:"template"\``) and runs the same `LocalExecutor`, so changing `LocalExecutor` covers both execution modes. `SurveyVars` has the json tag `survey_vars`, so it survives the transfer.
+
+---
+
+### Task 1: Backend model — `SurveyVar.Target` field + validation
+
+**Files:**
+- Modify: `db/Template.go` (SurveyVar struct at line ~103, constants near line ~63, `Validate()` at line ~215)
+- Test: `db/Template_test.go` (create if missing; check first — `db/Store_test.go` exists but this test belongs next to `Template.go`)
+
+**Interfaces:**
+- Produces: `db.SurveyVarTarget` type; constants `db.SurveyVarTargetDefault` (`""`), `db.SurveyVarTargetEnv` (`"env"`); field `db.SurveyVar.Target` (`json:"target,omitempty"`). Task 2 consumes `v.Target == db.SurveyVarTargetEnv`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `db/Template_test.go` (same package `db`). If the file does not exist, create it with this content; if it exists, append the test functions:
+
+```go
+package db
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSurveyVarTarget_JSONRoundTrip(t *testing.T) {
+	v := SurveyVar{Name: "MY_VAR", Title: "My Var", Target: SurveyVarTargetEnv}
+
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"target":"env"`)
+
+	// Default target must be omitted for backward compatibility.
+	v.Target = SurveyVarTargetDefault
+	data, err = json.Marshal(v)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "target")
+
+	var parsed SurveyVar
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"X","target":"env"}`), &parsed))
+	assert.Equal(t, SurveyVarTargetEnv, parsed.Target)
+}
+
+func TestTemplateValidate_SurveyVarTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  SurveyVarTarget
+		wantErr bool
+	}{
+		{"default target is valid", SurveyVarTargetDefault, false},
+		{"env target is valid", SurveyVarTargetEnv, false},
+		{"unknown target is rejected", SurveyVarTarget("bogus"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tpl := Template{
+				Name:     "test",
+				Playbook: "playbook.yml",
+				// App left empty ("") so Validate skips the util.Config.Apps whitelist check.
+				SurveyVars: []SurveyVar{{Name: "V", Title: "V", Target: tt.target}},
+			}
+			err := tpl.Validate()
+			if tt.wantErr {
+				assert.ErrorContains(t, err, "invalid survey variable target")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./db/ -run 'TestSurveyVarTarget_JSONRoundTrip|TestTemplateValidate_SurveyVarTarget' -v -count=1`
+Expected: compile error — `undefined: SurveyVarTargetEnv` (and `Target` field missing).
+
+- [ ] **Step 3: Implement the model change**
+
+In `db/Template.go`, after the `SurveyVarType` constants block (line ~70), add:
+
+```go
+type SurveyVarTarget string
+
+const (
+	// SurveyVarTargetDefault passes the variable the app-specific way:
+	// --extra-vars for Ansible, -var for Terraform apps, CLI argument for shell apps.
+	SurveyVarTargetDefault SurveyVarTarget = ""
+	// SurveyVarTargetEnv passes the variable as a process environment variable.
+	SurveyVarTargetEnv SurveyVarTarget = "env"
+)
+```
+
+In the `SurveyVar` struct (line ~103), add the field after `Type`:
+
+```go
+type SurveyVar struct {
+	Name         string               `json:"name" backup:"name"`
+	Title        string               `json:"title" backup:"title"`
+	Required     bool                 `json:"required,omitempty" backup:"required"`
+	Type         SurveyVarType        `json:"type,omitempty" backup:"type"`
+	Target       SurveyVarTarget      `json:"target,omitempty" backup:"target"`
+	Description  string               `json:"description,omitempty" backup:"description"`
+	Values       []SurveyVarEnumValue `json:"values,omitempty" backup:"values"`
+	DefaultValue string               `json:"default_value,omitempty" backup:"default_value"`
+}
+```
+
+In `Template.Validate()` (line ~215), before the final `return nil`, add:
+
+```go
+	for _, v := range tpl.SurveyVars {
+		switch v.Target {
+		case SurveyVarTargetDefault, SurveyVarTargetEnv:
+		default:
+			return &ValidationError{"invalid survey variable target: " + string(v.Target)}
+		}
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./db/ -run 'TestSurveyVarTarget_JSONRoundTrip|TestTemplateValidate_SurveyVarTarget' -v -count=1`
+Expected: PASS (all subtests).
+
+Also run the whole package to catch regressions: `go test ./db/ -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/Template.go db/Template_test.go
+git commit -m "feat(survey): add target field to survey vars (cli vs env)"
+```
+
+---
+
+### Task 2: Executor — deliver env-target vars via process environment
+
+**Files:**
+- Modify: `services/tasks/local_executor.go` (`getEnvironmentExtraVars` at line ~144, `Prepare` at line ~732)
+- Test: `services/tasks/local_executor_test.go` (append)
+
+**Interfaces:**
+- Consumes: `db.SurveyVarTargetEnv`, `db.SurveyVar.Target` from Task 1.
+- Produces: `(t *LocalExecutor) getSurveyEnvVars() (res []string, err error)` — returns `NAME=value` pairs for survey vars with `Target == db.SurveyVarTargetEnv`; `getEnvironmentExtraVars` no longer returns env-target vars.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `services/tasks/local_executor_test.go`:
+
+```go
+// TestGetEnvironmentExtraVars_SkipsEnvTargetVars verifies that survey vars with
+// Target "env" are excluded from the extra-vars map (they must not reach
+// --extra-vars / -var / shell CLI args).
+func TestGetEnvironmentExtraVars_SkipsEnvTargetVars(t *testing.T) {
+	setupExecutorConfig(t)
+
+	exec := &LocalExecutor{
+		Template: db.Template{
+			SurveyVars: []db.SurveyVar{
+				{Name: "ENV_VAR", Target: db.SurveyVarTargetEnv},
+				{Name: "CLI_VAR"},
+			},
+		},
+		Environment: db.Environment{JSON: `{"ENV_VAR":"via-env","CLI_VAR":"via-cli"}`},
+		Secret:      `{"SECRET_ENV_VAR":"s3cr3t"}`,
+	}
+	exec.Template.SurveyVars = append(exec.Template.SurveyVars,
+		db.SurveyVar{Name: "SECRET_ENV_VAR", Type: "secret", Target: db.SurveyVarTargetEnv})
+
+	extraVars, err := exec.getEnvironmentExtraVars("admin", nil)
+	require.NoError(t, err)
+
+	assert.NotContains(t, extraVars, "ENV_VAR")
+	assert.NotContains(t, extraVars, "SECRET_ENV_VAR")
+	assert.Equal(t, "via-cli", extraVars["CLI_VAR"])
+}
+
+// TestGetSurveyEnvVars verifies env-target survey vars are collected as
+// NAME=value pairs from both Environment.JSON and the Secret field, and that
+// CLI-target vars are ignored.
+func TestGetSurveyEnvVars(t *testing.T) {
+	setupExecutorConfig(t)
+
+	exec := &LocalExecutor{
+		Template: db.Template{
+			SurveyVars: []db.SurveyVar{
+				{Name: "ENV_VAR", Target: db.SurveyVarTargetEnv},
+				{Name: "SECRET_ENV_VAR", Type: "secret", Target: db.SurveyVarTargetEnv},
+				{Name: "CLI_VAR"},
+				{Name: "MISSING_VAR", Target: db.SurveyVarTargetEnv}, // no value provided
+			},
+		},
+		Environment: db.Environment{JSON: `{"ENV_VAR":"via-env","CLI_VAR":"via-cli"}`},
+		Secret:      `{"SECRET_ENV_VAR":"s3cr3t"}`,
+	}
+
+	envVars, err := exec.getSurveyEnvVars()
+	require.NoError(t, err)
+
+	assert.Contains(t, envVars, "ENV_VAR=via-env")
+	assert.Contains(t, envVars, "SECRET_ENV_VAR=s3cr3t")
+	assert.Len(t, envVars, 2, "CLI-target and valueless vars must not be included")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./services/tasks/ -run 'TestGetEnvironmentExtraVars_SkipsEnvTargetVars|TestGetSurveyEnvVars' -v -count=1`
+Expected: compile error — `exec.getSurveyEnvVars undefined`.
+
+- [ ] **Step 3: Implement**
+
+In `services/tasks/local_executor.go`:
+
+**(a)** In `getEnvironmentExtraVars` (line ~144), after the `t.Secret` merge block and before the `semaphore_vars` block, add:
+
+```go
+	// Survey vars with the "env" target are delivered as process environment
+	// variables (see getSurveyEnvVars), not as extra vars / CLI args.
+	for _, v := range t.Template.SurveyVars {
+		if v.Target == db.SurveyVarTargetEnv {
+			delete(extraVars, v.Name)
+		}
+	}
+```
+
+**(b)** Add a new method right after `getEnvironmentENV` (line ~216):
+
+```go
+// getSurveyEnvVars returns NAME=value pairs for survey vars with Target "env".
+// Values are read from the merged task environment (Environment.JSON) and the
+// Secret field — the same sources getEnvironmentExtraVars reads, which excludes
+// these vars so each one is delivered exactly once.
+func (t *LocalExecutor) getSurveyEnvVars() (res []string, err error) {
+	vars := make(map[string]any)
+
+	if t.Environment.JSON != "" {
+		if err = json.Unmarshal([]byte(t.Environment.JSON), &vars); err != nil {
+			return
+		}
+	}
+
+	if t.Secret != "" {
+		secretVars := make(map[string]any)
+		if err = json.Unmarshal([]byte(t.Secret), &secretVars); err != nil {
+			return
+		}
+		maps.Copy(vars, secretVars)
+	}
+
+	for _, v := range t.Template.SurveyVars {
+		if v.Target != db.SurveyVarTargetEnv {
+			continue
+		}
+		if val, ok := vars[v.Name]; ok {
+			res = append(res, fmt.Sprintf("%s=%v", v.Name, val))
+		}
+	}
+
+	return
+}
+```
+
+**(c)** In `Prepare` (line ~732), right after the `getEnvironmentENV()` call and its error check, add:
+
+```go
+	surveyEnvVars, err := t.getSurveyEnvVars()
+	if err != nil {
+		return
+	}
+	environmentVariables = append(environmentVariables, surveyEnvVars...)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./services/tasks/ -count=1`
+Expected: PASS (including the pre-existing `TestGetShellArgs_PassesSurveySecretVar` and `TestGetEnvironmentExtraVars_MergesSecret` — default-target behavior is unchanged).
+
+Also build everything: `go build ./...`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/tasks/local_executor.go services/tasks/local_executor_test.go
+git commit -m "feat(survey): pass env-target survey vars via process environment"
+```
+
+---
+
+### Task 3: Frontend — target selector in survey var dialog
+
+**Files:**
+- Modify: `web/src/components/SurveyVars.vue` (dialog form at line ~36, `data()` at line ~235)
+- Modify: `web/src/lang/en.js` (near line ~157, next to `default_value`)
+
+**Interfaces:**
+- Consumes: `target` JSON field from Task 1 (`""` or `"env"`). No other component changes: `TaskForm.vue` / `TaskParamsForm.vue` render inputs by `type` only — target does not affect how the value is entered, only how the backend delivers it.
+
+- [ ] **Step 1: Add the select to the dialog**
+
+In `web/src/components/SurveyVars.vue`, immediately after the existing `type` `v-select` (ends line ~44), add:
+
+```vue
+            <v-select
+              v-model="editedVar.target"
+              :label="$t('survey_var_target')"
+              :items="varTargets"
+              item-value="id"
+              item-text="name"
+              dense
+              outlined
+            ></v-select>
+```
+
+- [ ] **Step 2: Add the items list**
+
+In `data()` (line ~235), after the `varTypes` array, add:
+
+```js
+      varTargets: [
+        {
+          id: '',
+          name: 'CLI argument (extra-vars / -var / argument)',
+        },
+        {
+          id: 'env',
+          name: 'Environment variable',
+        },
+      ],
+```
+
+(Hardcoded English names match the existing `varTypes` convention in this file.)
+
+- [ ] **Step 3: Add the translation key**
+
+In `web/src/lang/en.js`, next to `default_value` (line ~157), add:
+
+```js
+  survey_var_target: 'Pass variable as',
+```
+
+(Other language files fall back to English for missing keys — only `en.js` is required, matching how recent keys were added.)
+
+- [ ] **Step 4: Lint the frontend**
+
+Run: `cd web && npm run lint`
+Expected: no errors (warnings pre-existing at worst).
+
+- [ ] **Step 5: Manual smoke check (optional but cheap)**
+
+Run `cd web && npm run serve`, open a template, add a survey variable, verify the "Pass variable as" select shows both options, save, reopen — the value persists (it round-trips through `survey_vars` JSON).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/components/SurveyVars.vue web/src/lang/en.js
+git commit -m "feat(survey): UI for survey var target selection"
+```
+
+---
+
+### Task 4: API docs
+
+**Files:**
+- Modify: `api-docs.yml` (`TemplateSurveyVar` definition at line ~1043)
+
+- [ ] **Step 1: Add the `target` property**
+
+In `api-docs.yml`, in `TemplateSurveyVar` properties (after `type`, line ~1055), add:
+
+```yaml
+      target:
+        type: string
+        enum: ["", env] # CLI (extra-vars / -var / argument) => "", Environment variable => "env"
+        example: env
+```
+
+- [ ] **Step 2: Validate the YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('api-docs.yml'))" && echo OK`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add api-docs.yml
+git commit -m "docs(api): survey var target field"
+```
+
+---
+
+## Design decisions (recorded for reviewers)
+
+1. **Field name `target`, values `""` / `"env"`** — mirrors the existing `EnvironmentSecretType` precedent (`db/Environment.go`: `"var"` / `"env"`). Empty default means zero migration and unchanged behavior for every existing template.
+2. **Env var name is the survey var name verbatim.** No auto-prefixing (`TF_VAR_`, etc.) — Terraform users name the variable `TF_VAR_foo` themselves. Keeps behavior app-agnostic and predictable.
+3. **Single implementation point in `LocalExecutor`** covers server-local execution and remote runners (runner deserializes the full `db.Template` including `survey_vars`).
+4. **Secret survey vars respect `target` too**: an env-target secret goes to the process environment instead of CLI/extra-vars (arguably the main use case — env vars don't appear in process listings, unlike CLI args).
+5. **Not done (YAGNI):** per-app target overrides, name prefix option, validation that env-target var names are valid shell identifiers, translations beyond `en.js`.
+
+## Out of scope / do not touch
+
+- The uncommitted `text` survey var type work (`db/Template.go`, `SurveyVars.vue`, `TaskForm.vue`, `TaskParamsForm.vue`, `api-docs.yml`) is a separate in-flight change on this branch. This plan's edits are adjacent but independent; do not revert or absorb them.
+- `web/public/swagger/api-docs.yml` — not updated by hand in recent survey changes.
+- Schedules (`TaskParamsForm.vue`) — no change needed; target does not affect value entry.

--- a/api-docs.yml
+++ b/api-docs.yml
@@ -1053,6 +1053,10 @@ definitions:
         type: string
         enum: ["", int, enum, secret, text] # String => "", Integer => "int", Text (multiline) => "text"
         example: int
+      target:
+        type: string
+        enum: ["", env] # CLI (extra-vars / -var / argument) => "", Environment variable => "env"
+        example: env
       required:
         type: boolean
       values:

--- a/db/Template.go
+++ b/db/Template.go
@@ -69,6 +69,16 @@ const (
 	SurveyVarText TemplateType = "text"
 )
 
+type SurveyVarTarget string
+
+const (
+	// SurveyVarTargetDefault passes the variable the app-specific way:
+	// --extra-vars for Ansible, -var for Terraform apps, CLI argument for shell apps.
+	SurveyVarTargetDefault SurveyVarTarget = ""
+	// SurveyVarTargetEnv passes the variable as a process environment variable.
+	SurveyVarTargetEnv SurveyVarTarget = "env"
+)
+
 type AnsibleTemplateParams struct {
 	AllowDebug             bool     `json:"allow_debug"`
 	AllowOverrideInventory bool     `json:"allow_override_inventory"`
@@ -105,6 +115,7 @@ type SurveyVar struct {
 	Title        string               `json:"title" backup:"title"`
 	Required     bool                 `json:"required,omitempty" backup:"required"`
 	Type         SurveyVarType        `json:"type,omitempty" backup:"type"`
+	Target       SurveyVarTarget      `json:"target,omitempty" backup:"target"`
 	Description  string               `json:"description,omitempty" backup:"description"`
 	Values       []SurveyVarEnumValue `json:"values,omitempty" backup:"values"`
 	DefaultValue string               `json:"default_value,omitempty" backup:"default_value"`
@@ -260,6 +271,14 @@ func (tpl *Template) Validate() error {
 
 	if err := tpl.JWTParams.Validate(); err != nil {
 		return err
+	}
+
+	for _, v := range tpl.SurveyVars {
+		switch v.Target {
+		case SurveyVarTargetDefault, SurveyVarTargetEnv:
+		default:
+			return &ValidationError{"invalid survey variable target: " + string(v.Target)}
+		}
 	}
 
 	return nil

--- a/db/Template_test.go
+++ b/db/Template_test.go
@@ -1,0 +1,55 @@
+package db
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSurveyVarTarget_JSONRoundTrip(t *testing.T) {
+	v := SurveyVar{Name: "MY_VAR", Title: "My Var", Target: SurveyVarTargetEnv}
+
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"target":"env"`)
+
+	// Default target must be omitted for backward compatibility.
+	v.Target = SurveyVarTargetDefault
+	data, err = json.Marshal(v)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "target")
+
+	var parsed SurveyVar
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"X","target":"env"}`), &parsed))
+	assert.Equal(t, SurveyVarTargetEnv, parsed.Target)
+}
+
+func TestTemplateValidate_SurveyVarTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  SurveyVarTarget
+		wantErr bool
+	}{
+		{"default target is valid", SurveyVarTargetDefault, false},
+		{"env target is valid", SurveyVarTargetEnv, false},
+		{"unknown target is rejected", SurveyVarTarget("bogus"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tpl := Template{
+				Name:     "test",
+				Playbook: "playbook.yml",
+				// App left empty ("") so Validate skips the util.Config.Apps whitelist check.
+				SurveyVars: []SurveyVar{{Name: "V", Title: "V", Target: tt.target}},
+			}
+			err := tpl.Validate()
+			if tt.wantErr {
+				assert.ErrorContains(t, err, "invalid survey variable target")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/services/tasks/local_executor.go
+++ b/services/tasks/local_executor.go
@@ -164,6 +164,14 @@ func (t *LocalExecutor) getEnvironmentExtraVars(username string, incomingVersion
 		maps.Copy(extraVars, extraSecretVars)
 	}
 
+	// Survey vars with the "env" target are delivered as process environment
+	// variables (see getSurveyEnvVars), not as extra vars / CLI args.
+	for _, v := range t.Template.SurveyVars {
+		if v.Target == db.SurveyVarTargetEnv {
+			delete(extraVars, v.Name)
+		}
+	}
+
 	vars := make(map[string]any)
 	vars["task_details"] = t.getTaskDetails(username, incomingVersion)
 	extraVars["semaphore_vars"] = vars
@@ -210,6 +218,39 @@ func (t *LocalExecutor) getEnvironmentENV() (res []string, err error) {
 
 	if t.JWT != "" {
 		res = append(res, fmt.Sprintf("SEMAPHORE_JWT=%s", t.JWT))
+	}
+
+	return
+}
+
+// getSurveyEnvVars returns NAME=value pairs for survey vars with Target "env".
+// Values are read from the merged task environment (Environment.JSON) and the
+// Secret field — the same sources getEnvironmentExtraVars reads, which excludes
+// these vars so each one is delivered exactly once.
+func (t *LocalExecutor) getSurveyEnvVars() (res []string, err error) {
+	vars := make(map[string]any)
+
+	if t.Environment.JSON != "" {
+		if err = json.Unmarshal([]byte(t.Environment.JSON), &vars); err != nil {
+			return
+		}
+	}
+
+	if t.Secret != "" {
+		secretVars := make(map[string]any)
+		if err = json.Unmarshal([]byte(t.Secret), &secretVars); err != nil {
+			return
+		}
+		maps.Copy(vars, secretVars)
+	}
+
+	for _, v := range t.Template.SurveyVars {
+		if v.Target != db.SurveyVarTargetEnv {
+			continue
+		}
+		if val, ok := vars[v.Name]; ok {
+			res = append(res, fmt.Sprintf("%s=%v", v.Name, val))
+		}
 	}
 
 	return
@@ -733,6 +774,12 @@ func (t *LocalExecutor) Prepare(username string, incomingVersion *string, alias 
 	if err != nil {
 		return
 	}
+
+	surveyEnvVars, err := t.getSurveyEnvVars()
+	if err != nil {
+		return
+	}
+	environmentVariables = append(environmentVariables, surveyEnvVars...)
 
 	tplParams, err := t.getTemplateParams()
 	if err != nil {

--- a/services/tasks/local_executor_test.go
+++ b/services/tasks/local_executor_test.go
@@ -58,3 +58,57 @@ func TestGetEnvironmentExtraVars_MergesSecret(t *testing.T) {
 	assert.Equal(t, "hello", extraVars["PLAIN_VAR"])
 	assert.Equal(t, "s3cr3t", extraVars["MY_VAR"])
 }
+
+// TestGetEnvironmentExtraVars_SkipsEnvTargetVars verifies that survey vars with
+// Target "env" are excluded from the extra-vars map (they must not reach
+// --extra-vars / -var / shell CLI args).
+func TestGetEnvironmentExtraVars_SkipsEnvTargetVars(t *testing.T) {
+	setupExecutorConfig(t)
+
+	exec := &LocalExecutor{
+		Template: db.Template{
+			SurveyVars: []db.SurveyVar{
+				{Name: "ENV_VAR", Target: db.SurveyVarTargetEnv},
+				{Name: "CLI_VAR"},
+			},
+		},
+		Environment: db.Environment{JSON: `{"ENV_VAR":"via-env","CLI_VAR":"via-cli"}`},
+		Secret:      `{"SECRET_ENV_VAR":"s3cr3t"}`,
+	}
+	exec.Template.SurveyVars = append(exec.Template.SurveyVars,
+		db.SurveyVar{Name: "SECRET_ENV_VAR", Type: "secret", Target: db.SurveyVarTargetEnv})
+
+	extraVars, err := exec.getEnvironmentExtraVars("admin", nil)
+	require.NoError(t, err)
+
+	assert.NotContains(t, extraVars, "ENV_VAR")
+	assert.NotContains(t, extraVars, "SECRET_ENV_VAR")
+	assert.Equal(t, "via-cli", extraVars["CLI_VAR"])
+}
+
+// TestGetSurveyEnvVars verifies env-target survey vars are collected as
+// NAME=value pairs from both Environment.JSON and the Secret field, and that
+// CLI-target vars are ignored.
+func TestGetSurveyEnvVars(t *testing.T) {
+	setupExecutorConfig(t)
+
+	exec := &LocalExecutor{
+		Template: db.Template{
+			SurveyVars: []db.SurveyVar{
+				{Name: "ENV_VAR", Target: db.SurveyVarTargetEnv},
+				{Name: "SECRET_ENV_VAR", Type: "secret", Target: db.SurveyVarTargetEnv},
+				{Name: "CLI_VAR"},
+				{Name: "MISSING_VAR", Target: db.SurveyVarTargetEnv}, // no value provided
+			},
+		},
+		Environment: db.Environment{JSON: `{"ENV_VAR":"via-env","CLI_VAR":"via-cli"}`},
+		Secret:      `{"SECRET_ENV_VAR":"s3cr3t"}`,
+	}
+
+	envVars, err := exec.getSurveyEnvVars()
+	require.NoError(t, err)
+
+	assert.Contains(t, envVars, "ENV_VAR=via-env")
+	assert.Contains(t, envVars, "SECRET_ENV_VAR=s3cr3t")
+	assert.Len(t, envVars, 2, "CLI-target and valueless vars must not be included")
+}

--- a/web/src/assets/scss/components.scss
+++ b/web/src/assets/scss/components.scss
@@ -50,3 +50,24 @@
     display: none;
   }
 }
+
+.InputWithAppendedButton {
+  .v-input__append-outer {
+    margin: 0 !important;
+    .v-btn {
+      max-width: 40px;
+      min-width: 40px;
+      height: 40px;
+      padding-left: 0;
+      padding-right: 0;
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+      border: 1px solid rgba(133, 133, 133, 0.4);
+      border-left: 0;
+    }
+  }
+  fieldset {
+    border-top-right-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+  }
+}

--- a/web/src/components/IntegrationForm.vue
+++ b/web/src/components/IntegrationForm.vue
@@ -1,21 +1,11 @@
 <template>
-  <v-form
-    ref="form"
-    lazy-validation
-    v-model="formValid"
-    v-if="isLoaded"
-  >
-    <v-alert
-      :value="formError"
-      color="error"
-      class="pb-2"
-    >{{ formError }}
-    </v-alert>
+  <v-form ref="form" lazy-validation v-model="formValid" v-if="isLoaded">
+    <v-alert :value="formError" color="error" class="pb-2">{{ formError }} </v-alert>
 
     <v-text-field
       v-model="item.name"
       label="Name"
-      :rules="[v => !!v || 'Name is required']"
+      :rules="[(v) => !!v || 'Name is required']"
       required
       :disabled="formSaving"
       outlined
@@ -36,27 +26,27 @@
 
     <v-card
       v-if="item.template_id"
-      style="background: rgba(133, 133, 133, 0.06)"
+      style="background: var(--highlighted-card-bg-color)"
       class="mb-6 pt-3"
     >
-
-      <div style="
-        position: absolute;
-        background: var(--highlighted-card-bg-color);
-        width: 28px;
-        height: 28px;
-        transform: rotate(45deg);
-        left: calc(50% - 14px);
-        top: -14px;
-        border-radius: 0;
-      "></div>
+      <div
+        style="
+          position: absolute;
+          background: var(--highlighted-card-bg-color);
+          width: 28px;
+          height: 28px;
+          transform: rotate(45deg);
+          left: calc(50% - 14px);
+          top: -14px;
+          border-radius: 0;
+        "
+      ></div>
 
       <v-card-text>
         <TaskParamsForm
-          :template="templates.find(t => t.id === item.template_id)"
+          :template="templates.find((t) => t.id === item.template_id)"
           v-model="item.task_params"
         />
-
       </v-card-text>
     </v-card>
 
@@ -92,7 +82,6 @@
       outlined
       dense
     ></v-select>
-
   </v-form>
 </template>
 <script>
@@ -106,34 +95,43 @@ export default {
   data() {
     return {
       templates: [],
-      authMethods: [{
-        id: '',
-        title: 'None',
-      }, {
-        id: 'github',
-        title: 'GitHub Webhooks',
-      }, {
-        id: 'bitbucket',
-        title: 'Bitbucket Webhooks',
-      }, {
-        id: 'token',
-        title: 'Token',
-      }, {
-        id: 'hmac',
-        title: 'HMAC',
-      }, {
-        id: 'basic',
-        title: 'BasicAuth',
-      }],
+      authMethods: [
+        {
+          id: '',
+          title: 'None',
+        },
+        {
+          id: 'github',
+          title: 'GitHub Webhooks',
+        },
+        {
+          id: 'bitbucket',
+          title: 'Bitbucket Webhooks',
+        },
+        {
+          id: 'token',
+          title: 'Token',
+        },
+        {
+          id: 'hmac',
+          title: 'HMAC',
+        },
+        {
+          id: 'basic',
+          title: 'BasicAuth',
+        },
+      ],
       keys: null,
     };
   },
   async created() {
-    this.templates = (await axios({
-      templates: 'get',
-      url: `/api/project/${this.projectId}/templates`,
-      responseType: 'json',
-    })).data;
+    this.templates = (
+      await axios({
+        templates: 'get',
+        url: `/api/project/${this.projectId}/templates`,
+        responseType: 'json',
+      })
+    ).data;
   },
 
   computed: {
@@ -154,7 +152,6 @@ export default {
   },
 
   methods: {
-
     getNewItem() {
       return {
         template_id: null,
@@ -170,17 +167,18 @@ export default {
     },
 
     async afterLoadData() {
-      this.keys = (await axios({
-        method: 'get',
-        url: `/api/project/${this.projectId}/keys`,
-        responseType: 'json',
-      })).data;
+      this.keys = (
+        await axios({
+          method: 'get',
+          url: `/api/project/${this.projectId}/keys`,
+          responseType: 'json',
+        })
+      ).data;
 
       if (this.item.task_params == null) {
         this.item.task_params = {};
       }
     },
-
   },
 };
 </script>

--- a/web/src/components/ProjectMixin.js
+++ b/web/src/components/ProjectMixin.js
@@ -7,12 +7,13 @@ export default {
   },
 
   methods: {
-    async loadEndpoint(endpoint) {
+    async loadEndpoint(endpoint, opts) {
       return (
         await axios({
           method: 'get',
           url: endpoint,
           responseType: 'json',
+          ...opts,
         })
       ).data;
     },
@@ -21,8 +22,8 @@ export default {
       EventBus.$emit('i-subscription', { feature });
     },
 
-    async loadProjectEndpoint(endpoint) {
-      return this.loadEndpoint(`/api/project/${this.projectId}${endpoint}`);
+    async loadProjectEndpoint(endpoint, opts) {
+      return this.loadEndpoint(`/api/project/${this.projectId}${endpoint}`, opts);
     },
 
     async loadProjectResources(name) {

--- a/web/src/components/SurveyVars.vue
+++ b/web/src/components/SurveyVars.vue
@@ -43,6 +43,16 @@
               outlined
             ></v-select>
 
+            <v-select
+              v-model="editedVar.target"
+              :label="$t('survey_var_target')"
+              :items="varTargets"
+              item-value="id"
+              item-text="name"
+              dense
+              outlined
+            ></v-select>
+
             <v-card
               v-if="editedVar.type === 'enum'"
               style="background: var(--highlighted-card-bg-color);"
@@ -259,6 +269,16 @@ export default {
         {
           id: 'text',
           name: 'Text',
+        },
+      ],
+      varTargets: [
+        {
+          id: '',
+          name: 'CLI argument (extra-vars / -var / argument)',
+        },
+        {
+          id: 'env',
+          name: 'Environment variable',
         },
       ],
       formError: null,

--- a/web/src/components/SurveyVars.vue
+++ b/web/src/components/SurveyVars.vue
@@ -33,41 +33,48 @@
               outlined
             />
 
-            <v-select
-              v-model="editedVar.type"
-              :label="$t('type')"
-              :items="varTypes"
-              item-value="id"
-              item-text="name"
-              dense
-              outlined
-            ></v-select>
-
-            <v-select
-              v-model="editedVar.target"
-              :label="$t('survey_var_target')"
-              :items="varTargets"
-              item-value="id"
-              item-text="name"
-              dense
-              outlined
-            ></v-select>
+            <v-row>
+              <v-col cols="5">
+                <v-select
+                  v-model="editedVar.type"
+                  :label="$t('type')"
+                  :items="varTypes"
+                  item-value="id"
+                  item-text="name"
+                  dense
+                  outlined
+                ></v-select>
+              </v-col>
+              <v-col cols="7">
+                <v-select
+                  v-model="editedVar.target"
+                  :label="$t('survey_var_target')"
+                  :items="varTargets"
+                  item-value="id"
+                  item-text="name"
+                  dense
+                  outlined
+                ></v-select>
+              </v-col>
+            </v-row>
 
             <v-card
               v-if="editedVar.type === 'enum'"
-              style="background: var(--highlighted-card-bg-color);"
+              style="background: var(--highlighted-card-bg-color)"
               class="mb-4 pt-3"
             >
-              <div style="
-                position: absolute;
-                background: var(--highlighted-card-bg-color);
-                width: 28px;
-                height: 28px;
-                transform: rotate(45deg);
-                left: calc(50% - 14px);
-                top: -14px;
-                border-radius: 0;
-              "></div>
+              <div
+                style="
+                  position: absolute;
+                  background: var(--highlighted-card-bg-color);
+                  width: 28px;
+                  height: 28px;
+                  transform: rotate(45deg);
+                  left: 60px;
+                  top: -14px;
+                  border-radius: 0;
+                "
+              ></div>
 
               <v-card-text class="pt-2">
                 <v-data-table
@@ -274,7 +281,7 @@ export default {
       varTargets: [
         {
           id: '',
-          name: 'CLI argument (extra-vars / -var / argument)',
+          name: 'Extra variable',
         },
         {
           id: 'env',
@@ -301,6 +308,10 @@ export default {
 
     editVar(index) {
       this.editedVar = index != null ? { ...this.modifiedVars[index] } : {};
+
+      if (!this.editedVar.target) {
+        this.editedVar.target = '';
+      }
 
       this.editedValues = [];
       this.editedValues.push(...(this.editedVar.values || []));

--- a/web/src/components/SurveyVars.vue
+++ b/web/src/components/SurveyVars.vue
@@ -161,7 +161,7 @@
             />
           </v-form>
         </v-card-text>
-        <v-card-actions class="pt-0">
+        <v-card-actions class="py-0">
           <v-checkbox
             :label="$t('required')"
             v-model="editedVar.required"

--- a/web/src/components/TemplateForm.vue
+++ b/web/src/components/TemplateForm.vue
@@ -45,7 +45,7 @@
             <a
               href="https://docs.semaphoreui.com/user-guide/task-templates#build"
               target="_blank"
-              >{{ $t('taskTemplateReference') }}</a
+            >{{ $t('taskTemplateReference') }}</a
             >.
           </p>
         </div>
@@ -58,7 +58,7 @@
             <a
               href="https://docs.semaphoreui.com/user-guide/task-templates#build"
               target="_blank"
-              >{{ $t('taskTemplateReference2') }}</a
+            >{{ $t('taskTemplateReference2') }}</a
             >.
           </p>
         </div>
@@ -69,14 +69,14 @@
             <a
               href="https://pkg.go.dev/github.com/robfig/cron/v3#hdr-CRON_Expression_Format"
               target="_blank"
-              >{{ $t('cronExpressionFormatReference') }}</a
+            >{{ $t('cronExpressionFormatReference') }}</a
             >.
           </p>
         </div>
       </v-alert>
     </v-dialog>
 
-    <v-alert :value="formError" color="error">{{ formError }} </v-alert>
+    <v-alert :value="formError" color="error">{{ formError }}</v-alert>
 
     <v-row class="mb-0">
       <v-col>
@@ -140,9 +140,81 @@
           :disabled="formSaving"
         ></v-text-field>
 
+        <div style="position: relative">
+          <v-autocomplete
+            v-model="item.repository_id"
+            :label="fieldLabel('repository') + ' *'"
+            :items="repositories"
+            item-value="id"
+            item-text="name"
+            :rules="isFieldRequired('repository') ? [(v) => !!v || $t('repository_required')] : []"
+            outlined
+            dense
+            :required="isFieldRequired('repository')"
+            :disabled="formSaving"
+            v-if="needField('repository')"
+          >
+          </v-autocomplete>
+          <v-chip
+            v-if="gitBranch"
+            small
+            label
+            style="position: absolute; right: 45px; top: 8px"
+            @click="setBranch = !setBranch"
+          >
+            {{ gitBranch }}
+          </v-chip>
+        </div>
+
+        <v-card
+          v-if="setBranch"
+          style="background: var(--highlighted-card-bg-color)"
+          class="mb-6 pt-3"
+        >
+          <div
+            style="
+              position: absolute;
+              background: var(--highlighted-card-bg-color);
+              width: 28px;
+              height: 28px;
+              transform: rotate(45deg);
+              right: 55px;
+              top: -14px;
+              border-radius: 0;
+            "
+          ></div>
+
+          <v-card-text class="pb-0">
+            <div v-if="branches != null">
+              <v-autocomplete
+                clearable
+                :items="branches"
+                v-model="item.git_branch"
+                :label="fieldLabel('branch')"
+                outlined
+                dense
+                :disabled="formSaving"
+                :placeholder="$t('branch')"
+              ></v-autocomplete>
+            </div>
+            <div v-else>
+              <v-text-field
+                clearable
+                v-model="item.git_branch"
+                :label="fieldLabel('branch')"
+                outlined
+                dense
+                :disabled="formSaving"
+                :placeholder="$t('branch')"
+              ></v-text-field>
+            </div>
+          </v-card-text>
+        </v-card>
+
         <div v-if="needField('playbook')">
           <div v-if="playbooks != null">
             <v-autocomplete
+              class="InputWithAppendedButton"
               v-model="item.playbook"
               :items="playbooks"
               :label="fieldLabel('playbook')"
@@ -155,10 +227,21 @@
               :required="isFieldRequired('playbook')"
               :disabled="formSaving"
               :placeholder="$t('exampleSiteyml')"
-            ></v-autocomplete>
+              :loading="playbooksLoading"
+            >
+              <template v-slot:append-outer>
+                <v-btn
+                  depressed
+                  @click="playbooksLoading ? cancelPlaybookLoading() : loadPlaybooks()"
+                >
+                  <v-icon>{{ playbooksLoading ? 'mdi-close' : 'mdi-refresh' }}</v-icon>
+                </v-btn>
+              </template>
+            </v-autocomplete>
           </div>
           <div v-else>
             <v-text-field
+              class="InputWithAppendedButton"
               v-model="item.playbook"
               :label="fieldLabel('playbook')"
               :rules="
@@ -169,7 +252,17 @@
               :required="isFieldRequired('playbook')"
               :disabled="formSaving"
               :placeholder="$t('exampleSiteyml')"
-            ></v-text-field>
+              :loading="playbooksLoading"
+            >
+              <template v-slot:append-outer>
+                <v-btn
+                  depressed
+                  @click="playbooksLoading ? cancelPlaybookLoading() : loadPlaybooks()"
+                >
+                  <v-icon>{{ playbooksLoading ? 'mdi-close' : 'mdi-refresh' }}</v-icon>
+                </v-btn>
+              </template>
+            </v-text-field>
           </div>
         </div>
 
@@ -185,51 +278,6 @@
           :disabled="formSaving"
           v-if="needField('inventory')"
         ></v-autocomplete>
-
-        <v-autocomplete
-          v-model="item.repository_id"
-          :label="fieldLabel('repository') + ' *'"
-          :items="repositories"
-          item-value="id"
-          item-text="name"
-          :rules="isFieldRequired('repository') ? [(v) => !!v || $t('repository_required')] : []"
-          outlined
-          dense
-          hide-details
-          :required="isFieldRequired('repository')"
-          :disabled="formSaving"
-          v-if="needField('repository')"
-        ></v-autocomplete>
-
-        <div class="mb-3 text-right">
-          <a v-if="!item.git_branch && !setBranch" @click="setBranch = true">Set branch</a>
-        </div>
-
-        <div v-if="item.git_branch || setBranch">
-          <div v-if="branches != null">
-            <v-autocomplete
-              clearable
-              :items="branches"
-              v-model="item.git_branch"
-              :label="fieldLabel('branch')"
-              outlined
-              dense
-              :disabled="formSaving"
-              :placeholder="$t('branch')"
-            ></v-autocomplete>
-          </div>
-          <div v-else>
-            <v-text-field
-              clearable
-              v-model="item.git_branch"
-              :label="fieldLabel('branch')"
-              outlined
-              dense
-              :disabled="formSaving"
-              :placeholder="$t('branch')"
-            ></v-text-field>
-          </div>
-        </div>
 
         <v-autocomplete
           v-model="item.environment_ids"
@@ -248,7 +296,6 @@
           deletable-chips
           outlined
           small-chips
-          class="mb-3"
           :required="isFieldRequired('environment')"
           :disabled="formSaving"
           v-if="needField('environment')"
@@ -292,7 +339,6 @@
           <v-checkbox class="mt-0" v-model="item.allow_parallel_tasks">
             <template v-slot:label>
               {{ $t('allow_parallel_tasks') }}
-              <v-chip class="ml-2" small color="error">New</v-chip>
             </template>
           </v-checkbox>
 
@@ -410,7 +456,7 @@
       <v-col v-if="needAppBlock">
         <div class="mb-3">
           <h2 class="mb-4">
-            {{ $t('template_app_options', {app: getAppTitle(app, true)}) }}
+            {{ $t('template_app_options', { app: getAppTitle(app, true) }) }}
           </h2>
 
           <ArgsPicker
@@ -483,7 +529,7 @@
         </div>
 
         <h2 class="mb-4">
-          {{ $t('template_app_prompts', {app: getAppTitle(app, true)}) }}
+          {{ $t('template_app_prompts', { app: getAppTitle(app, true) }) }}
         </h2>
         <div class="d-flex" style="column-gap: 20px; flex-wrap: wrap">
           <v-checkbox
@@ -631,22 +677,25 @@ export default {
       runnerTags: null,
       branches: null,
       playbooks: null,
+      playbooksLoading: false,
+      playbooksAbort: null,
       setBranch: false,
     };
   },
 
   watch: {
-    gitBranch() {
-      this.setBranch = false;
-      this.playbooks = null;
-      this.loadPlaybooks();
+    gitBranchOfTemplate() {
+      if (this.playbooks != null) {
+        this.playbooks = null;
+        this.loadPlaybooks();
+      }
     },
 
     async repositoryId() {
       this.branches = null;
       this.playbooks = null;
 
-      await Promise.all([this.loadBranches(), this.loadPlaybooks()]);
+      await Promise.all([this.loadBranches()]);
     },
 
     needReset(val) {
@@ -668,7 +717,7 @@ export default {
   },
 
   async created() {
-    await Promise.all([this.loadBranches(), this.loadPlaybooks()]);
+    await Promise.all([this.loadBranches()]);
   },
 
   computed: {
@@ -693,8 +742,19 @@ export default {
       return this.item?.repository_id;
     },
 
-    gitBranch() {
+    gitBranchOfTemplate() {
       return this.item?.git_branch;
+    },
+
+    gitBranch() {
+      let ret = this.item?.git_branch;
+      if (!ret) {
+        const repo = this.repositories.find((x) => x.id === this.repositoryId);
+        if (repo) {
+          ret = repo.git_branch;
+        }
+      }
+      return ret;
     },
 
     allow_override_inventory: {
@@ -778,9 +838,18 @@ export default {
       }
 
       try {
-        this.branches = await this.loadProjectEndpoint(`/repositories/${this.repositoryId}/branches`);
+        this.branches = await this.loadProjectEndpoint(
+          `/repositories/${this.repositoryId}/branches`,
+        );
       } catch (e) {
         this.branches = null;
+      }
+    },
+
+    cancelPlaybookLoading() {
+      if (this.playbooksAbort) {
+        this.playbooksAbort.abort();
+        this.playbooksAbort = null;
       }
     },
 
@@ -790,12 +859,24 @@ export default {
         return;
       }
 
+      this.cancelPlaybookLoading();
+      const ctrl = new AbortController();
+      this.playbooksAbort = ctrl;
+      this.playbooksLoading = true;
+
       try {
         this.playbooks = await this.loadProjectEndpoint(
           `/repositories/${this.repositoryId}/playbooks?branch=${encodeURIComponent(this.item.git_branch || '')}`,
+          { signal: ctrl.signal },
         );
       } catch (e) {
         this.playbooks = null;
+      } finally {
+        // ponytail: guard against a newer request having replaced this one
+        if (this.playbooksAbort === ctrl || this.playbooksAbort == null) {
+          this.playbooksAbort = null;
+          this.playbooksLoading = false;
+        }
       }
     },
 

--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -155,6 +155,7 @@ export default {
   vaultName: 'Vault ID (optional)',
   vaultNameDefault: 'Only one `default` (empty) name may exist',
   default_value: 'Default value',
+  survey_var_target: 'Pass variable as',
   vaultNameUnique: 'Must be unique',
   vaultTypePassword: 'Password',
   vaultTypeScript: 'Client Script',


### PR DESCRIPTION
- **ci: stable pro branch**
- **fix(templates): validate app**
- **feat(survey): enum style**
- **feat(survey_vars): add type text**
- **feat(survey): add target field to survey vars (cli vs env)**
- **feat(survey): pass env-target survey vars via process environment**
- **feat(survey): UI for survey var target selection**
- **docs(api): survey var target field**
- **docs: survey var target plan**
- **fix(survey): default target to CLI in edit dialog**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how task processes receive survey values (execution path) and tightens template app validation; verify create-template still rejects invalid apps if validation is only centralized in Validate.
> 
> **Overview**
> Survey variables gain a **`target`** field (default extra-vars/CLI vs **`env`** as process environment). **`LocalExecutor`** strips env-target names from the extra-vars map and injects them in **`Prepare`** via **`getSurveyEnvVars`**, including secrets when targeted to env.
> 
> Templates also support a **`text`** survey type (multiline defaults in **`SurveyVars.vue`**, **`TaskForm.vue`**, **`TaskParamsForm.vue`**). The survey editor adds a “Pass variable as” control and refreshes the enum editor layout.
> 
> **`Template.Validate`** now rejects template **`app`** values outside **`util.Config.Apps`** (blocks treating arbitrary strings as shell binaries). The post-create app check was removed from **`AddTemplate`** while **`UpdateTemplate`** still validates the app in the handler—create path should be confirmed against store validation.
> 
> PRO builds clone **`semaphorepro-module`** from **`2-19-stable`** instead of **`main`** (workflows and Dockerfiles). Root **`api-docs.yml`** documents **`text`** and **`target`**; an **`AGENTS/plans/2_19/survey-var-target.md`** implementation plan was added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6948fa7b0f3309257652ce69b0b3b4c8076a05a3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-line text survey variables in task forms.
  * Added options to pass survey variables as extra variables or environment variables.
  * Environment-targeted values are now delivered directly to launched tasks.
  * Added validation for supported survey variable targets and configured application names.
* **Documentation**
  * Updated API documentation for text survey variables and delivery targets.
* **Bug Fixes**
  * Prevented environment-targeted survey variables from being passed through duplicate input paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->