### PR TITLE
feat(templates): survey variables valiation on backend

### DIFF
--- a/api-docs.yml
+++ b/api-docs.yml
@@ -819,8 +819,16 @@ definitions:
         type: string
       environment:
         type: string
+        description: >
+          JSON object with the values of the template survey variables. Only
+          variables declared in `survey_vars` are accepted, and their values must
+          match the declared type, unless the template enables
+          `allow_any_vars_in_task`.
       secret:
         type: string
+        description: >
+          JSON object with the values of the template survey variables of type
+          `secret`. Write only, never returned by the API.
       arguments:
         type: string
       git_branch:
@@ -947,6 +955,13 @@ definitions:
       allow_override_args_in_task:
         type: boolean
         example: false
+      allow_any_vars_in_task:
+        type: boolean
+        example: false
+        description: >
+          Allows a task to set variables which are not declared in `survey_vars`.
+          Disabled by default: such variables override the template environment
+          and are passed to the app with the highest precedence.
       limit:
         type: string
         example: ''
@@ -1013,6 +1028,13 @@ definitions:
       allow_override_args_in_task:
         type: boolean
         example: false
+      allow_any_vars_in_task:
+        type: boolean
+        example: false
+        description: >
+          Allows a task to set variables which are not declared in `survey_vars`.
+          Disabled by default: such variables override the template environment
+          and are passed to the app with the highest precedence.
       suppress_success_alerts:
         type: boolean
       app:
@@ -3428,6 +3450,12 @@ paths:
                 type: string
               environment:
                 type: string
+                example: '{}'
+                description: >
+                  JSON object with the values of the template survey variables.
+                  Only variables declared in `survey_vars` are accepted, and their
+                  values must match the declared type, unless the template enables
+                  `allow_any_vars_in_task`.
               limit:
                 type: string
               git_branch:

