### PR TITLE
feat(secret-storage): add CyberArk Conjur as external secret storage provider

### DIFF
--- a/db/SecretStorage.go
+++ b/db/SecretStorage.go
@@ -9,8 +9,9 @@ const (
 	SecretStorageTypeVault   SecretStorageType = "vault"
 	SecretStorageTypeOpenBao SecretStorageType = "openbao"
 	SecretStorageTypeDvls    SecretStorageType = "dvls"
-	SecretStorageTypeAwsSm   SecretStorageType = "aws_sm"
-	SecretStorageTypeAzureKv SecretStorageType = "azure_kv"
+	SecretStorageTypeAwsSm     SecretStorageType = "aws_sm"
+	SecretStorageTypeAzureKv   SecretStorageType = "azure_kv"
+	SecretStorageTypeCyberArk  SecretStorageType = "cyberark"
 )
 
 type SecretStorage struct {

--- a/pro/services/server/access_key_serializer_cyberark.go
+++ b/pro/services/server/access_key_serializer_cyberark.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"github.com/semaphoreui/semaphore/db"
+)
+
+type CyberArkStorageTokenDeserializer interface {
+	DeserializeSecret(key *db.AccessKey) error
+}
+
+type CyberArkAccessKeyDeserializer struct {
+}
+
+func NewCyberArkAccessKeyDeserializer(
+	_ db.AccessKeyManager,
+	_ db.SecretStorageRepository,
+	_ CyberArkStorageTokenDeserializer,
+) *CyberArkAccessKeyDeserializer {
+	return &CyberArkAccessKeyDeserializer{}
+}
+
+func (d *CyberArkAccessKeyDeserializer) DeleteSecret(_ *db.AccessKey) error {
+	return nil
+}
+
+func (d *CyberArkAccessKeyDeserializer) SerializeSecret(_ *db.AccessKey) error {
+	return nil
+}
+
+func (d *CyberArkAccessKeyDeserializer) DeserializeSecret(_ *db.AccessKey) (res string, err error) {
+	return
+}

--- a/services/server/access_key_encryption_svc.go
+++ b/services/server/access_key_encryption_svc.go
@@ -95,6 +95,8 @@ func (s *accessKeyEncryptionServiceImpl) getDeserializer(key *db.AccessKey) (Acc
 		return pro.NewAwsSmAccessKeyDeserializer(s.accessKeyRepo, s.secretStorageRepo, s), storage.ReadOnly, nil
 	case db.SecretStorageTypeAzureKv:
 		return pro.NewAzureKvAccessKeyDeserializer(s.accessKeyRepo, s.secretStorageRepo, s), storage.ReadOnly, nil
+	case db.SecretStorageTypeCyberArk:
+		return pro.NewCyberArkAccessKeyDeserializer(s.accessKeyRepo, s.secretStorageRepo, s), storage.ReadOnly, nil
 	}
 
 	return nil, false, fmt.Errorf("unsupported secret storage type '%s'", storage.Type)

--- a/web/src/components/CyberArkIcon.vue
+++ b/web/src/components/CyberArkIcon.vue
@@ -1,0 +1,28 @@
+<template>
+  <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+    <!-- eslint-disable max-len -->
+    <path
+      d="M16 2L4 7v8.5c0 7.2 5.1 13.9 12 15.5 6.9-1.6 12-8.3 12-15.5V7L16 2z"
+      style="fill: #ff4f00"
+    />
+    <path
+      d="M16 5.5L7 9.2v6.3c0 5.5 3.9 10.6 9 11.8 5.1-1.2 9-6.3 9-11.8V9.2L16 5.5z"
+      style="fill: #fff"
+    />
+    <path
+      d="M16 8.5L10 11.2v4.3c0 3.8 2.7 7.3 6 8.1 3.3-.8 6-4.3 6-8.1v-4.3L16 8.5z"
+      style="fill: #ff4f00"
+    />
+    <path
+      d="M13.5 14.5h5v1.5h-5V14.5z M13.5 17h5v1.5h-5V17z"
+      style="fill: #fff"
+    />
+    <!-- eslint-enable max-len -->
+  </svg>
+</template>
+
+<script>
+export default {
+  name: 'CyberArkIcon',
+};
+</script>

--- a/web/src/components/EnvironmentForm.vue
+++ b/web/src/components/EnvironmentForm.vue
@@ -589,6 +589,8 @@ export default {
           return '$vuetify.icons.dvls';
         case 'azure_kv':
           return '$vuetify.icons.azure_kv';
+        case 'cyberark':
+          return '$vuetify.icons.cyberark';
         default:
           return '';
       }

--- a/web/src/components/SecretStorageForm.vue
+++ b/web/src/components/SecretStorageForm.vue
@@ -312,6 +312,71 @@
       ></v-text-field>
     </div>
 
