### PR TITLE
Feat/ldap tls verify

### DIFF
--- a/api/login.go
+++ b/api/login.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -44,18 +45,56 @@ func convertEntryToMap(entity *ldap.Entry) map[string]any {
 	return res
 }
 
+// ldapTLSConfig builds the TLS configuration used for LDAPS connections.
+//
+// SECURITY: certificates are verified unless the provider explicitly opts out
+// with tls_skip_verify. An unverified connection is open to MITM and the user's
+// password is sent over it, since authentication works by binding as the user.
+// The one opt-out that ships by default is the legacy flat ldap_* config, which
+// util.ActiveLdapProviders synthesizes with TLSSkipVerify because released
+// Semaphore never verified LDAPS and upgrading installs on self-signed certs
+// would otherwise be locked out. Point TLSCACertFile at your CA bundle to close
+// that hole — see issue #749.
+func ldapTLSConfig(provider util.LdapProvider) (*tls.Config, error) {
+	cfg := &tls.Config{
+		// #nosec G402 -- opt-out is deliberate and documented above.
+		InsecureSkipVerify: !provider.ShouldVerifyTLS(),
+	}
+
+	if provider.TLSCACertFile == "" {
+		return cfg, nil
+	}
+
+	caCert, err := os.ReadFile(provider.TLSCACertFile)
+	if err != nil {
+		return nil, fmt.Errorf("read ldap CA cert file %q: %w", provider.TLSCACertFile, err)
+	}
+
+	// Start from the system trust store so the supplied CA is additive rather
+	// than a replacement — a server presenting a publicly trusted cert must
+	// still verify. SystemCertPool returns a copy, so appending is safe.
+	pool, err := x509.SystemCertPool()
+	if err != nil || pool == nil {
+		pool = x509.NewCertPool()
+	}
+	if !pool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("no valid PEM certificates in ldap CA cert file %q", provider.TLSCACertFile)
+	}
+	cfg.RootCAs = pool
+
+	return cfg, nil
+}
+
 func tryFindLDAPUser(provider util.LdapProvider, username, password string) (*db.User, string, error) {
 	var l *ldap.Conn
 	var err error
 	if provider.NeedTLS {
-		// Verify the LDAP server certificate by default so a network attacker
-		// cannot impersonate the server to capture the bind credentials or a
-		// user's cleartext password. Verification can be disabled per provider
-		// via tls_skip_verify (default false) for trusted networks with
-		// self-signed certificates.
-		l, err = ldap.DialTLS("tcp", provider.Server, &tls.Config{
-			InsecureSkipVerify: provider.TLSSkipVerify, //nolint:gosec // opt-in via tls_skip_verify, defaults to false
-		})
+		var tlsConfig *tls.Config
+		tlsConfig, err = ldapTLSConfig(provider)
+		if err != nil {
+			return nil, "", err
+		}
+		l, err = ldap.DialTLS("tcp", provider.Server, tlsConfig)
 	} else {
 		l, err = ldap.Dial("tcp", provider.Server)
 	}

--- a/api/login_ldap_tls_test.go
+++ b/api/login_ldap_tls_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/semaphoreui/semaphore/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestCA generates a throwaway self-signed CA and returns its PEM path.
+func writeTestCA(t *testing.T) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(path, pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE", Bytes: der,
+	}), 0600))
+
+	return path
+}
+
+func TestLdapTLSConfig_DefaultsToVerify(t *testing.T) {
+	cfg, err := ldapTLSConfig(util.LdapProvider{})
+
+	require.NoError(t, err)
+	assert.False(t, cfg.InsecureSkipVerify, "a configured provider must verify by default")
+	assert.Nil(t, cfg.RootCAs, "no CA file means the system trust store is used")
+}
+
+// The legacy flat ldap_* config is synthesized with TLSSkipVerify set, so that
+// upgrading installs on self-signed certs keep working until they opt in.
+func TestLdapTLSConfig_SkipVerifyOptOut(t *testing.T) {
+	cfg, err := ldapTLSConfig(util.LdapProvider{TLSSkipVerify: true})
+
+	require.NoError(t, err)
+	assert.True(t, cfg.InsecureSkipVerify)
+	assert.Nil(t, cfg.RootCAs)
+}
+
+func TestLdapTLSConfig_CACertFileOverridesSkipVerify(t *testing.T) {
+	cfg, err := ldapTLSConfig(util.LdapProvider{TLSSkipVerify: true, TLSCACertFile: writeTestCA(t)})
+
+	require.NoError(t, err)
+	assert.False(t, cfg.InsecureSkipVerify, "supplying a CA forces verification on")
+	assert.NotNil(t, cfg.RootCAs)
+}
+
+func TestLdapTLSConfig_CACertFileEnablesVerification(t *testing.T) {
+	cfg, err := ldapTLSConfig(util.LdapProvider{TLSCACertFile: writeTestCA(t)})
+
+	require.NoError(t, err)
+	assert.False(t, cfg.InsecureSkipVerify, "supplying a CA implies opting into verification")
+	assert.NotNil(t, cfg.RootCAs)
+}
+
+func TestLdapTLSConfig_MissingCACertFile(t *testing.T) {
+	_, err := ldapTLSConfig(util.LdapProvider{TLSCACertFile: "/nonexistent/ca.pem"})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "read ldap CA cert file")
+}
+
+func TestLdapTLSConfig_InvalidPEM(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "garbage.pem")
+	require.NoError(t, os.WriteFile(path, []byte("not a certificate"), 0600))
+
+	_, err := ldapTLSConfig(util.LdapProvider{TLSCACertFile: path})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no valid PEM certificates")
+}

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -117,12 +117,23 @@ properties:
   ldap_searchfilter: { type: string }
   ldap_mappings:     { $ref: "#/$defs/LdapMappings" }
   ldap_needtls:      { type: boolean }