--- a/api/projects/tasks.go
+++ b/api/projects/tasks.go
@@ -48,6 +48,17 @@ func (c *TaskController) AddTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// By default a task may carry only the variables declared in the template
+	// survey, no matter who sends it: task variables override the template
+	// environment and are passed to the app with the highest precedence, so
+	// undeclared keys change settings the template author never exposed — see
+	// db.Task.ValidateSurveyVars. Templates whose tasks legitimately need
+	// arbitrary variables opt in with AllowAnyVarsInTask.
+	if err = taskObj.ValidateSurveyVars(tpl); err != nil {
+		helpers.WriteError(w, err)
+		return
+	}
+
 	newTask, err := taskPool(r).AddTask(
 		taskObj,
 		&user.ID,

--- a/db/Migration.go
+++ b/db/Migration.go
@@ -133,6 +133,7 @@ func GetMigrations(dialect string) []Migration {
 		{Version: "2.19.11"},
 		{Version: "2.20.0"},
 		{Version: "2.20.1"},
+		{Version: "2.20.2"},
 	}
 
 	return append(initScripts, commonScripts...)

--- a/db/Task.go
+++ b/db/Task.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/semaphoreui/semaphore/pkg/common_errors"
 	"github.com/semaphoreui/semaphore/pkg/git"
 	"github.com/semaphoreui/semaphore/pkg/tz"
 
@@ -195,6 +196,89 @@ func (task *Task) ValidateNewTask(template Template) error {
 	}
 
 	return task.ExtractParams(params)
+}
+
+// parseTaskVars parses a task-supplied variable payload (Task.Environment or
+// Task.Secret) into a map. Numbers are decoded as json.Number so integer survey
+// variables can be checked without float rounding.
+func parseTaskVars(payload string, field string) (map[string]any, error) {
+	res := make(map[string]any)
+
+	if payload == "" {
+		return res, nil
+	}
+
+	dec := json.NewDecoder(strings.NewReader(payload))
+	dec.UseNumber()
+
+	if err := dec.Decode(&res); err != nil {
+		return nil, common_errors.NewValidationError("task " + field + " must be a JSON object")
+	}
+
+	return res, nil
+}
+
+// ValidateSurveyVars ensures that the variables supplied with the task are
+// declared in the template survey and match their declared type.
+//
+// Task variables are merged over the template environment and reach the app as
+// extra variables (--extra-vars for Ansible, -var for Terraform apps, arguments
+// for shell apps), where they take precedence over everything the template
+// author configured. Undeclared keys therefore let the requester change
+// settings the template never exposed — for Ansible that includes connection
+// options such as ansible_ssh_common_args, whose ProxyCommand runs on the
+// Semaphore server itself. Nobody may send them by default, which is also all
+// the UI ever sends; a template opts in to arbitrary variables with
+// AllowAnyVarsInTask.
+func (task *Task) ValidateSurveyVars(template Template) error {
+	if template.AllowAnyVarsInTask {
+		return nil
+	}
+
+	env, err := parseTaskVars(task.Environment, "environment")
+	if err != nil {
+		return err
+	}
+
+	secrets, err := parseTaskVars(task.Secret, "secret")
+	if err != nil {
+		return err
+	}
+
+	for name, value := range env {
+		v := template.GetSurveyVar(name)
+
+		if v == nil {
+			return undeclaredSurveyVarError(name)
+		}
+
+		// Secret variables belong to the secret payload, which is stored
+		// encrypted and masked in logs; accepting them here would persist the
+		// value in plaintext on the task row.
+		if v.Type == SurveyVarSecret {
+			return common_errors.NewValidationError(
+				"survey variable " + name + " must be sent in the task secret")
+		}
+
+		if err = v.ValidateValue(value); err != nil {
+			return err
+		}
+	}
+
+	for name := range secrets {
+		v := template.GetSurveyVar(name)
+
+		if v == nil || v.Type != SurveyVarSecret {
+			return undeclaredSurveyVarError(name)
+		}
+	}
+
+	return nil
+}
+
+func undeclaredSurveyVarError(name string) error {
+	return common_errors.NewValidationError(
+		"variable " + name + " is not declared in the template survey")
 }
 
 func (task *TaskWithTpl) Fill(d Store) error {

--- a/db/Task_test.go
+++ b/db/Task_test.go
@@ -1,0 +1,141 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func surveyTemplate() Template {
+	return Template{
+		SurveyVars: []SurveyVar{
+			{Name: "app_version", Type: SurveyVarStr},
+			{Name: "replicas", Type: SurveyVarInt},
+			{Name: "stage", Type: SurveyVarEnum, Values: []SurveyVarEnumValue{
+				{Name: "Dev", Value: "dev"},
+				{Name: "Prod", Value: "prod"},
+			}},
+			{Name: "notes", Type: SurveyVarText},
+			{Name: "token", Type: SurveyVarSecret},
+		},
+	}
+}
+
+func TestTask_ValidateSurveyVars(t *testing.T) {
+	tests := []struct {
+		name        string
+		environment string
+		secret      string
+		errContains string
+	}{
+		{name: "no variables"},
+		{name: "declared variables", environment: `{"app_version":"1.2.3","replicas":3,"stage":"prod","notes":"hi"}`},
+		{name: "declared secret", secret: `{"token":"s3cret"}`},
+		{name: "integer as string", environment: `{"replicas":"3"}`},
+		{name: "empty value of typed var", environment: `{"replicas":"","stage":""}`},
+		{name: "null value of typed var", environment: `{"replicas":null,"stage":null}`},
+
+		{
+			name:        "undeclared variable",
+			environment: `{"ansible_ssh_common_args":"-o ProxyCommand=/bin/sh"}`,
+			errContains: "ansible_ssh_common_args is not declared",
+		},
+		{
+			name:        "undeclared variable next to a declared one",
+			environment: `{"app_version":"1.2.3","ansible_connection":"local"}`,
+			errContains: "ansible_connection is not declared",
+		},
+		{
+			name:        "undeclared secret",
+			secret:      `{"ansible_ssh_common_args":"-o ProxyCommand=/bin/sh"}`,
+			errContains: "ansible_ssh_common_args is not declared",
+		},
+		{
+			name:        "declared non secret variable sent as secret",
+			secret:      `{"app_version":"1.2.3"}`,
+			errContains: "app_version is not declared",
+		},
+		{
+			name:        "secret variable sent as environment",
+			environment: `{"token":"s3cret"}`,
+			errContains: "token must be sent in the task secret",
+		},
+		{
+			name:        "non integer value",
+			environment: `{"replicas":"3; rm -rf /"}`,
+			errContains: "replicas must be an integer",
+		},
+		{
+			name:        "fractional value of integer var",
+			environment: `{"replicas":1.5}`,
+			errContains: "replicas must be an integer",
+		},
+		{
+			name:        "value outside of enum",
+			environment: `{"stage":"staging"}`,
+			errContains: "stage has a value which is not allowed",
+		},
+		{
+			name:        "environment is not an object",
+			environment: `["app_version"]`,
+			errContains: "task environment must be a JSON object",
+		},
+		{
+			name:        "secret is not an object",
+			secret:      `"token"`,
+			errContains: "task secret must be a JSON object",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := Task{Environment: tt.environment, Secret: tt.secret}
+
+			err := task.ValidateSurveyVars(surveyTemplate())
+
+			if tt.errContains == "" {
+				assert.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.errContains)
+		})
+	}
+}
+
+func TestTask_ValidateSurveyVars_TemplateWithoutSurvey(t *testing.T) {
+	task := Task{Environment: `{"anything":"value"}`}
+
+	err := task.ValidateSurveyVars(Template{})
+
+	assert.ErrorContains(t, err, "anything is not declared")
+}
+
+func TestTask_ValidateSurveyVars_AllowAnyVarsInTask(t *testing.T) {
+	task := Task{
+		Environment: `{"ansible_ssh_common_args":"-o ProxyCommand=/bin/sh","replicas":"many"}`,
+		Secret:      `{"undeclared":"value"}`,
+	}
+
+	tpl := surveyTemplate()
+	tpl.AllowAnyVarsInTask = true
+
+	assert.NoError(t, task.ValidateSurveyVars(tpl))
+
+	// The very same task is rejected while the template does not opt in.
+	tpl.AllowAnyVarsInTask = false
+	assert.Error(t, task.ValidateSurveyVars(tpl))
+}
+
+func TestTemplate_GetSurveyVar(t *testing.T) {
+	tpl := surveyTemplate()
+
+	v := tpl.GetSurveyVar("stage")
+
+	require.NotNil(t, v)
+	assert.Equal(t, SurveyVarEnum, v.Type)
+	assert.Nil(t, tpl.GetSurveyVar("STAGE"))
+	assert.Nil(t, tpl.GetSurveyVar("unknown"))
+}