+    <div v-else-if="item.type === 'cyberark'">
+      <v-text-field
+        v-model="item.params.account"
+        label="Account"
+        hint="Organization account name"
+        :disabled="formSaving"
+        :rules="[(v) => !!v || 'Account is required']"
+        required
+        placeholder="myorg"
+        data-testid="secretStorage-cyberarkAccount"
+        outlined
+        dense
+      ></v-text-field>
+
+      <v-text-field
+        v-model="item.params.login"
+        label="Login"
+        hint="Username for API key authentication"
+        :disabled="formSaving"
+        :rules="[(v) => !!v || 'Login is required']"
+        required
+        data-testid="secretStorage-cyberarkLogin"
+        outlined
+        dense
+      ></v-text-field>
+
+      <div class="d-flex justify-space-between align-center mb-2">
+        <b style="font-size: 13px; margin-left: 5px">API Key</b>
+        <v-btn-toggle v-model="secretStorage" tile group mandatory>
+          <v-btn value="database" small class="ma-0" style="border-radius: 4px">
+            Store in DB
+          </v-btn>
+          <v-btn value="env" small class="ma-0" style="border-radius: 4px"> From ENV </v-btn>
+          <v-btn value="file" small class="ma-0" style="border-radius: 4px"> From File </v-btn>
+        </v-btn-toggle>
+      </div>
+
+      <v-text-field
+        v-if="secretStorage === 'database'"
+        class="TextInput TextInput--no-legend masked-secret-input"
+        v-model="item.secret"
+        label="API Key"
+        :disabled="formSaving"
+        :rules="[(v) => !!v || itemId !== 'new' || 'API Key is required']"
+        required
+        data-testid="secretStorage-cyberarkApiKey"
+        outlined
+        dense
+        append-icon="mdi-lock"
+      ></v-text-field>
+
+      <v-text-field
+        v-else
+        class="TextInput TextInput--no-legend"
+        v-model="item.secret"
+        :label="secretStorage === 'env' ? $t('Env var name') : $t('Path to the file')"
+        :disabled="formSaving"
+        :rules="[(v) => !!v || itemId !== 'new' || $t('envvar_required')]"
+        required
+        data-testid="secretStorage-cyberarkApiKeySource"
+        outlined
+        dense
+      ></v-text-field>
+    </div>
+
     <v-checkbox
       v-model="item.readonly"
       :label="$t('Read only')"

--- a/web/src/plugins/vuetify.js
+++ b/web/src/plugins/vuetify.js
@@ -8,6 +8,7 @@ import OpenBaoIcon from '@/components/OpenBaoIcon.vue';
 import DvlsIcon from '../components/DvlsIcon.vue';
 import AwsSmIcon from '../components/AwsSmIcon.vue';
 import AzureKvIcon from '../components/AzureKvIcon.vue';
+import CyberArkIcon from '../components/CyberArkIcon.vue';
 
 Vue.use(Vuetify);
 
@@ -37,6 +38,9 @@ export default new Vuetify({
       },
       azure_kv: {
         component: AzureKvIcon,
+      },
+      cyberark: {
+        component: CyberArkIcon,
       },
     },
   },

--- a/web/src/views/project/SecretStorages.vue
+++ b/web/src/views/project/SecretStorages.vue
@@ -137,6 +137,20 @@
               <v-list-item-title>Devolutions Server</v-list-item-title>
             </v-list-item>
 
+            <v-list-item
+              link
+              @click="
+                editItem('new');
+                itemType = 'cyberark';
+              "
+              :disabled="!features.secret_storage_management_ex"
+            >
+              <v-list-item-icon>
+                <v-icon>$vuetify.icons.cyberark</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>CyberArk Conjur</v-list-item-title>
+            </v-list-item>
+
             <a
               v-if="features.secret_storage_management && !features.secret_storage_management_ex"
               class="SecretStoragesEnterpriseMenu__overlay"
@@ -333,6 +347,8 @@ export default {
           return '$vuetify.icons.aws_sm';
         case 'azure_kv':
           return '$vuetify.icons.azure_kv';
+        case 'cyberark':
+          return '$vuetify.icons.cyberark';
         default:
           return '';
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds CyberArk Conjur as an Enterprise-tier external secret storage provider for project access keys and environment secrets, addressing PRO-1 for DICK'S Sporting Goods.

## Changes

- **Backend**: Added `SecretStorageTypeCyberArk` (`cyberark`) constant and a Pro module deserializer stub following the same pattern as AWS Secrets Manager, Azure Key Vault, and Devolutions Server
- **Routing**: Wired CyberArk into `AccessKeyEncryptionService.getDeserializer()` so keys stored in CyberArk Conjur are resolved at runtime
- **Frontend**: Added CyberArk Conjur to the Enterprise secret storage menu with configuration fields for:
  - Server URL
  - Account (organization account name)
  - Login (username for API key authentication)
  - API Key (with DB / ENV / file storage options)
- **UI**: Added CyberArk icon and icon mappings in Secret Storages and Environment forms

## Notes

The Pro module deserializer is a stub in this OSS repository; the actual CyberArk Conjur REST API integration (authenticate via `/authn/{account}/login`, retrieve secrets via `/secrets/{account}/variable/{identifier}`) will be implemented in the Enterprise codebase.

CyberArk Conjur is gated behind the `secret_storage_management_ex` Enterprise feature flag, consistent with other Enterprise providers.

## Testing

- `go test ./services/server/... -count=1` — pass
- `go test ./services/project/... -run TestBackup -count=1` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [PRO-1](https://linear.app/semaphoreui/issue/PRO-1/support-cyberarc)

<div><a href="https://cursor.com/agents/bc-e9374140-724b-4190-ad8f-3683623e5789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9374140-724b-4190-ad8f-3683623e5789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