-  ldap_tls_skip_verify:
+  ldap_tls_ca_cert_file:
+    type: string
+    description: >
+      PEM bundle used to verify the LDAP server's certificate, in addition to
+      the system trust store. Set this when the server uses a self-signed or
+      internal-CA certificate. Setting it implies ldap_tls_verify.
+  ldap_tls_verify:
     type: boolean
     default: false
     description: >
-      Disable verification of the LDAP server's TLS certificate for the legacy
-      flat ldap_* config. Defaults to false (certificates are verified).
+      Verify the LDAP server's certificate chain and hostname for the legacy
+      flat ldap_* config. Defaults to false because released Semaphore has
+      never verified LDAPS certificates and upgrading installs must not be
+      locked out. An unverified LDAPS connection is open to MITM and the
+      user's password travels over it, so enable this (or set
+      ldap_tls_ca_cert_file) once your server presents a verifiable
+      certificate. Providers under ldap_providers verify by default.
   ldap_providers:
     type: object
     additionalProperties: { $ref: "#/$defs/LdapProvider" }
@@ -389,13 +400,6 @@ $defs:
       display_name: { type: string }
       server:       { type: string }
       need_tls:      { type: boolean }
-      tls_skip_verify:
-        type: boolean
-        default: false
-        description: >
-          Disable verification of the LDAP server's TLS certificate. Defaults to
-          false (certificates are verified). Only enable on trusted networks
-          with self-signed certificates.
       bind_dn:       { type: string }
       bind_password:
         type: string
@@ -406,6 +410,20 @@ $defs:
       color:        { type: string }
       icon:         { type: string, description: MDI icon name without the mdi- prefix. }
       order:        { type: integer }
+      tls_ca_cert_file:
+        type: string
+        description: >
+          PEM bundle used to verify this LDAP server's certificate, in addition
+          to the system trust store. Set this when the server uses a self-signed
+          or internal-CA certificate. Setting it forces verification on.
+      tls_skip_verify:
+        type: boolean
+        default: false
+        description: >
+          Disable verification of this LDAP server's certificate chain and
+          hostname. Defaults to false, so providers configured here verify the
+          certificate. An unverified LDAPS connection is open to MITM and the
+          user's password travels over it — prefer tls_ca_cert_file.
 
   OidcProvider:
     type: object

