### PR TITLE
feat/executor image in template

### DIFF
--- a/api-docs.yml
+++ b/api-docs.yml
@@ -1039,6 +1039,12 @@ definitions:
           $ref: "#/definitions/TemplateVault"
       task_params:
         $ref: '#/definitions/TaskPrams'
+      executor_image:
+        type: string
+        description: >-
+          Container image used to run the task by the Docker and Kubernetes runner
+          executors. Empty means the image configured on the runner is used.
+        example: semaphoreui/job:latest
 
   TemplateSurveyVar:
     type: object

--- a/db/Migration.go
+++ b/db/Migration.go
@@ -131,6 +131,7 @@ func GetMigrations(dialect string) []Migration {
 		{Version: "2.18.15"},
 		{Version: "2.19.2"},
 		{Version: "2.19.11"},
+		{Version: "2.19.12"},
 		{Version: "2.20.0"},
 		{Version: "2.20.1"},
 	}

--- a/db/Template.go
+++ b/db/Template.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/semaphoreui/semaphore/pkg/common_errors"
 	"github.com/semaphoreui/semaphore/pkg/git"
@@ -190,6 +191,12 @@ type Template struct {
 
 	RunnerTag *string `db:"runner_tag" json:"runner_tag,omitempty"`
 
+	// ExecutorImage overrides the container image the runner uses to run this
+	// template's tasks. Only the container-based executors (Docker, Kubernetes)
+	// honour it; the local executor ignores it. Empty/nil means "use the image
+	// from the runner configuration".
+	ExecutorImage *string `db:"executor_image" json:"executor_image,omitempty"`
+
 	AllowOverrideBranchInTask bool `db:"allow_override_branch_in_task" json:"allow_override_branch_in_task,omitempty"`
 	//AllowOverrideEnvInTask    bool `db:"allow_override_env_in_task" json:"allow_override_env_in_task,omitempty"`
 	AllowParallelTasks bool `db:"allow_parallel_tasks" json:"allow_parallel_tasks,omitempty"`
@@ -209,6 +216,23 @@ func (tpl *Template) FillParams(target any) error {
 	}
 	err = json.Unmarshal(content, target)
 	return err
+}
+
+// NormalizedExecutorImage returns the value to persist. Clearing the field in the
+// WebUI sends an empty string; storing it as NULL keeps "no override" a single
+// representation in the database.
+func (tpl *Template) NormalizedExecutorImage() *string {
+	if tpl.ExecutorImage == nil {
+		return nil
+	}
+
+	img := strings.TrimSpace(*tpl.ExecutorImage)
+
+	if img == "" {
+		return nil
+	}
+
+	return &img
 }
 
 func (tpl *Template) CanOverrideInventory() (ok bool, err error) {

--- a/db/Template_test.go
+++ b/db/Template_test.go
@@ -53,3 +53,22 @@ func TestTemplateValidate_SurveyVarTarget(t *testing.T) {
 		})
 	}
 }
