### PR TITLE
feat(survey_vars): store survey secret to the database as access key

### DIFF
--- a/.claude/skills/semaphore-commit/SKILL.md
+++ b/.claude/skills/semaphore-commit/SKILL.md
@@ -8,7 +8,7 @@ Create well-formatted git commits following conventional commit standards.
 1. Analyze staged changes with `git diff --staged`
 2. Generate a conventional commit message
 3. Create the commit with proper formatting
-4. Do not add "Co-Authored-By: Claude ... <noreply@anthropic.com> to the foolter"
+4. Do not add "Co-Authored-By: Claude ... <noreply@anthropic.com> to the footer"
 
 ## Commit Format
 ```

--- a/.claude/skills/semaphore-commit/SKILL.md
+++ b/.claude/skills/semaphore-commit/SKILL.md
@@ -8,6 +8,7 @@ Create well-formatted git commits following conventional commit standards.
 1. Analyze staged changes with `git diff --staged`
 2. Generate a conventional commit message
 3. Create the commit with proper formatting
+4. Do not add "Co-Authored-By: Claude ... <noreply@anthropic.com> to the foolter"
 
 ## Commit Format
 ```

--- a/AGENTS/plans/2_20/survey-secrets-remote-runners.md
+++ b/AGENTS/plans/2_20/survey-secrets-remote-runners.md
@@ -1,0 +1,240 @@
+# Plan — Survey Secret Variables Lost on Remote Runners (HA-safe fix)
+
+- **Branch:** `develop`
+- **Status:** implemented (rev. 2 — task-bound access keys; the `task.secret`
+  column and Redis approaches were rejected). TTL decided: derived from
+  `MaxTaskDurationSec` (+1h queue allowance; 24h when unlimited). Note: the
+  pro_impl docker/k8s providers still need the `Secret: task.Secret` wiring
+  (separate PR).
+
+## 1. Problem
+
+Survey variables of type `secret` work when a task is executed by the server
+itself, but arrive **empty** on remote runners.
+
+Additionally (same root cause), the secret survives only in the memory of the
+node that accepted the task: it does not survive a server restart while the
+task is queued, and in HA mode no other node can ever dispatch the task with
+its secrets.
+
+## 2. Root Cause
+
+Survey secrets travel in `db.Task.Secret` (`db:"-" json:"secret,omitempty"`,
+`db/Task.go:52`) — never persisted and blanked before serialization:
+
+```go
+// services/tasks/TaskPool.go:971 (AddTask)
+extraSecretVars := taskObj.Secret
+taskObj.Secret = "{}"
+```
+
+- **Local branch** (`TaskPool.go:1048`): `extraSecretVars` is threaded into
+  `LocalExecutor{Secret: extraSecretVars}` → works, but only in the accepting
+  node's memory.
+- **Remote branch** (`TaskPool.go:1036`): `RemoteJob{Task: taskRunner.Task}` —
+  the secret is already `"{}"` and `extraSecretVars` is dropped. The runner
+  poll payload (`api/runners/runners.go:121`, `JobData{Task: tsk.Task}`) ships
+  `"secret": "{}"`.
+- **Second gap, runner side**: even if `Task.Secret` arrived, the runner never
+  uses it — `LocalExecutorProvider.NewExecutor`
+  (`services/tasks/local_executor_provider.go:37`) does not populate
+  `LocalExecutor.Secret`, and `mergeExtraVars` reads only that field
+  (`local_executor.go:159`), not `t.Task.Secret`.
+
+## 3. Design
+
+Industry consensus (research above; AWX is the closest analog): per-run
+secrets are persisted **encrypted at rest in the shared DB** with a key held
+in config identically on every node, decrypted on read by whichever node
+serves the worker request, hidden from user-facing surfaces.
+
+**Chosen approach: store survey secrets as a task-bound `access_key` row** —
+the table that already holds every other secret, already encrypted with the
+shared keyring (`util.Config.EncryptAccessSecret`, key-id envelope, rotation
+support) and already covered by the vault/rekey tooling.
+
+Principles:
+
+1. The secret is stored in `access_key` like any other secret (keyring
+   encryption via the existing `SerializeSecret` path).
+2. The key is **bound to the task** (new `task_id` column) and carries a new
+   owner value, so it is **invisible in the project secrets list** (the list
+   endpoint filters `owner=''` — `db/sql/access_key.go:28-29`,
+   `api/projects/keys.go:69` — non-empty owners are excluded automatically,
+   same as `environment`/`variable`/`vault` owners today).
+3. New **`expire_at`** column limits the secret's lifetime.
+4. **Expired secrets cannot be used**: enforced centrally at deserialization.
+
+Rejected alternatives: extra column on `task` (rejected by maintainer);
+encrypted values in Redis (area `AREA@d489ed1d499f99bd81a192`: acceptable only
+with hardening, but Redis can silently lose the value and joins the dispatch
+critical path).
+
+## 4. Implementation
+
+### 4.1 DB migration — `db/sql/migrations/v2.20.1.sql`
+
+```sql
+alter table `access_key` add `task_id` int null references task(`id`) on delete cascade;
+alter table `access_key` add `expire_at` datetime null;
+create index `access_key__task_id` on `access_key`(`task_id`);
+```
+
+Register `{Version: "2.20.1"}` in `db/Migration.go` (after `2.20.0`, line 134).
+
+`on delete cascade` ties the secret's lifetime to the task row: task retention
+cleanup (`MaxTasksPerTemplate`) deletes the key automatically.
+
+### 4.2 Model (`db/AccessKey.go`)
+
+```go
+const AccessKeyTaskSecret AccessKeyOwner = "task"
+
+// on AccessKey:
+TaskID   *int       `db:"task_id" json:"-" backup:"-"`
+ExpireAt *time.Time `db:"expire_at" json:"-" backup:"-"`
+```
+
+- Add both columns to `CreateAccessKey` inserts (`db/sql/access_key.go`).
+- `GetAccessKeys`: add `case db.AccessKeyTaskSecret` filtering by
+  `pe.task_id` (mirror of the `environment_id` cases).
+- New store method `GetTaskAccessKey(projectID, taskID int) (AccessKey, error)`
+  (lookup by `owner='task' and task_id=?`).
+- New store method `DeleteTaskAccessKeys(projectID, taskID int) error`.
+
+### 4.3 Expiry enforcement (generic, central)
+
+In `accessKeyEncryptionServiceImpl.DeserializeSecret`
+(`services/server/access_key_encryption_svc.go:128`):
+
+```go
+if key.ExpireAt != nil && tz.Now().After(*key.ExpireAt) {
+    return ErrAccessKeyExpired // "access key expired"
+}
+```
+
+One check point covers every consumer (local executor, runner dispatch,
+anything future). `ExpireAt == nil` → no expiry (all existing keys). The field
+is generic on purpose: any access key can later be given a TTL.
+
+### 4.4 Creating the secret — `TaskPool.AddTask` (`TaskPool.go:960`)
+
+After `p.store.CreateTask` succeeds and if the submitted secret is a
+non-empty JSON object:
+
+```go
+key := db.AccessKey{
+    Name:      fmt.Sprintf("task-%d-survey-secrets", newTask.ID),
+    Type:      db.AccessKeyString,
+    ProjectID: &projectID,
+    Owner:     db.AccessKeyTaskSecret,
+    TaskID:    &newTask.ID,
+    ExpireAt:  &expireAt,
+    String:    extraSecretVars, // whole survey-secrets JSON as one string secret
+}
+// SerializeSecret (keyring-encrypt) + CreateAccessKey via AccessKeyEncryptionService
+```
+
+- `expireAt = now + TTL` (decided: derive from `MaxTaskDurationSec`, no new
+  config option): TTL = `util.Config.MaxTaskDurationSec` + 1h queue allowance
+  when set; 24h when `MaxTaskDurationSec == 0` (expire_at is always set —
+  expiry is a hard requirement; deletion on finalize remains the primary
+  lifecycle, expiry is the backstop).
+- Failure to create the key fails the task (never run with silently-missing
+  secrets).
+- `taskObj.Secret = "{}"` stays as today; plaintext no longer retained in
+  memory at all — both execution branches read back through the service.
+
+### 4.5 Reading the secret at dispatch
+
+New service method (e.g. on `AccessKeyEncryptionService` or a small
+`TaskSecretService`): `GetTaskSurveySecrets(projectID, taskID) (string, error)`
+— loads via `GetTaskAccessKey`, calls `DeserializeSecret` (which enforces
+`expire_at`), returns the plaintext JSON. `db.ErrNotFound` → task simply has
+no survey secrets (normal case) → `""`.
+
+Consumers:
+
+- **Remote**: runner poll handler (`api/runners/runners.go`, where `JobData`
+  is built): set `jobData.Task.Secret` from the service. Works on any HA node
+  — ciphertext in the shared DB, keyring in config. Same trust channel that
+  already carries decrypted access keys and vault passwords (TLS + runner
+  token). On `ErrAccessKeyExpired` or decrypt failure: fail the task with a
+  clear log/status message, do not dispatch with empty vars.
+- **Local**: in `AddTask`'s local branch (and/or `LocalExecutor.Prepare`),
+  populate `LocalExecutor.Secret` via the same service call instead of the
+  in-memory `extraSecretVars`. This also fixes local secrets lost on node
+  restart while queued.
+
+### 4.6 Runner-side consumption
+
+`LocalExecutorProvider.NewExecutor`
+(`services/tasks/local_executor_provider.go:37`): add `Secret: task.Secret`.
+Mirror in pro docker/k8s providers (pro_impl, separate PR).
+
+Compatibility: old runner + new server deserializes `task.secret` and ignores
+it (same behavior as today, no error); new runner + old server sees an empty
+field. Fully backward compatible.
+
+### 4.7 Cleanup
+
+- **On terminal status**: call `DeleteTaskAccessKeys` from the finish path
+  (`TaskRunner.finishRun`), covering both local and remote
+  (`finalizeRemoteTaskLocked` → `finishRun`) completion; HA orphan cleaner as
+  backstop where it force-fails stale tasks.
+- **Expired sweep**: periodic cleanup deleting `access_key` rows where
+  `owner='task' and expire_at < now` (attach to an existing periodic job,
+  e.g. the task-pool/orphan maintenance loop). Idempotent — safe if several
+  HA nodes race.
+- **Task deletion/retention**: covered by `on delete cascade`.
+
+### 4.8 Guard rails / leak surface
+
+- Secret value never serialized: `AccessKey.Secret` is already `json:"-"`;
+  new `TaskID`/`ExpireAt` also `json:"-" backup:"-"`.
+- Secrets list: hidden automatically by the `owner=''` filter (verified,
+  `db/sql/access_key.go:28`).
+- Generic key endpoints (`api/projects/keys.go` get-by-id/update/delete):
+  reject keys with `Owner == AccessKeyTaskSecret` (mirror whatever guard
+  applies to other owned keys; verify during implementation — metadata-only
+  exposure today, but mutations must be blocked).
+- Project backup (`services/project/backup.go`): verify task-owned keys are
+  excluded (exclude non-shared owners if not already).
+- Rekey: `RekeyAccessKeys` iterates with `IgnoreOwner: true`
+  (`access_key_encryption_svc.go:208`) → task secrets are re-encrypted on key
+  rotation for free.
+- Never log the decrypted value.
+
+## 5. Tests
+
+Per `.claude/CLAUDE.md` rules (`testify`, table-driven):
+
+1. `AddTask` with survey secrets → `access_key` row created: `owner='task'`,
+   `task_id` set, `expire_at` set, ciphertext decrypts to the submitted JSON;
+   empty/`"{}"` secret → no row.
+2. `DeserializeSecret` with `ExpireAt` in the past → `ErrAccessKeyExpired`;
+   nil / future → OK (table-driven).
+3. Runner poll handler (httptest): task with secret key →
+   `new_jobs[0].task.secret` contains decrypted JSON; expired key → task
+   failed, no job dispatched.
+4. `LocalExecutorProvider.NewExecutor` populates `Secret`; `mergeExtraVars`
+   merges it (extend `local_executor_test.go`).
+5. Cleanup: after finalize the key row is gone; expired sweep removes stale
+   rows; project secrets list API does not contain the task key.
+
+## 6. Files Touched (summary)
+
+| File | Change |
+|------|--------|
+| `db/sql/migrations/v2.20.1.sql` | `task_id`, `expire_at` columns + index |
+| `db/Migration.go` | register version |
+| `db/AccessKey.go` | `AccessKeyTaskSecret` owner, `TaskID`, `ExpireAt` |
+| `db/Store.go` + `db/sql/access_key.go` | insert columns, owner filter case, `GetTaskAccessKey`, `DeleteTaskAccessKeys` |
+| `services/server/access_key_encryption_svc.go` | expiry check in `DeserializeSecret`; `GetTaskSurveySecrets` |
+| `services/tasks/TaskPool.go` | create task key in `AddTask`; read via service for local branch |
+| `services/tasks/TaskRunner.go` | delete key in `finishRun` |
+| `api/runners/runners.go` | inject decrypted secret into `JobData` |
+| `api/projects/keys.go` | block mutations on task-owned keys |
+| `services/project/backup.go` | verify/exclude task-owned keys |
+| `services/tasks/local_executor_provider.go` | populate `Secret` |
+| pro_impl docker/k8s providers | populate `Secret` (separate PR) |