--- a/util/LdapProvider.go
+++ b/util/LdapProvider.go
@@ -6,22 +6,45 @@ import "sort"
 // (analog of OidcProvider for `oidc_providers`). Field JSON names mirror
 // the legacy flat ldap_* config options.
 type LdapProvider struct {
-	DisplayName string `json:"display_name"`
-	Server      string `json:"server"`
-	NeedTLS     bool   `json:"need_tls"`
-	// TLSSkipVerify disables verification of the LDAP server's TLS certificate.
-	// It defaults to false so certificates are verified: a network attacker
-	// cannot impersonate the LDAP server to capture bind or user credentials.
-	// Only enable it for trusted networks with self-signed certificates.
-	TLSSkipVerify bool          `json:"tls_skip_verify"`
-	BindDN        string        `json:"bind_dn"`
-	BindPassword  string        `json:"bind_password"`
-	SearchDN      string        `json:"search_dn"`
-	SearchFilter  string        `json:"search_filter"`
-	Mappings      *LdapMappings `json:"mappings"`
-	Color         string        `json:"color"`
-	Icon          string        `json:"icon"`
-	Order         int           `json:"order"`
+	DisplayName  string        `json:"display_name"`
+	Server       string        `json:"server"`
+	NeedTLS      bool          `json:"need_tls"`
+	BindDN       string        `json:"bind_dn"`
+	BindPassword string        `json:"bind_password"`
+	SearchDN     string        `json:"search_dn"`
+	SearchFilter string        `json:"search_filter"`
+	Mappings     *LdapMappings `json:"mappings"`
+	Color        string        `json:"color"`
+	Icon         string        `json:"icon"`
+	Order        int           `json:"order"`
+
+	// TLSCACertFile is a PEM bundle used to verify the LDAP server's
+	// certificate, in addition to the system trust store. Set this when the
+	// server uses a self-signed or internal-CA cert. Setting it implies
+	// TLSVerify.
+	TLSCACertFile string `json:"tls_ca_cert_file"`
+
+	// TLSSkipVerify disables verification of the LDAP server's certificate
+	// chain and hostname when NeedTLS is set.
+	//
+	// It defaults to false, so a provider configured under `ldap_providers`
+	// verifies the server certificate. An unverified LDAPS connection is open
+	// to MITM and the user's password travels over it, since authentication
+	// works by binding as the user — so only enable this on a trusted network
+	// with a self-signed certificate, and prefer TLSCACertFile instead.
+	//
+	// The legacy flat ldap_* config is the exception: released Semaphore has
+	// never verified LDAPS certificates, so ActiveLdapProviders synthesizes
+	// the "ldap" entry with this set unless the operator opts in via
+	// ldap_tls_verify. See issue #749.
+	TLSSkipVerify bool `json:"tls_skip_verify"`
+}
+
+// ShouldVerifyTLS reports whether the LDAP server's certificate must be
+// verified. Supplying a CA bundle counts as opting in: configuring a CA only
+// makes sense if it is meant to be checked, so it overrides TLSSkipVerify.
+func (p LdapProvider) ShouldVerifyTLS() bool {
+	return p.TLSCACertFile != "" || !p.TLSSkipVerify
 }
 
 // GetMappings returns the attribute mappings, falling back to the same