+
+func TestTemplateNormalizedExecutorImage(t *testing.T) {
+	t.Run("no override is stored as NULL", func(t *testing.T) {
+		for _, image := range []*string{nil, new(""), new("   ")} {
+			tpl := Template{ExecutorImage: image}
+			assert.Nil(t, tpl.NormalizedExecutorImage())
+		}
+	})
+
+	t.Run("override is stored trimmed", func(t *testing.T) {
+		tpl := Template{ExecutorImage: new(" my-registry/job:1 ")}
+		require.NotNil(t, tpl.NormalizedExecutorImage())
+		assert.Equal(t, "my-registry/job:1", *tpl.NormalizedExecutorImage())
+	})
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/db/sql/migrations/v2.19.12.err.sql
+++ b/db/sql/migrations/v2.19.12.err.sql
@@ -1,0 +1,1 @@
+alter table `project__template` drop column `executor_image`;

--- a/db/sql/migrations/v2.19.12.sql
+++ b/db/sql/migrations/v2.19.12.sql
@@ -1,0 +1,1 @@
+alter table `project__template` add column `executor_image` varchar(255) null;

--- a/db/sql/template.go
+++ b/db/sql/template.go
@@ -26,13 +26,13 @@ func (d *SqlDb) CreateTemplate(template db.Template) (newTemplate db.Template, e
 			"playbook, arguments, allow_override_args_in_task, description, `type`, "+
 			"start_version, build_template_id, view_id, autorun, survey_vars, "+
 			"suppress_success_alerts, app, git_branch, runner_tag, task_params, "+
-			"allow_override_branch_in_task, allow_parallel_tasks, jwt_params)"+
+			"allow_override_branch_in_task, allow_parallel_tasks, jwt_params, executor_image)"+
 			"values ("+
 			"?, ?, ?, ?, "+
 			"?, ?, ?, ?, ?, "+
 			"?, ?, ?, ?, ?, "+
 			"?, ?, ?, ?, ?,"+
-			"?, ?, ?)",
+			"?, ?, ?, ?)",
 		template.ProjectID,
 		template.InventoryID,
 		template.RepositoryID,
@@ -59,6 +59,7 @@ func (d *SqlDb) CreateTemplate(template db.Template) (newTemplate db.Template, e
 		template.AllowOverrideBranchInTask,
 		template.AllowParallelTasks,
 		template.JWTParams,
+		template.NormalizedExecutorImage(),
 	)
 
 	if err != nil {
@@ -115,7 +116,8 @@ func (d *SqlDb) UpdateTemplate(template db.Template) error {
 		"runner_tag=?, "+
 		"allow_override_branch_in_task=?, "+
 		"allow_parallel_tasks=?, "+
-		"jwt_params=? "+
+		"jwt_params=?, "+
+		"executor_image=? "+
 		"where id=? and project_id=?",
 		template.InventoryID,
 		template.RepositoryID,
@@ -138,6 +140,7 @@ func (d *SqlDb) UpdateTemplate(template db.Template) error {
 		template.AllowOverrideBranchInTask,
 		template.AllowParallelTasks,
 		template.JWTParams,
+		template.NormalizedExecutorImage(),
 
 		template.ID,
 		template.ProjectID,
@@ -280,6 +283,7 @@ func (d *SqlDb) getTemplates(
 		"pt.allow_override_branch_in_task",
 		"pt.allow_parallel_tasks",
 		"pt.jwt_params",
+		"pt.executor_image",
 		"(SELECT `id` FROM `task` WHERE template_id = pt.id ORDER BY `id` DESC LIMIT 1) last_task_id",
 	}
 

--- a/db/sql/template_test.go
+++ b/db/sql/template_test.go
@@ -37,7 +37,7 @@ func newTemplateTestProject(t *testing.T, store *SqlDb) (projectID int, reposito
 // TestTemplateExecutorImageRoundTrip checks project__template.executor_image is
 // written, read back, updated and cleared through the store.
 func TestTemplateExecutorImageRoundTrip(t *testing.T) {
-	store := CreateTestStore()
+	store := InitConfigCreateTestStore()
 	projectID, repositoryID := newTemplateTestProject(t, store)
 
 	image := "my-registry/job:1.2"
@@ -82,7 +82,7 @@ func TestTemplateExecutorImageRoundTrip(t *testing.T) {
 // TestTemplateWithoutExecutorImage guards the common case: a template that does
 // not override the image reads back as nil rather than failing to scan NULL.
 func TestTemplateWithoutExecutorImage(t *testing.T) {
-	store := CreateTestStore()
+	store := InitConfigCreateTestStore()
 	projectID, repositoryID := newTemplateTestProject(t, store)
 
 	created, err := store.CreateTemplate(db.Template{

--- a/db/sql/template_test.go
+++ b/db/sql/template_test.go
@@ -1,0 +1,99 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/semaphoreui/semaphore/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTemplateTestProject creates the project + repository a template needs to
+// satisfy its foreign keys, and returns the repository id to attach templates to.
+func newTemplateTestProject(t *testing.T, store *SqlDb) (projectID int, repositoryID int) {
+	t.Helper()
+
+	project, err := store.CreateProject(db.Project{Name: "proj"})
+	require.NoError(t, err)
+
+	key, err := store.CreateAccessKey(db.AccessKey{
+		ProjectID: &project.ID,
+		Type:      db.AccessKeyNone,
+	})
+	require.NoError(t, err)
+
+	repo, err := store.CreateRepository(db.Repository{
+		ProjectID: project.ID,
+		Name:      "repo",
+		GitURL:    "https://example.com/repo.git",
+		GitBranch: "main",
+		SSHKeyID:  key.ID,
+	})
+	require.NoError(t, err)
+
+	return project.ID, repo.ID
+}
+
+// TestTemplateExecutorImageRoundTrip checks project__template.executor_image is
+// written, read back, updated and cleared through the store.
+func TestTemplateExecutorImageRoundTrip(t *testing.T) {
+	store := CreateTestStore()
+	projectID, repositoryID := newTemplateTestProject(t, store)
+
+	image := "my-registry/job:1.2"
+	created, err := store.CreateTemplate(db.Template{
+		ProjectID:     projectID,
+		RepositoryID:  repositoryID,
+		Name:          "with-image",
+		Playbook:      "site.yml",
+		ExecutorImage: &image,
+	})
+	require.NoError(t, err)
+
+	loaded, err := store.GetTemplate(projectID, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, image, *loaded.ExecutorImage)
+
+	// getTemplates() builds its own column list, so it needs asserting separately.
+	listed, err := store.GetTemplates(projectID, db.TemplateFilter{}, db.RetrieveQueryParams{})
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Equal(t, image, *listed[0].ExecutorImage)
+
+	newImage := "my-registry/job:2.0"
+	loaded.ExecutorImage = &newImage
+	require.NoError(t, store.UpdateTemplate(loaded))
+
+	loaded, err = store.GetTemplate(projectID, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, newImage, *loaded.NormalizedExecutorImage())
+
+	// Clearing the field in the WebUI sends "", which must be stored as NULL.
+	blank := ""
+	loaded.ExecutorImage = &blank
+	require.NoError(t, store.UpdateTemplate(loaded))
+
+	loaded, err = store.GetTemplate(projectID, created.ID)
+	require.NoError(t, err)
+	assert.Nil(t, loaded.NormalizedExecutorImage())
+	assert.Empty(t, loaded.ExecutorImage)
+}
+
+// TestTemplateWithoutExecutorImage guards the common case: a template that does
+// not override the image reads back as nil rather than failing to scan NULL.
+func TestTemplateWithoutExecutorImage(t *testing.T) {
+	store := CreateTestStore()
+	projectID, repositoryID := newTemplateTestProject(t, store)
+
+	created, err := store.CreateTemplate(db.Template{
+		ProjectID:    projectID,
+		RepositoryID: repositoryID,
+		Name:         "no-image",
+		Playbook:     "site.yml",
+	})
+	require.NoError(t, err)
+
+	loaded, err := store.GetTemplate(projectID, created.ID)
+	require.NoError(t, err)
+	assert.Nil(t, loaded.ExecutorImage)
+}

--- a/pro_interfaces/featues.go
+++ b/pro_interfaces/featues.go
@@ -10,4 +10,6 @@ type Features struct {
 	CustomRolesManagement     bool `json:"custom_roles_management"`
 	HighAvailability          bool `json:"high_availability"`
 	Workflows                 bool `json:"workflows"`
+	DockerExecutor            bool `json:"docker_executor"`
+	K8sExecutor               bool `json:"k8s_executor"`
 }

--- a/web/src/components/TemplateForm.vue
+++ b/web/src/components/TemplateForm.vue
@@ -334,6 +334,33 @@
             clearable
           ></v-autocomplete>
 
+          <div style="position: relative">
+            <v-text-field
+              v-model="item.executor_image"
+              :label="$t('executor_image')"
+              :hint="$t('executor_image_hint')"
+              persistent-hint
+              placeholder="semaphoreui/job:latest"
+              outlined
+              dense
+              clearable
+              class="mb-4"
+              :disabled="formSaving || !isExecutorImageAvailable"
+            ></v-text-field>
+
+            <v-chip
+              v-if="!isExecutorImageAvailable"
+              color="hsl(348deg, 86%, 61%)"
+              text-color="white"
+              small
+              label
+              style="position: absolute; top: -10px; right: 15px"
+              @click="upgradeToPro('docker_executor')"
+            >
+              Upgrade to PRO
+            </v-chip>
+          </div>
+
           <SurveyVars :vars="surveyVars" @change="setSurveyVars" />
 
           <v-checkbox class="mt-0" v-model="item.allow_parallel_tasks">
@@ -721,6 +748,12 @@ export default {
   },
 
   computed: {
+    // The image override is only honoured by the container-based executors, which
+    // are themselves paid features: Docker in PRO, Kubernetes in Enterprise.
+    isExecutorImageAvailable() {
+      return !!(this.features?.docker_executor || this.features?.k8s_executor);
+    },
+
     argsJson: {
       get() {
         return JSON.stringify(this.args);
@@ -1012,6 +1045,12 @@ export default {
 
       if (!this.item.task_params) {
         this.item.task_params = {};
+      }
+
+      // The API omits executor_image when it is not set; declare it explicitly so
+      // the text field stays reactive for templates without an override.
+      if (this.item.executor_image === undefined) {
+        this.$set(this.item, 'executor_image', null);
       }
 
       if (!this.item.jwt_params) {

--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -434,6 +434,7 @@ export default {
   limit: 'Limit',
 
   runner_tag: 'Runner tag',
+  executor_image: 'Executor image',
   allow_parallel_tasks: 'Allow parallel tasks',
   jwt_enabled: 'Issue JWT to task runner',
   jwt_audience: 'JWT audience',


### PR DESCRIPTION
- **feat(executors): pass image from template**
- **feat(executors): pass image from template**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional **executor image** override to templates, enabling per-template Docker/Kubernetes runner container image selection.
  * Updated template creation, update, retrieval, and clearing so the setting is persisted and reflected consistently.
  * Extended the API specification and added new i18n text for the setting.
* **UI Improvements**
  * Added an advanced template form field with availability checks and a “Upgrade to PRO” prompt when restricted.
  * Improved template loading to handle templates that don’t include the setting.
* **Tests**
  * Added coverage for round-trip storage and normalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->