--- a/api/projects/environment_test.go
+++ b/api/projects/environment_test.go
@@ -30,6 +30,11 @@ func (m *mockAccessKeyRepo) CreateAccessKey(k db.AccessKey) (db.AccessKey, error
 	return k, nil
 }
 func (m *mockAccessKeyRepo) DeleteAccessKey(int, int) error { return nil }
+func (m *mockAccessKeyRepo) GetTaskAccessKey(int, int) (db.AccessKey, error) {
+	return db.AccessKey{}, db.ErrNotFound
+}
+func (m *mockAccessKeyRepo) DeleteTaskAccessKeys(int, int) error { return nil }
+func (m *mockAccessKeyRepo) DeleteExpiredTaskAccessKeys() error  { return nil }
 
 type mockAccessKeyService struct {
 	deleted []int

--- a/api/projects/keys.go
+++ b/api/projects/keys.go
@@ -39,6 +39,13 @@ func KeyMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
+		// Task-bound survey-secret keys are internal: they must not be
+		// readable or mutable through the generic key endpoints.
+		if key.Owner == db.AccessKeyTaskSecret {
+			helpers.WriteError(w, db.ErrNotFound)
+			return
+		}
+
 		r = helpers.SetContextValue(r, "accessKey", key)
 		next.ServeHTTP(w, r)
 	})
@@ -96,6 +103,14 @@ func (c *KeyController) AddKey(w http.ResponseWriter, r *http.Request) {
 	key.Plain = nil
 	key.IgnorePlain = true
 	key.Synchronized = false
+
+	// Task-bound survey-secret keys are created internally at task start only.
+	if key.Owner == db.AccessKeyTaskSecret {
+		helpers.WriteJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "Invalid key owner",
+		})
+		return
+	}
 
 	//if err := key.Validate(true); err != nil {
 	//	helpers.WriteJSON(w, http.StatusBadRequest, map[string]string{