@@ -49,15 +72,22 @@ func (conf *ConfigType) ActiveLdapProviders() (res []LdapProviderEntry) {
 		res = append(res, LdapProviderEntry{
 			ID: "ldap",
 			Provider: LdapProvider{
-				DisplayName:   "LDAP",
-				Server:        conf.LdapServer,
-				NeedTLS:       conf.LdapNeedTLS,
-				TLSSkipVerify: conf.LdapTLSSkipVerify,
-				BindDN:        conf.LdapBindDN,
-				BindPassword:  conf.LdapBindPassword,
-				SearchDN:      conf.LdapSearchDN,
-				SearchFilter:  conf.LdapSearchFilter,
-				Mappings:      conf.LdapMappings,
+				DisplayName:  "LDAP",
+				Server:       conf.LdapServer,
+				NeedTLS:      conf.LdapNeedTLS,
+				BindDN:       conf.LdapBindDN,
+				BindPassword: conf.LdapBindPassword,
+				SearchDN:     conf.LdapSearchDN,
+				SearchFilter: conf.LdapSearchFilter,
+				Mappings:     conf.LdapMappings,
+				// Existing installs upgraded into this release have never had
+				// their LDAPS certificate verified, and many use a self-signed
+				// cert. Verifying by default here would lock them out, so the
+				// legacy provider stays unverified until the operator opts in
+				// with ldap_tls_verify or supplies a CA bundle. Providers under
+				// `ldap_providers` are new config and verify by default.
+				TLSSkipVerify: !conf.LdapTLSVerify,
+				TLSCACertFile: conf.LdapTLSCACertFile,
 			},
 		})
 	}

--- a/util/LdapProvider_test.go
+++ b/util/LdapProvider_test.go
@@ -77,3 +77,96 @@ func TestLdapProvider_GetMappings_DefaultsWhenNil(t *testing.T) {
 	assert.Equal(t, "uid", m.UID)
 	assert.Equal(t, "cn", m.CN)
 }
+
+func TestLdapProvider_ShouldVerifyTLS(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider LdapProvider
+		expected bool
+	}{
+		{"unconfigured provider verifies by default", LdapProvider{}, true},
+		{"explicit opt-out", LdapProvider{TLSSkipVerify: true}, false},
+		{"CA bundle implies verification", LdapProvider{TLSCACertFile: "/etc/ssl/ca.pem"}, true},
+		{"CA bundle overrides opt-out", LdapProvider{TLSSkipVerify: true, TLSCACertFile: "/etc/ssl/ca.pem"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.provider.ShouldVerifyTLS())
+		})
+	}
+}
+
+// Providers under `ldap_providers` are new config, so they verify unless the
+// operator opts out — unlike the synthesized legacy entry.
+func TestActiveLdapProviders_NewProviderVerifiesByDefault(t *testing.T) {
+	conf := &ConfigType{
+		LdapProviders: map[string]LdapProvider{
+			"corp":     {Server: "corp.example.com:636", NeedTLS: true},
+			"insecure": {Server: "old.example.com:636", NeedTLS: true, TLSSkipVerify: true},
+		},
+	}
+
+	corp, ok := conf.GetLdapProvider("corp")
+	require.True(t, ok)
+	assert.False(t, corp.TLSSkipVerify)
+	assert.True(t, corp.ShouldVerifyTLS())
+
+	insecure, ok := conf.GetLdapProvider("insecure")
+	require.True(t, ok)
+	assert.False(t, insecure.ShouldVerifyTLS())
+}
+
+// The legacy flat config keeps the released behaviour: no verification unless
+// the operator opts in, so upgrading installs on self-signed certs still work.
+func TestActiveLdapProviders_LegacyTLSDefaults(t *testing.T) {
+	tests := []struct {
+		name           string
+		conf           ConfigType
+		wantSkipVerify bool
+		wantVerify     bool
+	}{
+		{
+			name:           "unset keeps released insecure behaviour",
+			conf:           ConfigType{LdapEnable: true, LdapServer: "legacy.example.com:636", LdapNeedTLS: true},
+			wantSkipVerify: true,
+			wantVerify:     false,
+		},
+		{
+			name:           "opt in via ldap_tls_verify",
+			conf:           ConfigType{LdapEnable: true, LdapServer: "legacy.example.com:636", LdapNeedTLS: true, LdapTLSVerify: true},
+			wantSkipVerify: false,
+			wantVerify:     true,
+		},
+		{
+			name:           "CA bundle alone forces verification",
+			conf:           ConfigType{LdapEnable: true, LdapServer: "legacy.example.com:636", LdapNeedTLS: true, LdapTLSCACertFile: "/etc/ssl/corp-ca.pem"},
+			wantSkipVerify: true,
+			wantVerify:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := tt.conf
+			p, ok := conf.GetLdapProvider("ldap")
+			require.True(t, ok)
+			assert.Equal(t, tt.wantSkipVerify, p.TLSSkipVerify)
+			assert.Equal(t, tt.wantVerify, p.ShouldVerifyTLS())
+		})
+	}
+}
+
+func TestActiveLdapProviders_MapsLegacyTLSFields(t *testing.T) {
+	conf := &ConfigType{
+		LdapEnable:        true,
+		LdapServer:        "legacy.example.com:636",
+		LdapNeedTLS:       true,
+		LdapTLSVerify:     true,
+		LdapTLSCACertFile: "/etc/ssl/corp-ca.pem",
+	}
+
+	p, ok := conf.GetLdapProvider("ldap")
+	require.True(t, ok)
+	assert.False(t, p.TLSSkipVerify)
+	assert.Equal(t, "/etc/ssl/corp-ca.pem", p.TLSCACertFile)
+	assert.True(t, p.ShouldVerifyTLS())
+}