--- a/db/Template.go
+++ b/db/Template.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"encoding/json"
+	"fmt"
+	"strconv"
 
 	"github.com/semaphoreui/semaphore/pkg/common_errors"
 	"github.com/semaphoreui/semaphore/pkg/git"
@@ -64,10 +66,13 @@ func (t TemplateApp) IsTerraform() bool {
 type SurveyVarType string
 
 const (
-	SurveyVarStr  TemplateType = ""
-	SurveyVarInt  TemplateType = "int"
-	SurveyVarEnum TemplateType = "enum"
-	SurveyVarText TemplateType = "text"
+	SurveyVarStr  SurveyVarType = ""
+	SurveyVarInt  SurveyVarType = "int"
+	SurveyVarEnum SurveyVarType = "enum"
+	SurveyVarText SurveyVarType = "text"
+	// SurveyVarSecret is passed to the task via Task.Secret, not Task.Environment,
+	// so its value is never stored in the task row or returned by the API.
+	SurveyVarSecret SurveyVarType = "secret"
 )
 
 type SurveyVarTarget string
@@ -120,6 +125,55 @@ type SurveyVar struct {
 	Description  string               `json:"description,omitempty" backup:"description"`
 	Values       []SurveyVarEnumValue `json:"values,omitempty" backup:"values"`
 	DefaultValue string               `json:"default_value,omitempty" backup:"default_value"`
+}
+
+// ValidateValue checks a task-supplied value against the type declared for the
+// variable. An absent value (null or empty string) is accepted: the variable is
+// simply left unset, and required-ness is not enforced here.
+func (v *SurveyVar) ValidateValue(value any) error {
+	if value == nil {
+		return nil
+	}
+
+	if s, ok := value.(string); ok && s == "" {
+		return nil
+	}
+
+	switch v.Type {
+	case SurveyVarInt:
+		switch val := value.(type) {
+		case json.Number:
+			if _, err := val.Int64(); err == nil {
+				return nil
+			}
+		case string:
+			if _, err := strconv.ParseInt(val, 10, 64); err == nil {
+				return nil
+			}
+		}
+		return common_errors.NewValidationError("survey variable " + v.Name + " must be an integer")
+	case SurveyVarEnum:
+		for _, allowed := range v.Values {
+			if fmt.Sprintf("%v", value) == allowed.Value {
+				return nil
+			}
+		}
+		return common_errors.NewValidationError("survey variable " + v.Name + " has a value which is not allowed")
+	}
+
+	return nil
+}
+
+// GetSurveyVar returns the survey variable declared with the given name, or nil
+// if the template declares no such variable.
+func (tpl *Template) GetSurveyVar(name string) *SurveyVar {
+	for i := range tpl.SurveyVars {
+		if tpl.SurveyVars[i].Name == name {
+			return &tpl.SurveyVars[i]
+		}
+	}
+
+	return nil
 }
 
 type TemplateFilter struct {
@@ -193,6 +247,12 @@ type Template struct {
 	AllowOverrideBranchInTask bool `db:"allow_override_branch_in_task" json:"allow_override_branch_in_task,omitempty"`
 	//AllowOverrideEnvInTask    bool `db:"allow_override_env_in_task" json:"allow_override_env_in_task,omitempty"`
 	AllowParallelTasks bool `db:"allow_parallel_tasks" json:"allow_parallel_tasks,omitempty"`
+
+	// AllowAnyVarsInTask lets a task carry variables which the survey does not
+	// declare. It is disabled by default because such variables override the
+	// template environment and are passed to the app with the highest
+	// precedence — see Task.ValidateSurveyVars.
+	AllowAnyVarsInTask bool `db:"allow_any_vars_in_task" json:"allow_any_vars_in_task,omitempty"`
 
 	JWTParams *TemplateJWTParams `db:"jwt_params" json:"jwt_params,omitempty"`
 }

--- a/db/sql/migration_2_20_2_test.go
+++ b/db/sql/migration_2_20_2_test.go
@@ -1,0 +1,70 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/semaphoreui/semaphore/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigration_2_20_2_AllowAnyVarsInTask checks that the allow_any_vars_in_task
+// column exists after the migrations and that CreateTemplate/UpdateTemplate
+// persist it. It defaults to false, so a template which never sets it keeps
+// tasks restricted to the declared survey variables.
+func TestMigration_2_20_2_AllowAnyVarsInTask(t *testing.T) {
+	store := InitConfigCreateTestStore()
+
+	project, err := store.CreateProject(db.Project{Name: "test project"})
+	require.NoError(t, err)
+
+	key, err := store.CreateAccessKey(db.AccessKey{
+		Name:      "test key",
+		Type:      db.AccessKeyNone,
+		ProjectID: &project.ID,
+	})
+	require.NoError(t, err)
+
+	repo, err := store.CreateRepository(db.Repository{
+		Name:      "test repo",
+		ProjectID: project.ID,
+		GitURL:    "git@example.com:test/test.git",
+		GitBranch: "main",
+		SSHKeyID:  key.ID,
+	})
+	require.NoError(t, err)
+
+	template, err := store.CreateTemplate(db.Template{
+		Name:         "test template",
+		ProjectID:    project.ID,
+		RepositoryID: repo.ID,
+		Playbook:     "test.yml",
+		App:          db.AppBash,
+	})
+	require.NoError(t, err)
+
+	stored, err := store.GetTemplate(project.ID, template.ID)
+	require.NoError(t, err)
+	assert.False(t, stored.AllowAnyVarsInTask, "must be disabled by default")
+
+	stored.AllowAnyVarsInTask = true
+	require.NoError(t, store.UpdateTemplate(stored))
+
+	stored, err = store.GetTemplate(project.ID, template.ID)
+	require.NoError(t, err)
+	assert.True(t, stored.AllowAnyVarsInTask)
+
+	created, err := store.CreateTemplate(db.Template{
+		Name:               "permissive template",
+		ProjectID:          project.ID,
+		RepositoryID:       repo.ID,
+		Playbook:           "test.yml",
+		App:                db.AppBash,
+		AllowAnyVarsInTask: true,
+	})
+	require.NoError(t, err)
+
+	created, err = store.GetTemplate(project.ID, created.ID)
+	require.NoError(t, err)
+	assert.True(t, created.AllowAnyVarsInTask)
+}

--- a/db/sql/migrations/v2.20.2.err.sql
+++ b/db/sql/migrations/v2.20.2.err.sql
@@ -1,0 +1,1 @@
+alter table project__template drop column allow_any_vars_in_task;

--- a/db/sql/migrations/v2.20.2.sql
+++ b/db/sql/migrations/v2.20.2.sql
@@ -1,0 +1,1 @@
+alter table project__template add allow_any_vars_in_task boolean not null default false;

--- a/db/sql/template.go
+++ b/db/sql/template.go
@@ -26,13 +26,14 @@ func (d *SqlDb) CreateTemplate(template db.Template) (newTemplate db.Template, e
 			"playbook, arguments, allow_override_args_in_task, description, `type`, "+
 			"start_version, build_template_id, view_id, autorun, survey_vars, "+
 			"suppress_success_alerts, app, git_branch, runner_tag, task_params, "+
-			"allow_override_branch_in_task, allow_parallel_tasks, jwt_params)"+
+			"allow_override_branch_in_task, allow_parallel_tasks, allow_any_vars_in_task, "+
+			"jwt_params)"+
 			"values ("+
 			"?, ?, ?, ?, "+
 			"?, ?, ?, ?, ?, "+
 			"?, ?, ?, ?, ?, "+
 			"?, ?, ?, ?, ?,"+
-			"?, ?, ?)",
+			"?, ?, ?, ?)",
 		template.ProjectID,
 		template.InventoryID,
 		template.RepositoryID,
@@ -58,6 +59,7 @@ func (d *SqlDb) CreateTemplate(template db.Template) (newTemplate db.Template, e
 
 		template.AllowOverrideBranchInTask,
 		template.AllowParallelTasks,
+		template.AllowAnyVarsInTask,
 		template.JWTParams,
 	)
 
@@ -115,6 +117,7 @@ func (d *SqlDb) UpdateTemplate(template db.Template) error {
 		"runner_tag=?, "+
 		"allow_override_branch_in_task=?, "+
 		"allow_parallel_tasks=?, "+
+		"allow_any_vars_in_task=?, "+
 		"jwt_params=? "+
 		"where id=? and project_id=?",
 		template.InventoryID,
@@ -137,6 +140,7 @@ func (d *SqlDb) UpdateTemplate(template db.Template) error {
 		template.RunnerTag,
 		template.AllowOverrideBranchInTask,
 		template.AllowParallelTasks,
+		template.AllowAnyVarsInTask,
 		template.JWTParams,
 
 		template.ID,

--- a/web/src/components/TaskForm.vue
+++ b/web/src/components/TaskForm.vue
@@ -329,9 +329,28 @@ export default {
         this.item[field] = v[field];
       });
 
-      this.editedEnvironment = JSON.parse(v.environment || '{}');
+      this.editedEnvironment = this.filterDeclaredVars(JSON.parse(v.environment || '{}'));
       this.editedSecretEnvironment = JSON.parse(v.secret || '{}');
       this.hasCommit = v.commit_hash != null;
+    },
+
+    // A re-run inherits the variables of the source task, which can contain keys
+    // the survey does not declare — a task created before the survey changed, or
+    // by an API client of a template which allows any variables. The API rejects
+    // undeclared variables unless the template allows them, and the form has no
+    // field for them anyway, so they are dropped here.
+    filterDeclaredVars(vars) {
+      const template = this.template || {};
+
+      if (template.allow_any_vars_in_task) {
+        return vars;
+      }
+
+      const declared = (template.survey_vars || []).map((v) => v.name);
+
+      return Object.fromEntries(
+        Object.entries(vars).filter(([name]) => declared.includes(name)),
+      );
     },
 
     isLoaded() {

--- a/web/src/components/TemplateForm.vue
+++ b/web/src/components/TemplateForm.vue
@@ -336,7 +336,15 @@
 
           <SurveyVars :vars="surveyVars" @change="setSurveyVars" />
 
-          <v-checkbox class="mt-0" v-model="item.allow_parallel_tasks">
+          <v-checkbox
+            class="mt-0"
+            v-model="item.allow_any_vars_in_task"
+            :label="$t('allow_any_vars_in_task')"
+            :hint="$t('allow_any_vars_in_task_hint')"
+            persistent-hint
+          />
+
+          <v-checkbox class="mt-4" v-model="item.allow_parallel_tasks">
             <template v-slot:label>
               {{ $t('allow_parallel_tasks') }}
             </template>

--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -435,6 +435,10 @@ export default {
 
   runner_tag: 'Runner tag',
   allow_parallel_tasks: 'Allow parallel tasks',
+  allow_any_vars_in_task: 'Allow any variables in task',
+  allow_any_vars_in_task_hint: 'By default a task can only set the survey variables '
+    + 'declared above. Enable this to let a task set any variable, which overrides '
+    + 'the template environment and the app settings.',
   jwt_enabled: 'Issue JWT to task runner',
   jwt_audience: 'JWT audience',
   jwt_audience_hint: 'Press Enter to add another audience value.',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Templates can allow tasks to set variables beyond those declared in their survey configuration.
  * Added a template setting and explanatory guidance for enabling this behavior.
  * Task variables now support validation for names, types, enum values, and secret handling.
  * Rerun forms filter inherited variables unsupported by the selected template.

* **Bug Fixes**
  * Prevented invalid or undeclared task variables from being submitted.

* **Documentation**
  * Improved API documentation for task and template variable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->