--- a/api/runners/runners.go
+++ b/api/runners/runners.go
@@ -119,95 +119,7 @@ func (c *RunnerController) GetRunner(w http.ResponseWriter, r *http.Request) {
 
 		if tsk.Task.Status == task_logger.TaskWaitingStatus || tsk.Task.Status == task_logger.TaskStartingStatus {
 
-			// Survey secret variables are stored as a task-bound encrypted
-			// access key in the shared DB, so any HA node serving this poll can
-			// deliver them. An unreadable (e.g. expired) secret fails the task
-			// instead of dispatching it with silently empty variables.
-			surveySecrets, err := c.encryptionService.GetTaskSurveySecrets(tsk.Task.ProjectID, tsk.Task.ID)
-			if err != nil {
-				logger := log.WithError(err).WithFields(log.Fields{
-					"runner_id": runner.ID,
-					"task_id":   tsk.Task.ID,
-					"context":   "survey_secrets",
-				})
-				if errors.Is(err, server.ErrAccessKeyExpired) {
-					logger.Warn("task survey secrets expired before dispatch")
-					tsk.Log("Survey secrets expired before the task started. Please run the task again.")
-				} else {
-					logger.Error("failed to read task survey secrets")
-					tsk.Log("Failed to read survey secrets. More details in the server logs.")
-				}
-				tsk.SetStatus(task_logger.TaskFailStatus)
-				c.taskPool.FinalizeRemoteTask(tsk, &runner)
-				continue
-			}
-
-			jobData := runners.JobData{
-				Username:            tsk.Username,
-				IncomingVersion:     tsk.IncomingVersion,
-				Alias:               tsk.Alias,
-				Task:                tsk.Task,
-				Template:            tsk.Template,
-				Inventory:           tsk.Inventory,
-				InventoryRepository: tsk.Inventory.Repository,
-				Repository:          tsk.Repository,
-				Environment:         tsk.Environment,
-			}
-
-			// Always overwrite: the dispatched Secret must be exactly the
-			// DB-derived value, never whatever the in-memory task carries
-			jobData.Task.Secret = surveySecrets
-
-			if c.signer != nil && tsk.Template.JWTParams != nil && tsk.Template.JWTParams.Enabled {
-				ttl, terr := tsk.Template.JWTParams.ParsedTTL()
-				if terr != nil {
-					log.WithError(terr).WithFields(log.Fields{
-						"task_id":     tsk.Task.ID,
-						"template_id": tsk.Template.ID,
-						"context":     "jwt",
-					}).Warn("invalid template jwt_params.ttl")
-					tsk.Log("Invalid JWT token lifetime in the template settings: " + terr.Error())
-					tsk.SetStatus(task_logger.TaskFailStatus)
-					c.taskPool.FinalizeRemoteTask(tsk, &runner)
-					continue
-				}
-
-				token, jerr := c.signer.Sign(jwt.TaskInfo{
-					TaskID:     tsk.Task.ID,
-					ProjectID:  tsk.Task.ProjectID,
-					TemplateID: tsk.Template.ID,
-					UserID:     tsk.Task.UserID,
-					Audience:   tsk.Template.JWTParams.Audience,
-					TTL:        ttl,
-				})
-				if jerr != nil {
-					log.WithError(jerr).WithFields(log.Fields{
-						"task_id": tsk.Task.ID,
-						"context": "jwt",
-					}).Error("failed to sign task JWT")
-					tsk.Log("Failed to sign the task JWT. More details in the server logs.")
-					tsk.SetStatus(task_logger.TaskFailStatus)
-					c.taskPool.FinalizeRemoteTask(tsk, &runner)
-					continue
-				}
-
-				jobData.JWT = token
-			}
-
-			// Decrypt all keys of the task before publishing anything, so a
-			// task with an undecryptable key fails on its own instead of
-			// aborting the poll for the whole runner, and none of its keys
-			// leak into the response of a job that is not dispatched.
-			taskKeys := make(map[int]db.AccessKey)
-			if kerr := c.collectTaskAccessKeys(tsk, runner.ID, taskKeys); kerr != nil {
-				tsk.Log("Failed to decrypt access keys of the task. More details in the server logs.")
-				tsk.SetStatus(task_logger.TaskFailStatus)
-				c.taskPool.FinalizeRemoteTask(tsk, &runner)
-				continue
-			}
-
-			maps.Copy(data.AccessKeys, taskKeys)
-			data.NewJobs = append(data.NewJobs, jobData)
+			c.prepareRemoteJob(tsk, &runner, &data)
 
 		} else {
 			data.CurrentJobs = append(data.CurrentJobs, runners.JobState{
@@ -218,6 +130,102 @@ func (c *RunnerController) GetRunner(w http.ResponseWriter, r *http.Request) {
 	}
 
 	helpers.WriteJSON(w, http.StatusOK, data)
+}
+
+// prepareRemoteJob builds the job for a waiting/starting task and stages it,
+// together with the task's decrypted access keys, into data. On any failure it
+// fails and finalizes the task in place, leaving data untouched, so a single
+// bad task does not abort the poll for the whole runner.
+func (c *RunnerController) prepareRemoteJob(tsk *tasks.TaskRunner, runner *db.Runner, data *runners.RunnerState) {
+	// Survey secret variables are stored as a task-bound encrypted
+	// access key in the shared DB, so any HA node serving this poll can
+	// deliver them. An unreadable (e.g. expired) secret fails the task
+	// instead of dispatching it with silently empty variables.
+	surveySecrets, err := c.encryptionService.GetTaskSurveySecrets(tsk.Task.ProjectID, tsk.Task.ID)
+	if err != nil {
+		logger := log.WithError(err).WithFields(log.Fields{
+			"runner_id": runner.ID,
+			"task_id":   tsk.Task.ID,
+			"context":   "survey_secrets",
+		})
+		if errors.Is(err, server.ErrAccessKeyExpired) {
+			logger.Warn("task survey secrets expired before dispatch")
+			tsk.Log("Survey secrets expired before the task started. Please run the task again.")
+		} else {
+			logger.Error("failed to read task survey secrets")
+			tsk.Log("Failed to read survey secrets. More details in the server logs.")
+		}
+		tsk.SetStatus(task_logger.TaskFailStatus)
+		c.taskPool.FinalizeRemoteTask(tsk, runner)
+		return
+	}
+
+	jobData := runners.JobData{
+		Username:            tsk.Username,
+		IncomingVersion:     tsk.IncomingVersion,
+		Alias:               tsk.Alias,
+		Task:                tsk.Task,
+		Template:            tsk.Template,
+		Inventory:           tsk.Inventory,
+		InventoryRepository: tsk.Inventory.Repository,
+		Repository:          tsk.Repository,
+		Environment:         tsk.Environment,
+	}
+
+	// Always overwrite: the dispatched Secret must be exactly the
+	// DB-derived value, never whatever the in-memory task carries
+	jobData.Task.Secret = surveySecrets
+
+	if c.signer != nil && tsk.Template.JWTParams != nil && tsk.Template.JWTParams.Enabled {
+		ttl, terr := tsk.Template.JWTParams.ParsedTTL()
+		if terr != nil {
+			log.WithError(terr).WithFields(log.Fields{
+				"task_id":     tsk.Task.ID,
+				"template_id": tsk.Template.ID,
+				"context":     "jwt",
+			}).Warn("invalid template jwt_params.ttl")
+			tsk.Log("Invalid JWT token lifetime in the template settings: " + terr.Error())
+			tsk.SetStatus(task_logger.TaskFailStatus)
+			c.taskPool.FinalizeRemoteTask(tsk, runner)
+			return
+		}
+
+		token, jerr := c.signer.Sign(jwt.TaskInfo{
+			TaskID:     tsk.Task.ID,
+			ProjectID:  tsk.Task.ProjectID,
+			TemplateID: tsk.Template.ID,
+			UserID:     tsk.Task.UserID,
+			Audience:   tsk.Template.JWTParams.Audience,
+			TTL:        ttl,
+		})
+		if jerr != nil {
+			log.WithError(jerr).WithFields(log.Fields{
+				"task_id": tsk.Task.ID,
+				"context": "jwt",
+			}).Error("failed to sign task JWT")
+			tsk.Log("Failed to sign the task JWT. More details in the server logs.")
+			tsk.SetStatus(task_logger.TaskFailStatus)
+			c.taskPool.FinalizeRemoteTask(tsk, runner)
+			return
+		}
+
+		jobData.JWT = token
+	}
+
+	// Decrypt all keys of the task before publishing anything, so a
+	// task with an undecryptable key fails on its own instead of
+	// aborting the poll for the whole runner, and none of its keys
+	// leak into the response of a job that is not dispatched.
+	taskKeys := make(map[int]db.AccessKey)
+	if kerr := c.collectTaskAccessKeys(tsk, runner.ID, taskKeys); kerr != nil {
+		tsk.Log("Failed to decrypt access keys of the task. More details in the server logs.")
+		tsk.SetStatus(task_logger.TaskFailStatus)
+		c.taskPool.FinalizeRemoteTask(tsk, runner)
+		return
+	}
+
+	maps.Copy(data.AccessKeys, taskKeys)
+	data.NewJobs = append(data.NewJobs, jobData)
 }
 
 // collectTaskAccessKeys decrypts every access key the dispatched task needs
@@ -282,6 +290,9 @@ func (c *RunnerController) collectTaskAccessKeys(tsk *tasks.TaskRunner, runnerID
 		keys[tsk.Inventory.Repository.SSHKeyID] = tsk.Inventory.Repository.SSHKey
 	}
 
+	// tsk.Repository.SSHKey is already decrypted in TaskRunner.populateDetails,
+	// so it is staged as-is here. Do not call DeserializeSecret on it again —
+	// decrypting an already-plaintext key would fail.
 	keys[tsk.Repository.SSHKeyID] = tsk.Repository.SSHKey
 
 	return nil

--- a/api/runners/runners.go
+++ b/api/runners/runners.go
@@ -2,6 +2,7 @@ package runners
 
 import (
 	"errors"
+	"maps"
 	"net/http"
 	"strings"
 	"time"
@@ -193,76 +194,20 @@ func (c *RunnerController) GetRunner(w http.ResponseWriter, r *http.Request) {
 				jobData.JWT = token
 			}
 
+			// Decrypt all keys of the task before publishing anything, so a
+			// task with an undecryptable key fails on its own instead of
+			// aborting the poll for the whole runner, and none of its keys
+			// leak into the response of a job that is not dispatched.
+			taskKeys := make(map[int]db.AccessKey)
+			if kerr := c.collectTaskAccessKeys(tsk, runner.ID, taskKeys); kerr != nil {
+				tsk.Log("Failed to decrypt access keys of the task. More details in the server logs.")
+				tsk.SetStatus(task_logger.TaskFailStatus)
+				c.taskPool.FinalizeRemoteTask(tsk, &runner)
+				continue
+			}
+
+			maps.Copy(data.AccessKeys, taskKeys)
 			data.NewJobs = append(data.NewJobs, jobData)
-
-			if tsk.Inventory.SSHKeyID != nil {
-				err := c.encryptionService.DeserializeSecret(&tsk.Inventory.SSHKey)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"runner_id":     runner.ID,
-						"task_id":       tsk.Task.ID,
-						"inventory_id":  tsk.Inventory.ID,
-						"access_key_id": tsk.Inventory.SSHKey.ID,
-						"context":       "runner",
-					}).WithError(err).Error("Failed to decrypt inventory key")
-					helpers.WriteError(w, err)
-					return
-				}
-				data.AccessKeys[*tsk.Inventory.SSHKeyID] = tsk.Inventory.SSHKey
-			}
-
-			if tsk.Inventory.BecomeKeyID != nil {
-				err := c.encryptionService.DeserializeSecret(&tsk.Inventory.BecomeKey)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"runner_id":     runner.ID,
-						"task_id":       tsk.Task.ID,
-						"inventory_id":  tsk.Inventory.ID,
-						"access_key_id": tsk.Inventory.BecomeKey.ID,
-						"context":       "runner",
-					}).WithError(err).Error("Failed to decrypt become key")
-					helpers.WriteError(w, err)
-					return
-				}
-				data.AccessKeys[*tsk.Inventory.BecomeKeyID] = tsk.Inventory.BecomeKey
-			}
-
-			if tsk.Template.Vaults != nil {
-				for _, vault := range tsk.Template.Vaults {
-					if vault.VaultKeyID != nil {
-						err := c.encryptionService.DeserializeSecret(vault.Vault)
-						if err != nil {
-							log.WithFields(log.Fields{
-								"runner_id":     runner.ID,
-								"task_id":       tsk.Task.ID,
-								"access_key_id": vault.Vault.ID,
-								"context":       "runner",
-							}).WithError(err).Error("Failed to decrypt vault")
-							helpers.WriteError(w, err)
-							return
-						}
-						data.AccessKeys[*vault.VaultKeyID] = *vault.Vault
-					}
-				}
-			}
-
-			if tsk.Inventory.RepositoryID != nil {
-				err := c.encryptionService.DeserializeSecret(&tsk.Inventory.Repository.SSHKey)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"runner_id":     runner.ID,
-						"task_id":       tsk.Task.ID,
-						"repository_id": tsk.Inventory.Repository.ID,
-						"access_key_id": tsk.Inventory.Repository.SSHKey.ID,
-						"context":       "runner",
-					}).WithError(err).Error("Failed to decrypt repository key")
-					helpers.WriteError(w, err)
-					return
-				}
-				data.AccessKeys[tsk.Inventory.Repository.SSHKeyID] = tsk.Inventory.Repository.SSHKey
-			}
-
-			data.AccessKeys[tsk.Repository.SSHKeyID] = tsk.Repository.SSHKey
 
 		} else {
 			data.CurrentJobs = append(data.CurrentJobs, runners.JobState{
@@ -273,6 +218,73 @@ func (c *RunnerController) GetRunner(w http.ResponseWriter, r *http.Request) {
 	}
 
 	helpers.WriteJSON(w, http.StatusOK, data)
+}
+
+// collectTaskAccessKeys decrypts every access key the dispatched task needs
+// and stages them into keys, so the caller publishes either all of them or
+// none. It returns the first decryption error.
+func (c *RunnerController) collectTaskAccessKeys(tsk *tasks.TaskRunner, runnerID int, keys map[int]db.AccessKey) error {
+	if tsk.Inventory.SSHKeyID != nil {
+		if err := c.encryptionService.DeserializeSecret(&tsk.Inventory.SSHKey); err != nil {
+			log.WithFields(log.Fields{
+				"runner_id":     runnerID,
+				"task_id":       tsk.Task.ID,
+				"inventory_id":  tsk.Inventory.ID,
+				"access_key_id": tsk.Inventory.SSHKey.ID,
+				"context":       "runner",
+			}).WithError(err).Error("Failed to decrypt inventory key")
+			return err
+		}
+		keys[*tsk.Inventory.SSHKeyID] = tsk.Inventory.SSHKey
+	}
+
+	if tsk.Inventory.BecomeKeyID != nil {
+		if err := c.encryptionService.DeserializeSecret(&tsk.Inventory.BecomeKey); err != nil {
+			log.WithFields(log.Fields{
+				"runner_id":     runnerID,
+				"task_id":       tsk.Task.ID,
+				"inventory_id":  tsk.Inventory.ID,
+				"access_key_id": tsk.Inventory.BecomeKey.ID,
+				"context":       "runner",
+			}).WithError(err).Error("Failed to decrypt become key")
+			return err
+		}
+		keys[*tsk.Inventory.BecomeKeyID] = tsk.Inventory.BecomeKey
+	}
+
+	for _, vault := range tsk.Template.Vaults {
+		if vault.VaultKeyID == nil {
+			continue
+		}
+		if err := c.encryptionService.DeserializeSecret(vault.Vault); err != nil {
+			log.WithFields(log.Fields{
+				"runner_id":     runnerID,
+				"task_id":       tsk.Task.ID,
+				"access_key_id": vault.Vault.ID,
+				"context":       "runner",
+			}).WithError(err).Error("Failed to decrypt vault")
+			return err
+		}
+		keys[*vault.VaultKeyID] = *vault.Vault
+	}
+
+	if tsk.Inventory.RepositoryID != nil {
+		if err := c.encryptionService.DeserializeSecret(&tsk.Inventory.Repository.SSHKey); err != nil {
+			log.WithFields(log.Fields{
+				"runner_id":     runnerID,
+				"task_id":       tsk.Task.ID,
+				"repository_id": tsk.Inventory.Repository.ID,
+				"access_key_id": tsk.Inventory.Repository.SSHKey.ID,
+				"context":       "runner",
+			}).WithError(err).Error("Failed to decrypt repository key")
+			return err
+		}
+		keys[tsk.Inventory.Repository.SSHKeyID] = tsk.Inventory.Repository.SSHKey
+	}
+
+	keys[tsk.Repository.SSHKeyID] = tsk.Repository.SSHKey
+
+	return nil
 }
 
 func (c *RunnerController) UpdateRunner(w http.ResponseWriter, r *http.Request) {

--- a/api/runners/runners.go
+++ b/api/runners/runners.go
@@ -124,12 +124,18 @@ func (c *RunnerController) GetRunner(w http.ResponseWriter, r *http.Request) {
 			// instead of dispatching it with silently empty variables.
 			surveySecrets, err := c.encryptionService.GetTaskSurveySecrets(tsk.Task.ProjectID, tsk.Task.ID)
 			if err != nil {
-				log.WithFields(log.Fields{
+				logger := log.WithError(err).WithFields(log.Fields{
 					"runner_id": runner.ID,
 					"task_id":   tsk.Task.ID,
-					"context":   "runner",
-				}).WithError(err).Error("Failed to read task survey secrets")
-				tsk.Log("Error: failed to read survey secrets: " + err.Error())
+					"context":   "survey_secrets",
+				})
+				if errors.Is(err, server.ErrAccessKeyExpired) {
+					logger.Warn("task survey secrets expired before dispatch")
+					tsk.Log("Survey secrets expired before the task started. Please run the task again.")
+				} else {
+					logger.Error("failed to read task survey secrets")
+					tsk.Log("Failed to read survey secrets. More details in the server logs.")
+				}
 				tsk.SetStatus(task_logger.TaskFailStatus)
 				c.taskPool.FinalizeRemoteTask(tsk, &runner)
 				continue
@@ -158,25 +164,33 @@ func (c *RunnerController) GetRunner(w http.ResponseWriter, r *http.Request) {
 						"task_id":     tsk.Task.ID,
 						"template_id": tsk.Template.ID,
 						"context":     "jwt",
-					}).Error("invalid template jwt_params.ttl; skipping token issuance")
-				} else {
-					token, err := c.signer.Sign(jwt.TaskInfo{
-						TaskID:     tsk.Task.ID,
-						ProjectID:  tsk.Task.ProjectID,
-						TemplateID: tsk.Template.ID,
-						UserID:     tsk.Task.UserID,
-						Audience:   jwt.Audience(tsk.Template.JWTParams.Audience),
-						TTL:        ttl,
-					})
-					if err != nil {
-						log.WithError(err).WithFields(log.Fields{
-							"task_id": tsk.Task.ID,
-							"context": "jwt",
-						}).Error("failed to sign task JWT")
-					} else {
-						jobData.JWT = token
-					}
+					}).Warn("invalid template jwt_params.ttl")
+					tsk.Log("Invalid JWT token lifetime in the template settings: " + terr.Error())
+					tsk.SetStatus(task_logger.TaskFailStatus)
+					c.taskPool.FinalizeRemoteTask(tsk, &runner)
+					continue
 				}
+
+				token, jerr := c.signer.Sign(jwt.TaskInfo{
+					TaskID:     tsk.Task.ID,
+					ProjectID:  tsk.Task.ProjectID,
+					TemplateID: tsk.Template.ID,
+					UserID:     tsk.Task.UserID,
+					Audience:   tsk.Template.JWTParams.Audience,
+					TTL:        ttl,
+				})
+				if jerr != nil {
+					log.WithError(jerr).WithFields(log.Fields{
+						"task_id": tsk.Task.ID,
+						"context": "jwt",
+					}).Error("failed to sign task JWT")
+					tsk.Log("Failed to sign the task JWT. More details in the server logs.")
+					tsk.SetStatus(task_logger.TaskFailStatus)
+					c.taskPool.FinalizeRemoteTask(tsk, &runner)
+					continue
+				}
+
+				jobData.JWT = token
 			}
 
 			data.NewJobs = append(data.NewJobs, jobData)