--- a/util/config.go
+++ b/util/config.go
@@ -589,10 +589,18 @@ type ConfigType struct {
 	LdapSearchFilter string        `json:"ldap_searchfilter,omitempty" env:"SEMAPHORE_LDAP_SEARCH_FILTER"`
 	LdapMappings     *LdapMappings `json:"ldap_mappings,omitempty"`
 	LdapNeedTLS      bool          `json:"ldap_needtls,omitempty" env:"SEMAPHORE_LDAP_NEEDTLS"`
-	// LdapTLSSkipVerify disables verification of the LDAP server's TLS
-	// certificate for the legacy flat ldap_* config. Defaults to false
-	// (certificates are verified). See LdapProvider.TLSSkipVerify.
-	LdapTLSSkipVerify bool `json:"ldap_tls_skip_verify,omitempty" env:"SEMAPHORE_LDAP_TLS_SKIP_VERIFY"`
+
+	// LdapTLSCACertFile is a PEM bundle used to verify the LDAP server's
+	// certificate, in addition to the system trust store. Set this when the
+	// server uses a self-signed or internal-CA cert. Setting it implies
+	// LdapTLSVerify.
+	LdapTLSCACertFile string `json:"ldap_tls_ca_cert_file,omitempty" env:"SEMAPHORE_LDAP_TLS_CA_CERT_FILE"`
+	// LdapTLSVerify enables verification of the LDAP server's certificate for
+	// the legacy flat ldap_* config only. It defaults to false because released
+	// Semaphore has never verified LDAPS certificates and upgrading installs
+	// must not be locked out; providers under LdapProviders verify by default
+	// instead. See LdapProvider.TLSSkipVerify.
+	LdapTLSVerify bool `json:"ldap_tls_verify,omitempty" env:"SEMAPHORE_LDAP_TLS_VERIFY"`
 
 	// LdapProviders configures multiple LDAP directories (like OidcProviders
 	// for OIDC). The key is the provider ID shown in identity records; the


### PR DESCRIPTION
fix issue https://github.com/semaphoreui/semaphore/issues/749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable CA certificate bundles for trusted LDAP/LDAPS server verification.
  * Added certificate and hostname verification controls for legacy and provider-based LDAP configurations.
  * CA bundles automatically enable verification and extend system trust.

* **Bug Fixes**
  * Provider-based LDAP connections now verify server certificates by default.
  * Added clear errors for missing or invalid CA certificate files.

* **Documentation**
  * Updated LDAP TLS configuration guidance and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->