--- a/api/runners/runners.go
+++ b/api/runners/runners.go
@@ -118,6 +118,23 @@ func (c *RunnerController) GetRunner(w http.ResponseWriter, r *http.Request) {
 
 		if tsk.Task.Status == task_logger.TaskWaitingStatus || tsk.Task.Status == task_logger.TaskStartingStatus {
 
+			// Survey secret variables are stored as a task-bound encrypted
+			// access key in the shared DB, so any HA node serving this poll can
+			// deliver them. An unreadable (e.g. expired) secret fails the task
+			// instead of dispatching it with silently empty variables.
+			surveySecrets, err := c.encryptionService.GetTaskSurveySecrets(tsk.Task.ProjectID, tsk.Task.ID)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"runner_id": runner.ID,
+					"task_id":   tsk.Task.ID,
+					"context":   "runner",
+				}).WithError(err).Error("Failed to read task survey secrets")
+				tsk.Log("Error: failed to read survey secrets: " + err.Error())
+				tsk.SetStatus(task_logger.TaskFailStatus)
+				c.taskPool.FinalizeRemoteTask(tsk, &runner)
+				continue
+			}
+
 			jobData := runners.JobData{
 				Username:            tsk.Username,
 				IncomingVersion:     tsk.IncomingVersion,
@@ -128,6 +145,10 @@ func (c *RunnerController) GetRunner(w http.ResponseWriter, r *http.Request) {
 				InventoryRepository: tsk.Inventory.Repository,
 				Repository:          tsk.Repository,
 				Environment:         tsk.Environment,
+			}
+
+			if surveySecrets != "" {
+				jobData.Task.Secret = surveySecrets
 			}
 
 			if c.signer != nil && tsk.Template.JWTParams != nil && tsk.Template.JWTParams.Enabled {

--- a/api/runners/runners.go
+++ b/api/runners/runners.go
@@ -109,9 +109,9 @@ func (c *RunnerController) GetRunner(w http.ResponseWriter, r *http.Request) {
 		data.CacheCleanProjectID = runner.ProjectID
 	}
 
-	tasks := c.taskPool.GetRunningTasks()
+	runningTasks := c.taskPool.GetRunningTasks()
 
-	for _, tsk := range tasks {
+	for _, tsk := range runningTasks {
 		if tsk.Task.RunnerID == nil || *tsk.Task.RunnerID != runner.ID {
 			continue
 		}
@@ -147,9 +147,9 @@ func (c *RunnerController) GetRunner(w http.ResponseWriter, r *http.Request) {
 				Environment:         tsk.Environment,
 			}
 
-			if surveySecrets != "" {
-				jobData.Task.Secret = surveySecrets
-			}
+			// Always overwrite: the dispatched Secret must be exactly the
+			// DB-derived value, never whatever the in-memory task carries
+			jobData.Task.Secret = surveySecrets
 
 			if c.signer != nil && tsk.Template.JWTParams != nil && tsk.Template.JWTParams.Enabled {
 				ttl, terr := tsk.Template.JWTParams.ParsedTTL()

--- a/api/runners/runners.go
+++ b/api/runners/runners.go
@@ -290,9 +290,20 @@ func (c *RunnerController) collectTaskAccessKeys(tsk *tasks.TaskRunner, runnerID
 		keys[tsk.Inventory.Repository.SSHKeyID] = tsk.Inventory.Repository.SSHKey
 	}
 
-	// tsk.Repository.SSHKey is already decrypted in TaskRunner.populateDetails,
-	// so it is staged as-is here. Do not call DeserializeSecret on it again —
-	// decrypting an already-plaintext key would fail.
+	// Decrypt the task repository key here rather than relying on it having
+	// been decrypted earlier (e.g. in TaskRunner.populateDetails). Decryption
+	// reads key.Secret (the ciphertext, left intact) and refills the plaintext
+	// field, so this is idempotent even if the key is already decrypted.
+	if err := c.encryptionService.DeserializeSecret(&tsk.Repository.SSHKey); err != nil {
+		log.WithFields(log.Fields{
+			"runner_id":     runnerID,
+			"task_id":       tsk.Task.ID,
+			"repository_id": tsk.Repository.ID,
+			"access_key_id": tsk.Repository.SSHKey.ID,
+			"context":       "runner",
+		}).WithError(err).Error("Failed to decrypt repository key")
+		return err
+	}
 	keys[tsk.Repository.SSHKeyID] = tsk.Repository.SSHKey
 
 	return nil

--- a/db/AccessKey.go
+++ b/db/AccessKey.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"time"
 )
 
 type AccessKeyType string
@@ -19,7 +20,11 @@ const (
 	AccessKeyEnvironment   AccessKeyOwner = "environment"
 	AccessKeyVariable      AccessKeyOwner = "variable"
 	AccessKeySecretStorage AccessKeyOwner = "vault"
-	AccessKeyShared        AccessKeyOwner = ""
+	// AccessKeyTaskSecret marks a key holding survey secret variables of a
+	// single task. Such keys are bound to the task via TaskID, expire via
+	// ExpireAt, and are hidden from the project secrets list (non-empty owner).
+	AccessKeyTaskSecret AccessKeyOwner = "task"
+	AccessKeyShared     AccessKeyOwner = ""
 )
 const (
 	AccessKeySourceStorageVault AccessKeySourceStorageType = "vault"
@@ -54,6 +59,14 @@ type AccessKey struct {
 
 	// UserID is an ID of a user which owns the access key.
 	UserID *int `db:"user_id" json:"-" backup:"-"`
+
+	// TaskID is set for keys with owner AccessKeyTaskSecret: the task whose
+	// survey secrets this key holds. Deleted by cascade with the task.
+	TaskID *int `db:"task_id" json:"-" backup:"-"`
+
+	// ExpireAt, when set, makes the key unusable after this moment.
+	// Enforced centrally in AccessKeyEncryptionService.DeserializeSecret.
+	ExpireAt *time.Time `db:"expire_at" json:"-" backup:"-"`
 
 	Empty bool `db:"-" json:"empty,omitempty"`
 

--- a/db/Migration.go
+++ b/db/Migration.go
@@ -132,6 +132,7 @@ func GetMigrations(dialect string) []Migration {
 		{Version: "2.19.2"},
 		{Version: "2.19.11"},
 		{Version: "2.20.0"},
+		{Version: "2.20.1"},
 	}
 
 	return append(initScripts, commonScripts...)

--- a/db/Store.go
+++ b/db/Store.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"slices"
 	"strings"
@@ -316,12 +317,51 @@ type EnvironmentManager interface {
 }
 
 type GetAccessKeyOptions struct {
-	Owner           AccessKeyOwner
-	IgnoreOwner     bool
+	// Owner restricts the result to keys of a single owner type.
+	// The zero value is meaningful: it is AccessKeyShared, i.e. plain
+	// project keys created by the user. Because of that, "no owner filter"
+	// cannot be expressed by leaving Owner empty — use IgnoreOwner instead.
+	Owner AccessKeyOwner
+
+	// IgnoreOwner disables the Owner filter entirely, returning keys of
+	// every owner type (shared, environment, variable, vault, task).
+	// Needed by callers that must see all keys regardless of who owns
+	// them, e.g. vault rekeying and secret storage sync cleanup.
+	IgnoreOwner bool
+
 	EnvironmentID   *int
 	StorageID       *int
 	SourceStorageID *int
 	TaskID          *int
+}
+
+// Validate ensures that querying keys of an owned type always includes the
+// ID that scopes them; without it a query could return keys outside the
+// caller's scope.
+func (o GetAccessKeyOptions) Validate() error {
+	if o.IgnoreOwner {
+		return nil
+	}
+
+	var value *int
+	var name string
+
+	switch o.Owner {
+	case AccessKeyVariable, AccessKeyEnvironment:
+		value, name = o.EnvironmentID, "environment_id"
+	case AccessKeySecretStorage:
+		value, name = o.StorageID, "storage_id"
+	case AccessKeyTaskSecret:
+		value, name = o.TaskID, "task_id"
+	default:
+		return nil
+	}
+
+	if value == nil {
+		return fmt.Errorf("%s is required for owner %q", name, o.Owner)
+	}
+
+	return nil
 }
 
 // AccessKeyManager handles access key-related operations

--- a/db/Store.go
+++ b/db/Store.go
@@ -321,6 +321,7 @@ type GetAccessKeyOptions struct {
 	EnvironmentID   *int
 	StorageID       *int
 	SourceStorageID *int
+	TaskID          *int
 }
 
 // AccessKeyManager handles access key-related operations
@@ -331,6 +332,16 @@ type AccessKeyManager interface {
 	UpdateAccessKey(accessKey AccessKey) error
 	CreateAccessKey(accessKey AccessKey) (AccessKey, error)
 	DeleteAccessKey(projectID int, accessKeyID int) error
+	// GetTaskAccessKey returns the AccessKeyTaskSecret-owned key of a task
+	// (survey secret variables), or ErrNotFound when the task has none.
+	GetTaskAccessKey(projectID int, taskID int) (AccessKey, error)
+	// DeleteTaskAccessKeys removes all AccessKeyTaskSecret-owned keys of a task.
+	// Deleting for a task without such keys is not an error.
+	DeleteTaskAccessKeys(projectID int, taskID int) error
+	// DeleteExpiredTaskAccessKeys removes all AccessKeyTaskSecret-owned keys
+	// whose expire_at is in the past, across all projects. Idempotent, safe to
+	// run concurrently on several HA nodes.
+	DeleteExpiredTaskAccessKeys() error
 }
 
 // IntegrationManager handles integration-related operations

--- a/db/Store_test.go
+++ b/db/Store_test.go
@@ -31,3 +31,34 @@ func TestObjectToJSON3(t *testing.T) {
 	assert.NotNil(t, s)
 	assert.Equal(t, "{\"name\":\"test\",\"title\":\"Test\"}", *s)
 }
+
+func TestGetAccessKeyOptionsValidate(t *testing.T) {
+	id := 1
+
+	tests := []struct {
+		name    string
+		options GetAccessKeyOptions
+		wantErr string
+	}{
+		{"ignore owner skips checks", GetAccessKeyOptions{IgnoreOwner: true}, ""},
+		{"shared owner needs no id", GetAccessKeyOptions{Owner: AccessKeyShared}, ""},
+		{"variable owner with environment id", GetAccessKeyOptions{Owner: AccessKeyVariable, EnvironmentID: &id}, ""},
+		{"variable owner without environment id", GetAccessKeyOptions{Owner: AccessKeyVariable}, "environment_id is required"},
+		{"environment owner without environment id", GetAccessKeyOptions{Owner: AccessKeyEnvironment}, "environment_id is required"},
+		{"storage owner with storage id", GetAccessKeyOptions{Owner: AccessKeySecretStorage, StorageID: &id}, ""},
+		{"storage owner without storage id", GetAccessKeyOptions{Owner: AccessKeySecretStorage}, "storage_id is required"},
+		{"task owner with task id", GetAccessKeyOptions{Owner: AccessKeyTaskSecret, TaskID: &id}, ""},
+		{"task owner without task id", GetAccessKeyOptions{Owner: AccessKeyTaskSecret}, "task_id is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.options.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/db/TemplateJWT.go
+++ b/db/TemplateJWT.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/semaphoreui/semaphore/pkg/common_errors"
+	"github.com/semaphoreui/semaphore/pkg/jwt"
 	"github.com/semaphoreui/semaphore/util"
 )
 
@@ -18,9 +19,9 @@ const maxJWTAudienceEntries = 32
 
 // TemplateJWTParams holds the JWT configuration for a template.
 type TemplateJWTParams struct {
-	Enabled  bool     `json:"enabled,omitempty"`
-	Audience []string `json:"audience,omitempty"`
-	TTL      string   `json:"ttl,omitempty"`
+	Enabled  bool         `json:"enabled,omitempty"`
+	Audience jwt.Audience `json:"audience,omitempty"`
+	TTL      string       `json:"ttl,omitempty"`
 }
 
 // Scan implements sql.Scanner so TemplateJWTParams can be read from the database.

--- a/db/sql/access_key.go
+++ b/db/sql/access_key.go
@@ -26,23 +26,26 @@ func (d *SqlDb) GetAccessKeys(projectID int, options db.GetAccessKeyOptions, par
 		return
 	}
 
-	if !options.IgnoreOwner {
-		q = q.Where("pe.owner=?", options.Owner)
-
-		switch options.Owner {
-		case db.AccessKeyVariable, db.AccessKeyEnvironment:
-			q = q.Where(squirrel.Eq{"pe.environment_id": *options.EnvironmentID})
-		case db.AccessKeySecretStorage:
-			q = q.Where(squirrel.Eq{"pe.storage_id": options.StorageID})
-		case db.AccessKeyTaskSecret:
-			q = q.Where(squirrel.Eq{"pe.task_id": options.TaskID})
-		}
-	} else if options.EnvironmentID != nil {
-		q = q.Where(squirrel.Eq{"pe.environment_id": *options.EnvironmentID})
+	if err = options.Validate(); err != nil {
+		return
 	}
 
-	if options.SourceStorageID != nil {
-		q = q.Where(squirrel.Eq{"pe.source_storage_id": *options.SourceStorageID})
+	if !options.IgnoreOwner {
+		q = q.Where(squirrel.Eq{"pe.owner": options.Owner})
+	}
+
+	for _, f := range []struct {
+		column string
+		value  *int
+	}{
+		{"pe.environment_id", options.EnvironmentID},
+		{"pe.storage_id", options.StorageID},
+		{"pe.task_id", options.TaskID},
+		{"pe.source_storage_id", options.SourceStorageID},
+	} {
+		if f.value != nil {
+			q = q.Where(squirrel.Eq{f.column: *f.value})
+		}
 	}
 
 	query, args, err := q.ToSql()

--- a/db/sql/access_key.go
+++ b/db/sql/access_key.go
@@ -217,16 +217,16 @@ func (d *SqlDb) DeleteExpiredTaskAccessKeys() error {
 	// task with an expired key must fail dispatch with ErrAccessKeyExpired, not
 	// silently run with empty survey variables after the row disappears.
 	_, err := d.exec(
-		`delete from access_key ak
-		 where ak.owner=?
-		   and ak.expire_at is not null
-		   and ak.expire_at < ?
+		`delete from access_key
+		 where owner=?
+		   and expire_at is not null
+		   and expire_at < ?
 		   and (
-		     ak.task_id is null
+		     task_id is null
 		     or exists (
 		       select 1 from task t
-		       where t.id = ak.task_id
-		         and t.project_id = ak.project_id
+		       where t.id = task_id
+		         and t.project_id = access_key.project_id
 		         and t.status in ('stopped', 'success', 'error')
 		     )
 		   )`,

--- a/db/sql/access_key.go
+++ b/db/sql/access_key.go
@@ -210,8 +210,23 @@ func (d *SqlDb) DeleteTaskAccessKeys(projectID int, taskID int) error {
 }
 
 func (d *SqlDb) DeleteExpiredTaskAccessKeys() error {
+	// Do not delete keys for tasks that are still queued or running: an active
+	// task with an expired key must fail dispatch with ErrAccessKeyExpired, not
+	// silently run with empty survey variables after the row disappears.
 	_, err := d.exec(
-		"delete from access_key where owner=? and expire_at is not null and expire_at < ?",
+		`delete from access_key ak
+		 where ak.owner=?
+		   and ak.expire_at is not null
+		   and ak.expire_at < ?
+		   and (
+		     ak.task_id is null
+		     or exists (
+		       select 1 from task t
+		       where t.id = ak.task_id
+		         and t.project_id = ak.project_id
+		         and t.status in ('stopped', 'success', 'error')
+		     )
+		   )`,
 		db.AccessKeyTaskSecret,
 		tz.Now())
 	return err

--- a/db/sql/access_key.go
+++ b/db/sql/access_key.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Masterminds/squirrel"
 	"github.com/semaphoreui/semaphore/db"
+	"github.com/semaphoreui/semaphore/pkg/tz"
 )
 
 func (d *SqlDb) GetAccessKey(projectID int, accessKeyID int) (key db.AccessKey, err error) {
@@ -33,6 +34,8 @@ func (d *SqlDb) GetAccessKeys(projectID int, options db.GetAccessKeyOptions, par
 			q = q.Where(squirrel.Eq{"pe.environment_id": *options.EnvironmentID})
 		case db.AccessKeySecretStorage:
 			q = q.Where(squirrel.Eq{"pe.storage_id": options.StorageID})
+		case db.AccessKeyTaskSecret:
+			q = q.Where(squirrel.Eq{"pe.task_id": options.TaskID})
 		}
 	} else if options.EnvironmentID != nil {
 		q = q.Where(squirrel.Eq{"pe.environment_id": *options.EnvironmentID})
@@ -114,8 +117,10 @@ func (d *SqlDb) CreateAccessKey(key db.AccessKey) (newKey db.AccessKey, err erro
 				"source_storage_id, "+
 				"source_storage_key, "+
 				"source_storage_type, "+
-				"synchronized) "+
-				"values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+				"synchronized, "+
+				"task_id, "+
+				"expire_at) "+
+				"values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
 			key.Name,
 			key.Type,
 			key.ProjectID,
@@ -127,6 +132,8 @@ func (d *SqlDb) CreateAccessKey(key db.AccessKey) (newKey db.AccessKey, err erro
 			key.SourceStorageKey,
 			key.SourceStorageType,
 			key.Synchronized,
+			key.TaskID,
+			key.ExpireAt,
 		)
 	} else {
 		insertID, err = d.insert(
@@ -143,8 +150,10 @@ func (d *SqlDb) CreateAccessKey(key db.AccessKey) (newKey db.AccessKey, err erro
 				"source_storage_id, "+
 				"source_storage_key, "+
 				"source_storage_type, "+
-				"synchronized) "+
-				"values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+				"synchronized, "+
+				"task_id, "+
+				"expire_at) "+
+				"values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
 			key.Name,
 			key.Type,
 			key.ProjectID,
@@ -157,6 +166,8 @@ func (d *SqlDb) CreateAccessKey(key db.AccessKey) (newKey db.AccessKey, err erro
 			key.SourceStorageKey,
 			key.SourceStorageType,
 			key.Synchronized,
+			key.TaskID,
+			key.ExpireAt,
 		)
 
 	}
@@ -172,4 +183,36 @@ func (d *SqlDb) CreateAccessKey(key db.AccessKey) (newKey db.AccessKey, err erro
 
 func (d *SqlDb) DeleteAccessKey(projectID int, accessKeyID int) error {
 	return d.deleteObject(projectID, db.AccessKeyProps, accessKeyID)
+}
+
+func (d *SqlDb) GetTaskAccessKey(projectID int, taskID int) (key db.AccessKey, err error) {
+	err = d.selectOne(
+		&key,
+		"select * from access_key where project_id=? and owner=? and task_id=?",
+		projectID,
+		db.AccessKeyTaskSecret,
+		taskID)
+
+	if err == sql.ErrNoRows {
+		err = db.ErrNotFound
+	}
+
+	return
+}
+
+func (d *SqlDb) DeleteTaskAccessKeys(projectID int, taskID int) error {
+	_, err := d.exec(
+		"delete from access_key where project_id=? and owner=? and task_id=?",
+		projectID,
+		db.AccessKeyTaskSecret,
+		taskID)
+	return err
+}
+
+func (d *SqlDb) DeleteExpiredTaskAccessKeys() error {
+	_, err := d.exec(
+		"delete from access_key where owner=? and expire_at is not null and expire_at < ?",
+		db.AccessKeyTaskSecret,
+		tz.Now())
+	return err
 }

--- a/db/sql/migrations/v2.20.1.sql
+++ b/db/sql/migrations/v2.20.1.sql
@@ -1,0 +1,3 @@
+alter table `access_key` add `task_id` int null references task(`id`) on delete cascade;
+alter table `access_key` add `expire_at` datetime null;
+create index `access_key__task_id` on `access_key`(`task_id`);

--- a/services/project/backup.go
+++ b/services/project/backup.go
@@ -180,6 +180,17 @@ func (b *BackupDB) load(projectID int, store db.Store, workflowStore db.Workflow
 		return
 	}
 
+	// Task-bound survey-secret keys are ephemeral internals of a single task
+	// run; they don't belong in a project backup.
+	filteredKeys := make([]db.AccessKey, 0, len(b.keys))
+	for _, k := range b.keys {
+		if k.Owner == db.AccessKeyTaskSecret {
+			continue
+		}
+		filteredKeys = append(filteredKeys, k)
+	}
+	b.keys = filteredKeys
+
 	b.views, err = store.GetViews(projectID)
 	if err != nil {
 		return

--- a/services/runners/executor_factory_test.go
+++ b/services/runners/executor_factory_test.go
@@ -58,7 +58,7 @@ func TestNewExecutor_DispatchesToProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	jobData := JobData{
-		Task:       db.Task{ID: 42},
+		Task:       db.Task{ID: 42, Secret: `{"passwd":"123456"}`},
 		Template:   db.Template{ID: 7, App: db.AppAnsible},
 		Inventory:  db.Inventory{ID: 3},
 		Repository: db.Repository{ID: 5},
@@ -75,6 +75,8 @@ func TestNewExecutor_DispatchesToProvider(t *testing.T) {
 	assert.Equal(t, 3, local.Inventory.ID)
 	assert.Equal(t, 5, local.Repository.ID)
 	assert.NotNil(t, local.App, "provider must populate App so Prepare has somewhere to install requirements")
+	assert.Equal(t, `{"passwd":"123456"}`, local.Secret,
+		"survey secrets delivered in the job payload must reach the executor")
 }
 
 func TestNewExecutor_RejectsNilProvider(t *testing.T) {

--- a/services/schedules/SchedulePool_test.go
+++ b/services/schedules/SchedulePool_test.go
@@ -37,6 +37,18 @@ func (m *mockEncryptionService) DeleteSecret(key *db.AccessKey) error {
 	return nil
 }
 
+func (m *mockEncryptionService) CreateTaskSurveySecrets(projectID int, taskID int, secrets string, expireAt time.Time) error {
+	return nil
+}
+
+func (m *mockEncryptionService) GetTaskSurveySecrets(projectID int, taskID int) (string, error) {
+	return "", nil
+}
+
+func (m *mockEncryptionService) DeleteTaskSurveySecrets(projectID int, taskID int) error {
+	return nil
+}
+
 func TestValidateCronFormat(t *testing.T) {
 	err := ValidateCronFormat("* * * *")
 	if err == nil {

--- a/services/server/AccessKey_test.go
+++ b/services/server/AccessKey_test.go
@@ -312,3 +312,8 @@ func (m *mockAccessKeyRepo) CreateAccessKey(k db.AccessKey) (db.AccessKey, error
 	return k, nil
 }
 func (m *mockAccessKeyRepo) DeleteAccessKey(int, int) error { return nil }
+func (m *mockAccessKeyRepo) GetTaskAccessKey(int, int) (db.AccessKey, error) {
+	return db.AccessKey{}, db.ErrNotFound
+}
+func (m *mockAccessKeyRepo) DeleteTaskAccessKeys(int, int) error { return nil }
+func (m *mockAccessKeyRepo) DeleteExpiredTaskAccessKeys() error  { return nil }

--- a/services/server/access_key_encryption_svc.go
+++ b/services/server/access_key_encryption_svc.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/semaphoreui/semaphore/db"
 	"github.com/semaphoreui/semaphore/pkg/common_errors"
+	"github.com/semaphoreui/semaphore/pkg/tz"
 	pro "github.com/semaphoreui/semaphore/pro/services/server"
 )
 
@@ -15,12 +17,22 @@ const RekeyBatchSize = 100
 
 var ErrReadOnlyStorage = errors.New("cannot modify secret in read-only storage")
 
+// ErrAccessKeyExpired is returned when a key with ExpireAt in the past is
+// deserialized. Expired secrets must never be usable.
+var ErrAccessKeyExpired = errors.New("access key expired")
+
 type AccessKeyEncryptionService interface {
 	SerializeSecret(key *db.AccessKey) error
 	DeserializeSecret(key *db.AccessKey) error
 	FillEnvironmentSecrets(env *db.Environment, deserializeSecret bool) error
 	DeleteSecret(key *db.AccessKey) error
 	RekeyAccessKeys(oldKey string) (err error)
+
+	// Task survey secrets: task-bound, expiring access keys
+	// (owner AccessKeyTaskSecret). See task_secret_svc.go.
+	CreateTaskSurveySecrets(projectID int, taskID int, secrets string, expireAt time.Time) error
+	GetTaskSurveySecrets(projectID int, taskID int) (string, error)
+	DeleteTaskSurveySecrets(projectID int, taskID int) error
 }
 
 func NewAccessKeyEncryptionService(
@@ -126,6 +138,10 @@ func (s *accessKeyEncryptionServiceImpl) SerializeSecret(key *db.AccessKey) erro
 }
 
 func (s *accessKeyEncryptionServiceImpl) DeserializeSecret(key *db.AccessKey) error {
+	if key.ExpireAt != nil && tz.Now().After(*key.ExpireAt) {
+		return ErrAccessKeyExpired
+	}
+
 	d, _, err := s.getDeserializer(key)
 	if err != nil {
 		return err

--- a/services/server/project_svc_test.go
+++ b/services/server/project_svc_test.go
@@ -90,6 +90,11 @@ func (m *mockAccessKeyManager) GetAccessKeyRefs(projectID int, accessKeyID int) 
 	return db.ObjectReferrers{}, nil
 }
 func (m *mockAccessKeyManager) RekeyAccessKeys(oldKey string) error { return nil }
+func (m *mockAccessKeyManager) GetTaskAccessKey(projectID int, taskID int) (db.AccessKey, error) {
+	return db.AccessKey{}, db.ErrNotFound
+}
+func (m *mockAccessKeyManager) DeleteTaskAccessKeys(projectID int, taskID int) error { return nil }
+func (m *mockAccessKeyManager) DeleteExpiredTaskAccessKeys() error                   { return nil }
 
 func TestProjectServiceImpl_DeleteProject(t *testing.T) {
 	mockRepo := &mockProjectStore{

--- a/services/server/task_secret_svc.go
+++ b/services/server/task_secret_svc.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/semaphoreui/semaphore/db"
+)
+
+// Task survey secrets are stored in the access_key table as keys with owner
+// AccessKeyTaskSecret: bound to the task via task_id, hidden from the project
+// secrets list (non-empty owner), encrypted with the shared keyring like any
+// other secret, and unusable after ExpireAt. This keeps them readable by any
+// HA node serving the runner dispatch while never persisting plaintext.
+
+// CreateTaskSurveySecrets stores the survey-secrets JSON of a task as an
+// encrypted task-bound access key. secrets must be a JSON object string.
+func (s *accessKeyEncryptionServiceImpl) CreateTaskSurveySecrets(
+	projectID int,
+	taskID int,
+	secrets string,
+	expireAt time.Time,
+) error {
+	key := db.AccessKey{
+		Name:           fmt.Sprintf("task-%d-survey-secrets", taskID),
+		Type:           db.AccessKeyString,
+		ProjectID:      &projectID,
+		Owner:          db.AccessKeyTaskSecret,
+		TaskID:         &taskID,
+		ExpireAt:       &expireAt,
+		String:         secrets,
+		OverrideSecret: true,
+	}
+
+	if err := s.SerializeSecret(&key); err != nil {
+		return err
+	}
+
+	_, err := s.accessKeyRepo.CreateAccessKey(key)
+	return err
+}
+
+// GetTaskSurveySecrets returns the decrypted survey-secrets JSON of a task.
+// A task without survey secrets yields "" with no error; an expired secret
+// yields ErrAccessKeyExpired.
+func (s *accessKeyEncryptionServiceImpl) GetTaskSurveySecrets(projectID int, taskID int) (string, error) {
+	key, err := s.accessKeyRepo.GetTaskAccessKey(projectID, taskID)
+
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	if err = s.DeserializeSecret(&key); err != nil {
+		return "", err
+	}
+
+	return key.String, nil
+}
+
+// DeleteTaskSurveySecrets removes the task-bound secret once the task has
+// reached a terminal state. Missing keys are not an error.
+func (s *accessKeyEncryptionServiceImpl) DeleteTaskSurveySecrets(projectID int, taskID int) error {
+	return s.accessKeyRepo.DeleteTaskAccessKeys(projectID, taskID)
+}

--- a/services/server/task_secret_svc_test.go
+++ b/services/server/task_secret_svc_test.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/semaphoreui/semaphore/db"
+	"github.com/semaphoreui/semaphore/pkg/tz"
+	"github.com/semaphoreui/semaphore/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// taskSecretRepoMock overrides only the methods used by the task-secret
+// service; any other call panics via the embedded nil interface.
+type taskSecretRepoMock struct {
+	db.AccessKeyManager
+
+	created *db.AccessKey
+	stored  *db.AccessKey
+	deleted bool
+}
+
+func (m *taskSecretRepoMock) CreateAccessKey(key db.AccessKey) (db.AccessKey, error) {
+	m.created = &key
+	return key, nil
+}
+
+func (m *taskSecretRepoMock) GetTaskAccessKey(int, int) (db.AccessKey, error) {
+	if m.stored == nil {
+		return db.AccessKey{}, db.ErrNotFound
+	}
+	return *m.stored, nil
+}
+
+func (m *taskSecretRepoMock) DeleteTaskAccessKeys(int, int) error {
+	m.deleted = true
+	return nil
+}
+
+func TestCreateTaskSurveySecrets(t *testing.T) {
+	util.Config = &util.ConfigType{}
+	repo := &taskSecretRepoMock{}
+	svc := NewAccessKeyEncryptionService(repo, nil, nil, nil)
+
+	expireAt := tz.Now().Add(time.Hour)
+	err := svc.CreateTaskSurveySecrets(1, 42, `{"passwd":"123456"}`, expireAt)
+
+	require.NoError(t, err)
+	require.NotNil(t, repo.created)
+	assert.Equal(t, db.AccessKeyTaskSecret, repo.created.Owner)
+	assert.Equal(t, db.AccessKeyString, repo.created.Type)
+	assert.Equal(t, "task-42-survey-secrets", repo.created.Name)
+	require.NotNil(t, repo.created.TaskID)
+	assert.Equal(t, 42, *repo.created.TaskID)
+	require.NotNil(t, repo.created.ExpireAt)
+	assert.Equal(t, expireAt, *repo.created.ExpireAt)
+
+	// Without an encryption key configured the secret is base64-encoded.
+	require.NotNil(t, repo.created.Secret)
+	secret, err := base64.StdEncoding.DecodeString(*repo.created.Secret)
+	require.NoError(t, err)
+	assert.Equal(t, `{"passwd":"123456"}`, string(secret))
+}
+
+func TestGetTaskSurveySecrets(t *testing.T) {
+	util.Config = &util.ConfigType{}
+	expireAt := tz.Now().Add(time.Hour)
+	repo := &taskSecretRepoMock{
+		stored: &db.AccessKey{
+			Type:     db.AccessKeyString,
+			Owner:    db.AccessKeyTaskSecret,
+			ExpireAt: &expireAt,
+			Secret:   new(base64.StdEncoding.EncodeToString([]byte(`{"passwd":"123456"}`))),
+		},
+	}
+	svc := NewAccessKeyEncryptionService(repo, nil, nil, nil)
+
+	secrets, err := svc.GetTaskSurveySecrets(1, 42)
+
+	require.NoError(t, err)
+	assert.Equal(t, `{"passwd":"123456"}`, secrets)
+}
+
+func TestGetTaskSurveySecrets_NotFound(t *testing.T) {
+	util.Config = &util.ConfigType{}
+	svc := NewAccessKeyEncryptionService(&taskSecretRepoMock{}, nil, nil, nil)
+
+	secrets, err := svc.GetTaskSurveySecrets(1, 42)
+
+	require.NoError(t, err)
+	assert.Empty(t, secrets)
+}
+
+func TestGetTaskSurveySecrets_Expired(t *testing.T) {
+	util.Config = &util.ConfigType{}
+	expireAt := tz.Now().Add(-time.Minute)
+	repo := &taskSecretRepoMock{
+		stored: &db.AccessKey{
+			Type:     db.AccessKeyString,
+			Owner:    db.AccessKeyTaskSecret,
+			ExpireAt: &expireAt,
+			Secret:   new(base64.StdEncoding.EncodeToString([]byte(`{"passwd":"123456"}`))),
+		},
+	}
+	svc := NewAccessKeyEncryptionService(repo, nil, nil, nil)
+
+	_, err := svc.GetTaskSurveySecrets(1, 42)
+
+	assert.ErrorIs(t, err, ErrAccessKeyExpired)
+}
+
+func TestDeleteTaskSurveySecrets(t *testing.T) {
+	repo := &taskSecretRepoMock{}
+	svc := NewAccessKeyEncryptionService(repo, nil, nil, nil)
+
+	err := svc.DeleteTaskSurveySecrets(1, 42)
+
+	require.NoError(t, err)
+	assert.True(t, repo.deleted)
+}
+
+func TestDeserializeSecret_ExpireAt(t *testing.T) {
+	util.Config = &util.ConfigType{}
+	svc := NewAccessKeyEncryptionService(nil, nil, nil, nil)
+
+	past := tz.Now().Add(-time.Minute)
+	future := tz.Now().Add(time.Minute)
+	secret := base64.StdEncoding.EncodeToString([]byte("value"))
+
+	tests := []struct {
+		name     string
+		expireAt *time.Time
+		expired  bool
+	}{
+		{"no expiry", nil, false},
+		{"future expiry", &future, false},
+		{"past expiry", &past, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := db.AccessKey{
+				Type:     db.AccessKeyString,
+				ExpireAt: tt.expireAt,
+				Secret:   &secret,
+			}
+
+			err := svc.DeserializeSecret(&key)
+
+			if tt.expired {
+				assert.ErrorIs(t, err, ErrAccessKeyExpired)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, "value", key.String)
+			}
+		})
+	}
+}

--- a/services/tasks/TaskPool.go
+++ b/services/tasks/TaskPool.go
@@ -551,13 +551,19 @@ func (p *TaskPool) hydrateTaskRunner(taskID int, projectID int) (*TaskRunner, er
 		job = &RemoteJob{RunnerTag: tag, Task: tr.Task, taskPool: p}
 	} else {
 		app := db_lib.CreateApp(tr.Template, tr.Repository, tr.Inventory, tr)
+
+		secret, sErr := p.encryptionService.GetTaskSurveySecrets(projectID, taskID)
+		if sErr != nil {
+			return nil, sErr
+		}
+
 		job = &LocalExecutor{
 			Task:         tr.Task,
 			Template:     tr.Template,
 			Inventory:    tr.Inventory,
 			Repository:   tr.Repository,
 			Environment:  tr.Environment,
-			Secret:       "{}",
+			Secret:       secret,
 			Logger:       app.SetLogger(tr),
 			App:          app,
 			KeyInstaller: p.keyInstallationService,
@@ -942,7 +948,7 @@ func (p *TaskPool) GetQueuedTasks() []*TaskRunner {
 // hasSurveySecrets reports whether the task-supplied secret payload contains
 // at least one survey secret variable (a non-empty JSON object).
 func hasSurveySecrets(secretVars string) bool {
-	if secretVars == "" || secretVars == "{}" {
+	if secretVars == "" {
 		return false
 	}
 
@@ -1019,7 +1025,7 @@ func (p *TaskPool) AddTask(
 	taskObj.UserID = userID
 	taskObj.ProjectID = projectID
 	extraSecretVars := taskObj.Secret
-	taskObj.Secret = "{}"
+	taskObj.Secret = ""
 
 	tpl, err := p.store.GetTemplate(projectID, taskObj.TemplateID)
 	if err != nil {

--- a/services/tasks/TaskPool.go
+++ b/services/tasks/TaskPool.go
@@ -552,18 +552,18 @@ func (p *TaskPool) hydrateTaskRunner(taskID int, projectID int) (*TaskRunner, er
 	} else {
 		app := db_lib.CreateApp(tr.Template, tr.Repository, tr.Inventory, tr)
 
-		secret, sErr := p.encryptionService.GetTaskSurveySecrets(projectID, taskID)
-		if sErr != nil {
-			return nil, sErr
-		}
-
+		// Leave Secret empty. This snapshot is used only to change task status
+		// (stop/confirm/reject) and to restore tasks after restart -- it never runs
+		// the task, so it does not need the secrets. Reading them here would make
+		// those operations fail when a secret is expired or unreadable. The secrets
+		// are read by run(), right before the task actually starts.
 		job = &LocalExecutor{
 			Task:         tr.Task,
 			Template:     tr.Template,
 			Inventory:    tr.Inventory,
 			Repository:   tr.Repository,
 			Environment:  tr.Environment,
-			Secret:       secret,
+			Secret:       "",
 			Logger:       app.SetLogger(tr),
 			App:          app,
 			KeyInstaller: p.keyInstallationService,

--- a/services/tasks/TaskPool.go
+++ b/services/tasks/TaskPool.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -218,6 +219,7 @@ func (p *TaskPool) Run() {
 
 	go p.handleQueue()
 	go p.handleLogs()
+	go p.taskSecretSweepLoop()
 	go func() {
 		// reconcileDone lets Stop block until the reconcile loop has actually
 		// finished reading shared state (e.g. util.Config). Closing it here,
@@ -937,6 +939,54 @@ func (p *TaskPool) GetQueuedTasks() []*TaskRunner {
 	return p.state.QueueRange()
 }
 
+// hasSurveySecrets reports whether the task-supplied secret payload contains
+// at least one survey secret variable (a non-empty JSON object).
+func hasSurveySecrets(secretVars string) bool {
+	if secretVars == "" || secretVars == "{}" {
+		return false
+	}
+
+	vars := make(map[string]any)
+	if err := json.Unmarshal([]byte(secretVars), &vars); err != nil {
+		return false
+	}
+
+	return len(vars) > 0
+}
+
+// taskSecretExpireAt returns the expiry moment for a task's survey-secret key:
+// MaxTaskDurationSec plus an hour of queue allowance when the limit is set,
+// otherwise 24 hours. Expiry is a backstop — the key is deleted when the task
+// reaches a terminal state.
+func taskSecretExpireAt() time.Time {
+	ttl := 24 * time.Hour
+	if util.Config.MaxTaskDurationSec > 0 {
+		ttl = time.Duration(util.Config.MaxTaskDurationSec)*time.Second + time.Hour
+	}
+	return tz.Now().Add(ttl)
+}
+
+// taskSecretSweepLoop deletes expired task-bound survey-secret keys once at
+// startup and then hourly. finishRun's delete is the primary cleanup; the
+// sweep covers tasks that never reached it (e.g. node crash). It runs on every
+// HA node — the delete is idempotent, so concurrent sweeps are safe.
+func (p *TaskPool) taskSecretSweepLoop() {
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+
+	for {
+		if err := p.store.DeleteExpiredTaskAccessKeys(); err != nil {
+			log.WithError(err).Error("failed to delete expired task survey secrets")
+		}
+
+		select {
+		case <-ticker.C:
+		case <-p.stop:
+			return
+		}
+	}
+}
+
 // AddTask creates and queues a new task for execution in the task pool.
 //
 // Parameters:
@@ -1020,6 +1070,19 @@ func (p *TaskPool) AddTask(
 		taskRunner.Log("Error: " + err.Error())
 		taskRunner.SetStatus(task_logger.TaskFailStatus)
 		return
+	}
+
+	// Persist survey secret variables as a task-bound, expiring access key so
+	// any HA node can decrypt them at dispatch time (local or remote runner).
+	// The plaintext never reaches the task row, API payloads, or events.
+	if hasSurveySecrets(extraSecretVars) {
+		err = p.encryptionService.CreateTaskSurveySecrets(
+			projectID, newTask.ID, extraSecretVars, taskSecretExpireAt())
+		if err != nil {
+			taskRunner.Log("Error: failed to store survey secrets: " + err.Error())
+			taskRunner.SetStatus(task_logger.TaskFailStatus)
+			return
+		}
 	}
 
 	var job Job

--- a/services/tasks/TaskRunner.go
+++ b/services/tasks/TaskRunner.go
@@ -263,7 +263,7 @@ func (t *TaskRunner) run() {
 					ProjectID:  t.Task.ProjectID,
 					TemplateID: t.Template.ID,
 					UserID:     t.Task.UserID,
-					Audience:   jwt.Audience(t.Template.JWTParams.Audience),
+					Audience:   t.Template.JWTParams.Audience,
 					TTL:        ttl,
 				})
 				if jerr != nil {

--- a/services/tasks/TaskRunner.go
+++ b/services/tasks/TaskRunner.go
@@ -325,6 +325,16 @@ func (t *TaskRunner) finishRun() {
 	now := tz.Now()
 	t.Task.End = &now
 	t.saveStatus()
+
+	// The task-bound survey-secret key is only needed until dispatch; drop it
+	// as soon as the task is terminal. Failure is non-fatal: the expired-key
+	// sweep and the task_id cascade remain as backstops.
+	if t.pool.encryptionService != nil {
+		if err := t.pool.encryptionService.DeleteTaskSurveySecrets(t.Task.ProjectID, t.Task.ID); err != nil {
+			log.WithError(err).WithField("task_id", t.Task.ID).Warn("failed to delete task survey secrets")
+		}
+	}
+
 	t.createTaskEvent()
 	t.pool.queueEvents <- PoolEvent{EventTypeFinished, t}
 

--- a/services/tasks/TaskRunner.go
+++ b/services/tasks/TaskRunner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/semaphoreui/semaphore/pkg/jwt"
 	"github.com/semaphoreui/semaphore/pkg/tz"
 	"github.com/semaphoreui/semaphore/pro_interfaces"
+	"github.com/semaphoreui/semaphore/services/server"
 	"github.com/semaphoreui/semaphore/services/tasks/hooks"
 
 	"github.com/semaphoreui/semaphore/api/sockets"
@@ -249,6 +250,27 @@ func (t *TaskRunner) run() {
 	// can be exposed to the playbook as SEMAPHORE_JWT. Remote runners receive
 	// the JWT inside the JobData payload returned by the API.
 	if localJob, ok := t.job.(*LocalExecutor); ok {
+
+		secret, sErr := t.pool.encryptionService.GetTaskSurveySecrets(t.Task.ProjectID, t.Task.ID)
+		if sErr != nil {
+			logger := log.WithError(sErr).WithFields(log.Fields{
+				"task_id":     t.Task.ID,
+				"template_id": t.Template.ID,
+				"context":     "survey_secrets",
+			})
+			if errors.Is(sErr, server.ErrAccessKeyExpired) {
+				logger.Warn("task survey secrets expired before start")
+				t.Log("Survey secrets expired before the task started. Please run the task again.")
+			} else {
+				logger.Error("failed to read task survey secrets")
+				t.Log("Failed to read survey secrets. More details in the server logs.")
+			}
+			t.SetStatus(task_logger.TaskFailStatus)
+			return
+		}
+
+		localJob.Secret = secret
+
 		if t.pool.signer != nil && t.Template.JWTParams != nil && t.Template.JWTParams.Enabled {
 			ttl, terr := t.Template.JWTParams.ParsedTTL()
 			if terr != nil {
@@ -256,25 +278,32 @@ func (t *TaskRunner) run() {
 					"task_id":     t.Task.ID,
 					"template_id": t.Template.ID,
 					"context":     "jwt",
-				}).Error("invalid template jwt_params.ttl; skipping token issuance")
-			} else {
-				token, jerr := t.pool.signer.Sign(jwt.TaskInfo{
-					TaskID:     t.Task.ID,
-					ProjectID:  t.Task.ProjectID,
-					TemplateID: t.Template.ID,
-					UserID:     t.Task.UserID,
-					Audience:   t.Template.JWTParams.Audience,
-					TTL:        ttl,
-				})
-				if jerr != nil {
-					log.WithError(jerr).WithFields(log.Fields{
-						"task_id": t.Task.ID,
-						"context": "jwt",
-					}).Error("failed to sign task JWT")
-				} else {
-					localJob.JWT = token
-				}
+				}).Warn("invalid template jwt_params.ttl")
+				t.Log("Invalid JWT token lifetime in the template settings: " + terr.Error())
+				t.SetStatus(task_logger.TaskFailStatus)
+				return
 			}
+
+			token, jerr := t.pool.signer.Sign(jwt.TaskInfo{
+				TaskID:     t.Task.ID,
+				ProjectID:  t.Task.ProjectID,
+				TemplateID: t.Template.ID,
+				UserID:     t.Task.UserID,
+				Audience:   t.Template.JWTParams.Audience,
+				TTL:        ttl,
+			})
+
+			if jerr != nil {
+				log.WithError(jerr).WithFields(log.Fields{
+					"task_id": t.Task.ID,
+					"context": "jwt",
+				}).Error("failed to sign task JWT")
+				t.Log("Failed to sign the task JWT. More details in the server logs.")
+				t.SetStatus(task_logger.TaskFailStatus)
+				return
+			}
+
+			localJob.JWT = token
 		}
 	}
 

--- a/services/tasks/TaskRunner_test.go
+++ b/services/tasks/TaskRunner_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/semaphoreui/semaphore/db/sql"
 	"github.com/semaphoreui/semaphore/pkg/ssh"
@@ -57,6 +58,18 @@ func (s *EncryptionServiceMock) FillEnvironmentSecrets(env *db.Environment, dese
 	return nil
 }
 
+func (s *EncryptionServiceMock) CreateTaskSurveySecrets(projectID int, taskID int, secrets string, expireAt time.Time) error {
+	return nil
+}
+
+func (s *EncryptionServiceMock) GetTaskSurveySecrets(projectID int, taskID int) (string, error) {
+	return "", nil
+}
+
+func (s *EncryptionServiceMock) DeleteTaskSurveySecrets(projectID int, taskID int) error {
+	return nil
+}
+
 type mockLogWriteService struct {
 }
 
@@ -81,7 +94,7 @@ func TestTaskRunnerRun(t *testing.T) {
 		&MemoryTaskStateStore{},
 		nil,
 		&InventoryServiceMock{},
-		nil,
+		&EncryptionServiceMock{},
 		keyInstaller,
 		&mockLogWriteService{},
 		nil,

--- a/services/tasks/local_executor_provider.go
+++ b/services/tasks/local_executor_provider.go
@@ -36,11 +36,14 @@ func NewLocalExecutorProvider(keyInstaller db_lib.AccessKeyInstaller) *LocalExec
 // non-nil App — Prepare's contract is "do the I/O", not "build the structure".
 func (p *LocalExecutorProvider) NewExecutor(task db.Task, template db.Template, inventory db.Inventory, repository db.Repository, environment db.Environment, jwt string) (Executor, error) {
 	return &LocalExecutor{
-		Task:         task,
-		Template:     template,
-		Inventory:    inventory,
-		Repository:   repository,
-		Environment:  environment,
+		Task:        task,
+		Template:    template,
+		Inventory:   inventory,
+		Repository:  repository,
+		Environment: environment,
+		// Survey secret variables delivered by the server in the job payload
+		// (see JobData in the runner API).
+		Secret:       task.Secret,
 		KeyInstaller: p.keyInstaller,
 		App:          db_lib.CreateApp(template, repository, inventory, nil),
 		JWT:          jwt,

--- a/services/tasks/local_executor_test.go
+++ b/services/tasks/local_executor_test.go
@@ -58,3 +58,25 @@ func TestGetEnvironmentExtraVars_MergesSecret(t *testing.T) {
 	assert.Equal(t, "hello", extraVars["PLAIN_VAR"])
 	assert.Equal(t, "s3cr3t", extraVars["MY_VAR"])
 }
+
+// TestGetEnvironmentExtraVars_EmptySecret pins that "" and "{}" are equivalent
+// "no survey secrets" values: "" comes from DB-loaded tasks and API clients
+// omitting the field, "{}" from the UI and the AddTask sanitization.
+func TestGetEnvironmentExtraVars_EmptySecret(t *testing.T) {
+	setupExecutorConfig(t)
+
+	for _, secret := range []string{"", "{}"} {
+		t.Run("secret "+secret, func(t *testing.T) {
+			exec := &LocalExecutor{
+				Environment: db.Environment{JSON: `{"PLAIN_VAR":"hello"}`},
+				Secret:      secret,
+			}
+
+			extraVars, err := exec.getEnvironmentExtraVars("admin", nil)
+			require.NoError(t, err)
+
+			assert.Equal(t, "hello", extraVars["PLAIN_VAR"])
+			assert.Len(t, extraVars, 2) // PLAIN_VAR + semaphore_vars only
+		})
+	}
+}

--- a/services/tasks/task_secret_test.go
+++ b/services/tasks/task_secret_test.go
@@ -1,0 +1,53 @@
+package tasks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/semaphoreui/semaphore/pkg/tz"
+	"github.com/semaphoreui/semaphore/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasSurveySecrets(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"empty string", "", false},
+		{"empty object", "{}", false},
+		{"invalid json", "not-json", false},
+		{"json array", `["a"]`, false},
+		{"one secret", `{"passwd":"123456"}`, true},
+		{"several secrets", `{"a":"1","b":"2"}`, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, hasSurveySecrets(tt.input))
+		})
+	}
+}
+
+func TestTaskSecretExpireAt(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxDurationSec int
+		expectedTTL    time.Duration
+	}{
+		{"unlimited task duration", 0, 24 * time.Hour},
+		{"limited task duration", 3600, time.Hour + time.Hour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			util.Config = &util.ConfigType{MaxTaskDurationSec: tt.maxDurationSec}
+
+			expireAt := taskSecretExpireAt()
+
+			ttl := expireAt.Sub(tz.Now())
+			assert.InDelta(t, tt.expectedTTL.Seconds(), ttl.Seconds(), 5)
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes how survey secrets are stored, encrypted, dispatched to runners, and cleaned up; mistakes could leak secrets, drop them silently, or break HA/remote execution.
> 
> **Overview**
> Fixes **survey secret variables arriving empty on remote runners** and **not surviving server restarts or HA dispatch** by persisting them in the shared DB instead of only in memory on the node that accepted the task.
> 
> On task creation, non-empty survey secret JSON is written as an **`access_key`** row with owner `task`, `task_id`, and **`expire_at`** (TTL from `MaxTaskDurationSec` + 1h, or 24h when unlimited). Creation failure **fails the task**; the task row still keeps `secret` as `{}`. **Runner poll** loads secrets via `GetTaskSurveySecrets`, sets `jobData.Task.Secret`, and **fails the task** if decrypt/expiry fails rather than dispatching empty vars. **`LocalExecutorProvider`** passes `task.Secret` into the executor so runners actually merge survey vars.
> 
> **`DeserializeSecret`** rejects expired keys (`ErrAccessKeyExpired`). Keys are **deleted on `finishRun`**, with an **hourly expired-key sweep** as backstop. Task-owned keys are **hidden from project key APIs**, **omitted from backups**, and cascade-delete with the task.
> 
> **Note:** Local execution in `AddTask` still wires `LocalExecutor.Secret` from in-memory `extraSecretVars` at enqueue time (plan called for DB read at local dispatch too—that may be follow-up).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac555267bf6f1dbdfb531a89b334165ae0b4394a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve survey secret variables for both remote runner dispatch and local execution.
  * Fetch task-scoped secrets per task; failures affect only the impacted task.
  * Enforce expiration automatically and delete expired secrets; task secrets no longer appear in backups.
  * Local task JWT TTL/signing failures now correctly fail the task.
* **Security**
  * Isolate task-scoped secrets from generic key endpoints and ensure encrypted, non-leakage handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->