### PR TITLE
feat(schedules): add monthly weekday schedules (Nth weekday and offset)

### DIFF
--- a/AGENTS/plans/2_20/schedule-monthly-weekday.md
+++ b/AGENTS/plans/2_20/schedule-monthly-weekday.md
@@ -1,0 +1,58 @@
+# Plan — Monthly Weekday Schedules ("Nth weekday + offset")
+
+## Why
+
+Commonly needed when patching Windows servers: updates ship on Patch Tuesday
+(2nd Tuesday), so windows are often defined relative to it. Cron can't express
+these:
+
+- **Third Wednesday** — no nth-weekday operator; the DOM∧DOW trick fails because
+  robfig/cron ORs a restricted DOM with a restricted DOW.
+- **First Wednesday after Patch Tuesday** — not a fixed ordinal (2nd Tue + 1 day),
+  so even a Quartz `#` can't name it.
+
+## What
+
+A Semaphore cron descriptor stored in the existing `cron_format`:
+
+```
+@monthly-weekday <ordinal> <weekday> [offset <days>] [at <HH:MM>]
+```
+
+`<ordinal>` = `1`..`5` or `last`; `<weekday>` = `sun`..`sat`; `offset` in
+`[-28,28]` (calendar-day shift, may cross a month); `at` = 24h local, default
+`00:00`. Example: `@monthly-weekday 2 tue offset 1 at 03:00` = first Wednesday
+after Patch Tuesday.
+
+## Design
+
+- **Cron descriptor, not a new column.** A custom `cron.ScheduleParser` parses it
+  and delegates every other expression to the standard parser; it backs both the
+  pool (`cron.WithParser`) and `ValidateCronFormat`, so what validates is what
+  fires. Reusing `cron_format` means no DB migration and export/backup keep
+  working. HA-safe (pure function of the string). No new dependency.
+- **Timezone** mirrors robfig/cron: ambient pool location, or a `CRON_TZ=`/`TZ=`
+  prefix overrides.
+- **Preview**: `schedules/validate` returns `next_run` for descriptors the JS
+  cron parser can't evaluate.
+
+## Files
+
+- `services/schedules/monthly_weekday.go` — grammar, schedule, parser, `NextRunTimes`.
+- `services/schedules/SchedulePool.go` — `WithParser`; `ValidateCronFormat`.
+- `api/projects/schedules.go` — `next_run` in the validate response.
+- `web/src/components/ScheduleForm.vue` — "Monthly (by weekday)" builder (same
+  chip grids as Monthly); `api-docs.yml`.
+
+## Edge cases
+
+Ordinal 5 that doesn't occur → skip that month (scan bounded to 5 years). Offset
+spill → scan starts one month back; occurrences are monotonic. DST → `time.Date`
+resolves wall-clock correctly; `AddDate` preserves it. Validation is total.
+
+## Tests
+
+testify, table-driven, next to source: both headline cases across a year;
+last/5th/offset/negative; DST; `CRON_TZ`; every validation error; a property
+suite vs an independent oracle; a differential sweep proving the parser is a pure
+superset of `ParseStandard`.

--- a/api-docs.yml
+++ b/api-docs.yml
@@ -1103,6 +1103,13 @@ definitions:
         type: integer
       cron_format:
         type: string
+        description: >
+          Standard 5-field cron expression, a robfig/cron @-descriptor
+          (@hourly, @daily, ...), or the Semaphore @monthly-weekday descriptor
+          "@monthly-weekday <ordinal> <weekday> [offset <days>] [at <HH:MM>]"
+          (ordinal 1..5 or 'last'). Example: "@monthly-weekday 2 tue offset 1
+          at 03:00" is the first Wednesday after Patch Tuesday. An optional
+          CRON_TZ=/TZ= prefix pins the timezone.
         x-example: "* * * 1 *"
         example: "* * * 1 *"
       project_id:
@@ -3330,6 +3337,42 @@ paths:
           description: schedule created
           schema:
             $ref: "#/definitions/Schedule"
+
+  /project/{project_id}/schedules/validate:
+    parameters:
+      - $ref: "#/parameters/project_id"
+    post:
+      tags:
+        - schedule
+      summary: validate a schedule cron format
+      description: >
+        Validates cron_format and, on success, returns the next upcoming
+        activation instants. This is authoritative for descriptors the
+        frontend cannot evaluate locally (e.g. @monthly-weekday).
+      parameters:
+        - name: schedule
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/ScheduleRequest"
+      responses:
+        200:
+          description: cron format is valid
+          schema:
+            type: object
+            properties:
+              next_run:
+                type: array
+                items:
+                  type: string
+                  format: date-time
+        400:
+          description: invalid cron format
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
 
   # project views
   /project/{project_id}/views:

--- a/api/projects/schedules.go
+++ b/api/projects/schedules.go
@@ -117,13 +117,33 @@ func validateSchedulePayload(schedule *db.Schedule, w http.ResponseWriter) bool 
 	}
 }
 
+// scheduleValidateNextRuns is how many upcoming activations the validate
+// endpoint returns for the schedule form's preview.
+const scheduleValidateNextRuns = 5
+
 func ValidateScheduleCronFormat(w http.ResponseWriter, r *http.Request) {
 	var schedule db.Schedule
 	if !helpers.Bind(w, r, &schedule) {
 		return
 	}
 
-	_ = validateCronFormat(schedule.CronFormat, w)
+	if !validateCronFormat(schedule.CronFormat, w) {
+		return
+	}
+
+	// Return the next activations so the UI can show a backend-authoritative
+	// preview, including for descriptors (e.g. @monthly-weekday) that the
+	// frontend cron parser cannot evaluate. A parse failure here cannot happen
+	// after a successful validation, but degrade to an empty list rather than
+	// failing the request if it somehow does.
+	nextRuns, err := schedules.NextRunTimes(schedule.CronFormat, scheduleValidateNextRuns)
+	if err != nil {
+		nextRuns = []time.Time{}
+	}
+
+	helpers.WriteJSON(w, http.StatusOK, map[string]interface{}{
+		"next_run": nextRuns,
+	})
 }
 
 // AddSchedule adds a template to the database

--- a/api/projects/schedules.go
+++ b/api/projects/schedules.go
@@ -121,6 +121,8 @@ func validateSchedulePayload(schedule *db.Schedule, w http.ResponseWriter) bool 
 // endpoint returns for the schedule form's preview.
 const scheduleValidateNextRuns = 5
 
+// ValidateScheduleCronFormat validates a schedule's cron_format and, when it is
+// valid, returns the next few run times so the form can preview them.
 func ValidateScheduleCronFormat(w http.ResponseWriter, r *http.Request) {
 	var schedule db.Schedule
 	if !helpers.Bind(w, r, &schedule) {

--- a/api/projects/schedules_test.go
+++ b/api/projects/schedules_test.go
@@ -1,0 +1,67 @@
+package projects
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/semaphoreui/semaphore/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupScheduleConfig(t *testing.T) {
+	t.Helper()
+	if util.Config == nil {
+		util.Config = &util.ConfigType{}
+	}
+	orig := util.Config.Schedule
+	t.Cleanup(func() { util.Config.Schedule = orig })
+	util.Config.Schedule = &util.ScheduleConfig{Timezone: "UTC"}
+}
+
+func postValidate(t *testing.T, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/project/1/schedules/validate", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ValidateScheduleCronFormat(w, req)
+	return w
+}
+
+func TestValidateScheduleCronFormat(t *testing.T) {
+	setupScheduleConfig(t)
+
+	t.Run("monthly-weekday descriptor returns next runs", func(t *testing.T) {
+		w := postValidate(t, `{"cron_format":"@monthly-weekday 2 tue offset 1 at 03:00"}`)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp struct {
+			NextRun []time.Time `json:"next_run"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Len(t, resp.NextRun, scheduleValidateNextRuns)
+		assert.True(t, resp.NextRun[0].After(time.Now()))
+		assert.True(t, resp.NextRun[1].After(resp.NextRun[0]))
+	})
+
+	t.Run("standard cron returns next runs", func(t *testing.T) {
+		w := postValidate(t, `{"cron_format":"* * 1 * *"}`)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "next_run")
+	})
+
+	t.Run("invalid cron is rejected", func(t *testing.T) {
+		w := postValidate(t, `{"cron_format":"* * * *"}`)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "Cron:")
+	})
+
+	t.Run("invalid descriptor is rejected", func(t *testing.T) {
+		w := postValidate(t, `{"cron_format":"@monthly-weekday 9 wed"}`)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "ordinal")
+	})
+}

--- a/api/projects/schedules_test.go
+++ b/api/projects/schedules_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// setupScheduleConfig points util.Config.Schedule at a fixed timezone for the
+// test and restores the previous value afterwards.
 func setupScheduleConfig(t *testing.T) {
 	t.Helper()
 	if util.Config == nil {
@@ -23,6 +25,7 @@ func setupScheduleConfig(t *testing.T) {
 	util.Config.Schedule = &util.ScheduleConfig{Timezone: "UTC"}
 }
 
+// postValidate posts body to the validate handler and returns the recorder.
 func postValidate(t *testing.T, body string) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, "/api/project/1/schedules/validate", strings.NewReader(body))

--- a/services/schedules/SchedulePool.go
+++ b/services/schedules/SchedulePool.go
@@ -252,7 +252,11 @@ func (p *SchedulePool) init() {
 	if err != nil {
 		panic(err)
 	}
-	p.cron = cron.New(cron.WithLocation(loc))
+	// WithParser installs the Semaphore cron grammar: the monthly-weekday
+	// descriptor plus a standard fallback. The same parser backs
+	// ValidateCronFormat, so an expression that validates is exactly one that
+	// fires.
+	p.cron = cron.New(cron.WithLocation(loc), cron.WithParser(newCronParser()))
 	p.locker = &sync.Mutex{}
 }
 
@@ -404,6 +408,6 @@ func CreateSchedulePool(
 }
 
 func ValidateCronFormat(cronFormat string) error {
-	_, err := cron.ParseStandard(cronFormat)
+	_, err := newCronParser().Parse(cronFormat)
 	return err
 }

--- a/services/schedules/monthly_weekday.go
+++ b/services/schedules/monthly_weekday.go
@@ -1,0 +1,367 @@
+package schedules
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/semaphoreui/semaphore/util"
+)
+
+// monthlyWeekdayKeyword is the descriptor that selects a "Nth weekday of the
+// month, plus an optional day offset" schedule. It is intentionally namespaced
+// so it can never collide with a standard cron expression or one of
+// robfig/cron's built-in descriptors (@monthly, @weekly, ...).
+const monthlyWeekdayKeyword = "@monthly-weekday"
+
+// ordinalLast marks the "last occurrence of the weekday in the month" variant.
+// Regular ordinals are the positive integers 1..5.
+const ordinalLast = -1
+
+// maxWeekdayOffsetDays bounds the day offset. An offset larger than a month is
+// meaningless (it would be better expressed as a different ordinal/weekday) and
+// keeping it small guarantees the Next scan only has to look one month back to
+// catch an occurrence that spilled across a month boundary.
+const maxWeekdayOffsetDays = 28
+
+// nextScanMonths bounds how far Next scans before giving up, matching
+// robfig/cron's own five-year cap. It is only ever reached for the pathological
+// case of an ordinal that never occurs, which cannot happen for a valid weekday.
+const nextScanMonths = 5 * 12
+
+// monthlyWeekdaySchedule fires on the Nth (or last) occurrence of a weekday in
+// each month, shifted by offsetDays calendar days, at hour:minute. It
+// implements cron.Schedule and is immutable, so it is safe to share and to
+// evaluate concurrently on every node of an HA cluster.
+type monthlyWeekdaySchedule struct {
+	ordinal    int          // 1..5, or ordinalLast
+	weekday    time.Weekday // Sunday..Saturday
+	offsetDays int          // calendar-day shift applied to the anchor, [-28, 28]
+	hour       int          // 0..23
+	minute     int          // 0..59
+
+	// loc pins the evaluation timezone when the descriptor carried a
+	// CRON_TZ=/TZ= prefix. When nil the schedule is evaluated in the ambient
+	// location of the time passed to Next — exactly how robfig/cron treats a
+	// prefix-less expression (time.Local sentinel), which lets the pool's
+	// WithLocation continue to drive the effective timezone.
+	loc *time.Location
+}
+
+// Next returns the first activation strictly after t, or the zero time if none
+// is found within the scan bound. It satisfies cron.Schedule.
+func (s monthlyWeekdaySchedule) Next(t time.Time) time.Time {
+	loc := s.loc
+	if loc == nil {
+		loc = t.Location()
+	}
+	t = t.In(loc)
+
+	// Start one month before t. A positive offset applied to the previous
+	// month's occurrence can land after t, and occurrences are strictly
+	// increasing month over month, so scanning from the previous month and
+	// returning the first occurrence after t yields the true next activation.
+	year, month := t.Year(), t.Month()
+	month--
+	if month < time.January {
+		month = time.December
+		year--
+	}
+
+	for i := 0; i < nextScanMonths; i++ {
+		if occ, ok := s.occurrenceIn(year, month, loc); ok && occ.After(t) {
+			return occ
+		}
+		month++
+		if month > time.December {
+			month = time.January
+			year++
+		}
+	}
+
+	return time.Time{}
+}
+
+// occurrenceIn computes the activation instant for a specific month. ok is
+// false when the requested ordinal does not occur that month (for example, a
+// month with no fifth Friday).
+func (s monthlyWeekdaySchedule) occurrenceIn(year int, month time.Month, loc *time.Location) (time.Time, bool) {
+	last := daysInMonth(year, month, loc)
+
+	var day int
+	if s.ordinal == ordinalLast {
+		lastDate := time.Date(year, month, last, 0, 0, 0, 0, loc)
+		back := (int(lastDate.Weekday()) - int(s.weekday) + 7) % 7
+		day = last - back
+	} else {
+		first := time.Date(year, month, 1, 0, 0, 0, 0, loc)
+		forward := (int(s.weekday) - int(first.Weekday()) + 7) % 7
+		day = 1 + forward + (s.ordinal-1)*7
+		if day > last {
+			return time.Time{}, false
+		}
+	}
+
+	anchor := time.Date(year, month, day, s.hour, s.minute, 0, 0, loc)
+	// AddDate normalises across month and DST boundaries while preserving the
+	// wall-clock time of day, so "second Tuesday at 03:00, offset 1 day" fires
+	// on the following Wednesday at 03:00.
+	return anchor.AddDate(0, 0, s.offsetDays), true
+}
+
+// daysInMonth returns the number of days in the given month. Day 0 of the
+// following month is the last day of this one; time.Date normalises a December
+// query (month+1 == 13) into the next year.
+func daysInMonth(year int, month time.Month, loc *time.Location) int {
+	return time.Date(year, month+1, 0, 0, 0, 0, 0, loc).Day()
+}
+
+// cronParser parses Semaphore's monthly-weekday descriptor and delegates every
+// other expression to a standard robfig/cron parser. It implements
+// cron.ScheduleParser so it can back both the scheduling pool (via
+// cron.WithParser) and ValidateCronFormat, guaranteeing that what validates is
+// exactly what fires.
+type cronParser struct {
+	standard cron.Parser
+}
+
+// newCronParser builds a parser whose fallback accepts exactly the same
+// expressions as cron.ParseStandard (five fields plus @-descriptors). It holds
+// no package-level state, so it can be constructed wherever it is needed.
+func newCronParser() cronParser {
+	return cronParser{
+		standard: cron.NewParser(
+			cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
+		),
+	}
+}
+
+// Parse returns a cron.Schedule for spec. A monthly-weekday descriptor (with an
+// optional CRON_TZ=/TZ= prefix) is parsed here; anything else is handed to the
+// standard parser unchanged, including its own prefix handling.
+func (p cronParser) Parse(spec string) (cron.Schedule, error) {
+	body := strings.TrimSpace(spec)
+
+	var loc *time.Location
+	if strings.HasPrefix(body, "TZ=") || strings.HasPrefix(body, "CRON_TZ=") {
+		eq := strings.Index(body, "=")
+		sp := strings.IndexAny(body, " \t")
+		if sp < 0 {
+			return nil, fmt.Errorf("provided bad location: %s", body)
+		}
+		z, err := time.LoadLocation(strings.TrimSpace(body[eq+1 : sp]))
+		if err != nil {
+			return nil, err
+		}
+		loc = z
+		body = strings.TrimSpace(body[sp+1:])
+	}
+
+	if isMonthlyWeekdaySpec(body) {
+		return parseMonthlyWeekday(body, loc)
+	}
+
+	// Delegate the original spec so the standard parser applies its own,
+	// identical prefix handling — no double interpretation.
+	return p.standard.Parse(spec)
+}
+
+// isMonthlyWeekdaySpec reports whether body (already stripped of any timezone
+// prefix) is a monthly-weekday descriptor.
+func isMonthlyWeekdaySpec(body string) bool {
+	fields := strings.Fields(body)
+	return len(fields) > 0 && strings.EqualFold(fields[0], monthlyWeekdayKeyword)
+}
+
+// parseMonthlyWeekday turns a descriptor body into a monthlyWeekdaySchedule.
+// The grammar is:
+//
+//	@monthly-weekday <ordinal> <weekday> [offset <days>] [at <HH:MM>]
+//
+// The optional "offset" and "at" clauses may appear in either order but at most
+// once each. Every malformed input yields a descriptive error and never a
+// partially-built schedule.
+func parseMonthlyWeekday(body string, loc *time.Location) (monthlyWeekdaySchedule, error) {
+	var zero monthlyWeekdaySchedule
+
+	fields := strings.Fields(body)
+	if len(fields) < 3 {
+		return zero, fmt.Errorf(
+			"%s requires an ordinal and a weekday, e.g. %q",
+			monthlyWeekdayKeyword, monthlyWeekdayKeyword+" 3 wed at 09:00")
+	}
+
+	ordinal, err := parseOrdinal(fields[1])
+	if err != nil {
+		return zero, err
+	}
+
+	weekday, err := parseWeekday(fields[2])
+	if err != nil {
+		return zero, err
+	}
+
+	s := monthlyWeekdaySchedule{
+		ordinal: ordinal,
+		weekday: weekday,
+		loc:     loc,
+	}
+
+	seenOffset := false
+	seenAt := false
+	for i := 3; i < len(fields); {
+		switch strings.ToLower(fields[i]) {
+		case "offset":
+			if seenOffset {
+				return zero, fmt.Errorf("%s: duplicate offset clause", monthlyWeekdayKeyword)
+			}
+			if i+1 >= len(fields) {
+				return zero, fmt.Errorf("%s: offset requires a number of days", monthlyWeekdayKeyword)
+			}
+			s.offsetDays, err = parseOffset(fields[i+1])
+			if err != nil {
+				return zero, err
+			}
+			seenOffset = true
+			i += 2
+		case "at":
+			if seenAt {
+				return zero, fmt.Errorf("%s: duplicate at clause", monthlyWeekdayKeyword)
+			}
+			if i+1 >= len(fields) {
+				return zero, fmt.Errorf("%s: at requires a HH:MM time", monthlyWeekdayKeyword)
+			}
+			s.hour, s.minute, err = parseHourMinute(fields[i+1])
+			if err != nil {
+				return zero, err
+			}
+			seenAt = true
+			i += 2
+		default:
+			return zero, fmt.Errorf(
+				"%s: unexpected token %q (expected 'offset <days>' or 'at <HH:MM>')",
+				monthlyWeekdayKeyword, fields[i])
+		}
+	}
+
+	return s, nil
+}
+
+// parseOrdinal accepts 1..5 or the word "last".
+func parseOrdinal(s string) (int, error) {
+	if strings.EqualFold(s, "last") {
+		return ordinalLast, nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 1 || n > 5 {
+		return 0, fmt.Errorf("%s: ordinal must be 1..5 or 'last', got %q", monthlyWeekdayKeyword, s)
+	}
+	return n, nil
+}
+
+// parseWeekday accepts every common spelling of a weekday. Numeric weekdays are
+// deliberately not accepted: the 0=Sunday vs 1=Monday ambiguity between cron
+// dialects is exactly the kind of silent misconfiguration this feature exists
+// to avoid.
+func parseWeekday(s string) (time.Weekday, error) {
+	switch strings.ToLower(s) {
+	case "sun", "sunday":
+		return time.Sunday, nil
+	case "mon", "monday":
+		return time.Monday, nil
+	case "tue", "tues", "tuesday":
+		return time.Tuesday, nil
+	case "wed", "weds", "wednesday":
+		return time.Wednesday, nil
+	case "thu", "thur", "thurs", "thursday":
+		return time.Thursday, nil
+	case "fri", "friday":
+		return time.Friday, nil
+	case "sat", "saturday":
+		return time.Saturday, nil
+	default:
+		return 0, fmt.Errorf("%s: unknown weekday %q (use sun..sat)", monthlyWeekdayKeyword, s)
+	}
+}
+
+func parseOffset(s string) (int, error) {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("%s: offset must be an integer number of days, got %q", monthlyWeekdayKeyword, s)
+	}
+	if n < -maxWeekdayOffsetDays || n > maxWeekdayOffsetDays {
+		return 0, fmt.Errorf("%s: offset must be within ±%d days, got %d", monthlyWeekdayKeyword, maxWeekdayOffsetDays, n)
+	}
+	return n, nil
+}
+
+func parseHourMinute(s string) (hour int, minute int, err error) {
+	h, m, ok := strings.Cut(s, ":")
+	// Require a canonical 24-hour HH:MM: a 1-2 digit hour and an exactly
+	// 2-digit minute, digits only. "9:5" is ambiguous (09:05 vs 09:50) and a
+	// signed or non-ASCII value is not a clock time, so all are rejected rather
+	// than silently reinterpreted.
+	if !ok || !isDecimal(h) || len(h) < 1 || len(h) > 2 || !isDecimal(m) || len(m) != 2 {
+		return 0, 0, fmt.Errorf("%s: time must be HH:MM (24-hour), got %q", monthlyWeekdayKeyword, s)
+	}
+	hour, _ = strconv.Atoi(h)
+	if hour > 23 {
+		return 0, 0, fmt.Errorf("%s: hour must be 0..23, got %q", monthlyWeekdayKeyword, s)
+	}
+	minute, _ = strconv.Atoi(m)
+	if minute > 59 {
+		return 0, 0, fmt.Errorf("%s: minute must be 0..59, got %q", monthlyWeekdayKeyword, s)
+	}
+	return hour, minute, nil
+}
+
+// isDecimal reports whether s is a non-empty run of ASCII decimal digits (no
+// sign, no whitespace, no non-ASCII digits).
+func isDecimal(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// NextRunTimes returns up to count upcoming activations for a cron format,
+// starting from now. It powers the schedule form's "Next run time" preview,
+// which is authoritative for descriptors the frontend cron parser cannot
+// evaluate. The base timezone matches the scheduling pool: an explicit
+// CRON_TZ=/TZ= prefix wins, otherwise util.Config.Schedule.Timezone (UTC by
+// default) is used.
+func NextRunTimes(cronFormat string, count int) ([]time.Time, error) {
+	schedule, err := newCronParser().Parse(cronFormat)
+	if err != nil {
+		return nil, err
+	}
+
+	t := time.Now().In(scheduleLocation())
+	runs := make([]time.Time, 0, count)
+	for i := 0; i < count; i++ {
+		t = schedule.Next(t)
+		if t.IsZero() {
+			break
+		}
+		runs = append(runs, t)
+	}
+	return runs, nil
+}
+
+// scheduleLocation resolves the pool's base timezone, falling back to UTC when
+// the config is absent or names an unknown zone.
+func scheduleLocation() *time.Location {
+	if util.Config != nil && util.Config.Schedule != nil {
+		if loc, err := time.LoadLocation(util.Config.Schedule.Timezone); err == nil {
+			return loc
+		}
+	}
+	return time.UTC
+}

--- a/services/schedules/monthly_weekday.go
+++ b/services/schedules/monthly_weekday.go
@@ -286,6 +286,7 @@ func parseWeekday(s string) (time.Weekday, error) {
 	}
 }
 
+// parseOffset reads the signed day offset and rejects anything beyond ±28 days.
 func parseOffset(s string) (int, error) {
 	n, err := strconv.Atoi(s)
 	if err != nil {
@@ -297,6 +298,8 @@ func parseOffset(s string) (int, error) {
 	return n, nil
 }
 
+// parseHourMinute reads a canonical 24-hour "HH:MM", rejecting ambiguous forms
+// like "9:5" and out-of-range values.
 func parseHourMinute(s string) (hour int, minute int, err error) {
 	h, m, ok := strings.Cut(s, ":")
 	// Require a canonical 24-hour HH:MM: a 1-2 digit hour and an exactly

--- a/services/schedules/monthly_weekday_property_test.go
+++ b/services/schedules/monthly_weekday_property_test.go
@@ -41,7 +41,7 @@ func nthWeekdayOfMonth(year int, month time.Month, wd time.Weekday, ordinal int,
 }
 
 // oracleNext computes the true next activation strictly after t by enumerating
-// every candidate anchor over a wide window (t-3 months .. t+16 months),
+// every candidate anchor over a wide window (t-2 months .. t+9 months),
 // applying the SAME fire formula the spec defines (anchor at H:M, then AddDate
 // offset), and taking the minimum instant strictly after t.
 func oracleNext(s monthlyWeekdaySchedule, t time.Time) time.Time {

--- a/services/schedules/monthly_weekday_property_test.go
+++ b/services/schedules/monthly_weekday_property_test.go
@@ -1,0 +1,485 @@
+package schedules
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Independent oracle for the monthly-weekday rule, used to property-test
+// monthlyWeekdaySchedule.Next against a deliberately different algorithm.
+//
+// nthWeekdayOfMonth finds the day-of-month of the Nth (1..5) or last occurrence
+// of weekday wd in (year, month), by *counting days independently* (no modulo
+// arithmetic — deliberately different from the implementation). Returns ok=false
+// when a positive ordinal does not occur that month.
+// ---------------------------------------------------------------------------
+func nthWeekdayOfMonth(year int, month time.Month, wd time.Weekday, ordinal int, loc *time.Location) (int, bool) {
+	daysIn := time.Date(year, month+1, 0, 0, 0, 0, 0, loc).Day()
+
+	var matches []int
+	for d := 1; d <= daysIn; d++ {
+		if time.Date(year, month, d, 0, 0, 0, 0, loc).Weekday() == wd {
+			matches = append(matches, d)
+		}
+	}
+	if len(matches) == 0 {
+		return 0, false
+	}
+	if ordinal == ordinalLast {
+		return matches[len(matches)-1], true
+	}
+	if ordinal < 1 || ordinal > len(matches) {
+		return 0, false
+	}
+	return matches[ordinal-1], true
+}
+
+// oracleNext computes the true next activation strictly after t by enumerating
+// every candidate anchor over a wide window (t-3 months .. t+16 months),
+// applying the SAME fire formula the spec defines (anchor at H:M, then AddDate
+// offset), and taking the minimum instant strictly after t.
+func oracleNext(s monthlyWeekdaySchedule, t time.Time) time.Time {
+	loc := s.loc
+	if loc == nil {
+		loc = t.Location()
+	}
+	t = t.In(loc)
+
+	year, month := t.Year(), t.Month()
+	// Two months before t through nine after: with |offset| <= 28 and monthly
+	// occurrences, the true next is always inside this window.
+	startYear, startMonth := year, month-2
+	for startMonth < time.January {
+		startMonth += 12
+		startYear--
+	}
+
+	var best time.Time
+	yy, mm := startYear, startMonth
+	for i := 0; i < 12; i++ {
+		if day, ok := nthWeekdayOfMonth(yy, mm, s.weekday, s.ordinal, loc); ok {
+			anchor := time.Date(yy, mm, day, s.hour, s.minute, 0, 0, loc)
+			fire := anchor.AddDate(0, 0, s.offsetDays)
+			if fire.After(t) && (best.IsZero() || fire.Before(best)) {
+				best = fire
+			}
+		}
+		mm++
+		if mm > time.December {
+			mm = time.January
+			yy++
+		}
+	}
+	return best
+}
+
+// combos returns a representative grid of schedules.
+func combos(loc *time.Location) []monthlyWeekdaySchedule {
+	var out []monthlyWeekdaySchedule
+	ordinals := []int{1, 2, 3, 4, 5, ordinalLast}
+	weekdays := []time.Weekday{
+		time.Sunday, time.Monday, time.Tuesday, time.Wednesday,
+		time.Thursday, time.Friday, time.Saturday,
+	}
+	offsets := []int{-28, -15, -7, -1, 0, 1, 7, 15, 28}
+	hm := [][2]int{{0, 0}, {9, 0}, {2, 30}, {23, 59}}
+	for _, o := range ordinals {
+		for _, w := range weekdays {
+			for _, off := range offsets {
+				h := hm[(o+int(w)+off)&3] // vary time deterministically
+				out = append(out, monthlyWeekdaySchedule{
+					ordinal: o, weekday: w, offsetDays: off,
+					hour: h[0], minute: h[1], loc: loc,
+				})
+			}
+		}
+	}
+	return out
+}
+
+// TestMonthlyWeekday_Prop_BruteForceOracle is a brute-force property check: for a large grid of schedules
+// and many reference instants across several years, Next(t) must equal an
+// independent oracle. Also feeds occurrence instants back in to exercise the
+// strict-after boundary.
+func TestMonthlyWeekday_Prop_BruteForceOracle(t *testing.T) {
+	loc := time.UTC
+	refs := []time.Time{}
+	// Dense sampling across ~6 years, including odd hours/minutes and
+	// month/year boundaries.
+	for _, y := range []int{2026, 2027, 2028} { // includes a leap year
+		for _, m := range []time.Month{time.February, time.December} {
+			for _, d := range []int{1, 15, 28} {
+				for _, hh := range []int{0, 23} {
+					refs = append(refs, time.Date(y, m, d, hh, 30, 0, 0, loc))
+				}
+			}
+		}
+	}
+
+	for _, s := range combos(loc) {
+		for _, ref := range refs {
+			got := s.Next(ref)
+			want := oracleNext(s, ref)
+			require.Truef(t, got.Equal(want), "MISMATCH desc=%s ref=%s got=%s want=%s",
+				descOf(s), ref.Format(time.RFC3339), fmtT(got), fmtT(want))
+			// Strict-after: feed the result back; must advance and match oracle.
+			if !got.IsZero() {
+				assert.True(t, got.After(ref), "Next not strictly after ref: %s ref=%s got=%s", descOf(s), ref, got)
+				got2 := s.Next(got)
+				want2 := oracleNext(s, got)
+				require.Truef(t, got2.Equal(want2), "MISMATCH(2nd) desc=%s from=%s got=%s want=%s",
+					descOf(s), fmtT(got), fmtT(got2), fmtT(want2))
+			}
+		}
+	}
+}
+
+// TestMonthlyWeekday_Prop_OneMonthBackSufficiency directly stresses the "start one month
+// before t" assumption with the worst-case offsets and last/5th ordinals at
+// year rollover.
+func TestMonthlyWeekday_Prop_OneMonthBackSufficiency(t *testing.T) {
+	loc := time.UTC
+	worst := []monthlyWeekdaySchedule{
+		{ordinal: ordinalLast, weekday: time.Friday, offsetDays: 28, hour: 23, minute: 59, loc: loc},
+		{ordinal: ordinalLast, weekday: time.Saturday, offsetDays: -28, hour: 0, minute: 0, loc: loc},
+		{ordinal: 5, weekday: time.Sunday, offsetDays: 28, hour: 23, minute: 59, loc: loc},
+		{ordinal: 5, weekday: time.Monday, offsetDays: -28, hour: 0, minute: 0, loc: loc},
+		{ordinal: 1, weekday: time.Sunday, offsetDays: -28, hour: 0, minute: 0, loc: loc},
+	}
+	// Every hour across two full years — will catch any boundary miss.
+	for _, s := range worst {
+		cur := time.Date(2027, time.January, 1, 0, 0, 0, 0, loc)
+		end := time.Date(2029, time.January, 1, 0, 0, 0, 0, loc)
+		for cur.Before(end) {
+			got := s.Next(cur)
+			want := oracleNext(s, cur)
+			require.Truef(t, got.Equal(want), "MISMATCH desc=%s ref=%s got=%s want=%s",
+				descOf(s), cur.Format(time.RFC3339), fmtT(got), fmtT(want))
+			cur = cur.Add(6 * time.Hour)
+		}
+	}
+}
+
+// TestMonthlyWeekday_Prop_DSTZones checks DST zones: monotonicity + oracle agreement in
+// tricky zones (NY: 1h DST; Chatham: :45 offset + DST; Lord Howe: 30-min DST),
+// including anchors deliberately at wall times inside spring-forward gaps.
+func TestMonthlyWeekday_Prop_DSTZones(t *testing.T) {
+	for _, zone := range []string{"America/New_York", "Pacific/Chatham", "Australia/Lord_Howe"} {
+		loc, err := time.LoadLocation(zone)
+		if err != nil {
+			t.Logf("zone %s unavailable, skipping: %v", zone, err)
+			continue
+		}
+		t.Run(zone, func(t *testing.T) {
+			// Include gap-prone wall times: 02:30 (NY/LordHowe), 02:45/03:45 (Chatham).
+			schedules := []monthlyWeekdaySchedule{
+				{ordinal: 2, weekday: time.Sunday, hour: 2, minute: 30, loc: loc},
+				{ordinal: 1, weekday: time.Sunday, hour: 2, minute: 45, loc: loc},
+				{ordinal: ordinalLast, weekday: time.Sunday, hour: 2, minute: 30, offsetDays: 1, loc: loc},
+				{ordinal: 3, weekday: time.Wednesday, hour: 9, minute: 0, offsetDays: -1, loc: loc},
+			}
+			for _, s := range schedules {
+				prev := time.Date(2024, time.January, 1, 0, 0, 0, 0, loc)
+				for i := 0; i < 120; i++ { // 10 years of monthly fires
+					next := s.Next(prev)
+					require.False(t, next.IsZero(), "unexpected zero: %s from %s", descOf(s), prev)
+					assert.True(t, next.After(prev),
+						"NON-MONOTONIC desc=%s prev=%s next=%s", descOf(s), fmtT(prev), fmtT(next))
+					want := oracleNext(s, prev)
+					require.Truef(t, next.Equal(want), "MISMATCH desc=%s prev=%s got=%s want=%s",
+						descOf(s), fmtT(prev), fmtT(next), fmtT(want))
+					prev = next
+				}
+			}
+		})
+	}
+}
+
+// TestMonthlyWeekday_Prop_NeverSilentlyNeverFires confirms no valid descriptor returns the
+// zero time (a schedule that silently never fires) within a long horizon — i.e.
+// the 60-month cap is never hit for a valid weekday rule.
+func TestMonthlyWeekday_Prop_NeverSilentlyNeverFires(t *testing.T) {
+	loc := time.UTC
+	for _, s := range combos(loc) {
+		// Sample a few starting points per year across a decade.
+		for y := 2024; y <= 2034; y++ {
+			from := time.Date(y, time.February, 27, 12, 0, 0, 0, loc)
+			got := s.Next(from)
+			assert.False(t, got.IsZero(), "valid descriptor returned zero (never fires): %s from %s", descOf(s), from)
+		}
+	}
+}
+
+// ---- end-to-end through the real cron pool ----------------------------------
+
+func TestMonthlyWeekday_Prop_PoolEndToEnd(t *testing.T) {
+	loc := time.UTC
+	c := cron.New(cron.WithLocation(loc), cron.WithParser(newCronParser()))
+
+	id, err := c.AddJob("@monthly-weekday 3 wed at 09:00", cron.FuncJob(func() {}))
+	require.NoError(t, err, "pool must accept the descriptor")
+	entry := c.Entry(id)
+	require.NotNil(t, entry.Schedule)
+	next := entry.Schedule.Next(time.Date(2026, time.January, 1, 0, 0, 0, 0, loc))
+	assert.Equal(t, "2026-01-21T09:00:00Z", next.Format(time.RFC3339))
+
+	_, err = c.AddJob("@monthly-weekday 9 wed", cron.FuncJob(func() {}))
+	assert.Error(t, err, "pool must reject an invalid descriptor")
+
+	// CRON_TZ-pinned via the pool.
+	id2, err := c.AddJob("CRON_TZ=America/New_York @monthly-weekday 2 sun at 09:00", cron.FuncJob(func() {}))
+	require.NoError(t, err)
+	ny, _ := time.LoadLocation("America/New_York")
+	n2 := c.Entry(id2).Schedule.Next(time.Date(2026, time.January, 1, 0, 0, 0, 0, loc))
+	assert.Equal(t, "EST", n2.In(ny).Format("MST"))
+	assert.Equal(t, "2026-01-11T09:00:00", n2.In(ny).Format("2006-01-02T15:04:05"))
+}
+
+// TestMonthlyWeekday_Prop_ValidatePreviewMatchesFire checks that the validate preview matches firing: the validate preview
+// (NextRunTimes, based on util.Config.Schedule.Timezone) must produce the same
+// instants the pool would fire, for both a prefix-less descriptor (ambient =
+// config TZ) and a CRON_TZ-pinned one (overrides config TZ).
+func TestMonthlyWeekday_Prop_ValidatePreviewMatchesFire(t *testing.T) {
+	setupScheduleConfig(t, "America/New_York") // non-UTC config to expose ambient bugs
+	cfgLoc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	specs := []string{
+		"@monthly-weekday 3 wed at 09:00",                    // prefix-less -> ambient/config TZ
+		"CRON_TZ=Asia/Tokyo @monthly-weekday 2 mon at 06:30", // pinned, overrides config
+		"CRON_TZ=America/New_York @monthly-weekday last fri at 22:30",
+	}
+	for _, spec := range specs {
+		t.Run(spec, func(t *testing.T) {
+			// Preview path (what the validate endpoint returns).
+			preview, err := NextRunTimes(spec, 5)
+			require.NoError(t, err)
+			require.NotEmpty(t, preview)
+
+			// Fire path: exactly how the pool evaluates it. The pool passes
+			// time.Now().In(config TZ) into Schedule.Next.
+			sched, err := newCronParser().Parse(spec)
+			require.NoError(t, err)
+			base := time.Now().In(cfgLoc)
+			cur := base
+			for i, want := range preview {
+				cur = sched.Next(cur)
+				assert.Truef(t, cur.Equal(want),
+					"preview[%d]=%s != fire=%s for %q", i, fmtT(want), fmtT(cur), spec)
+			}
+		})
+	}
+}
+
+// ---- delegation is a pure superset of ParseStandard ------------------------
+
+func safeParse(fn func() (cron.Schedule, error)) (sched cron.Schedule, err error, panicked bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			panicked = true
+			err = fmt.Errorf("panic: %v", r)
+		}
+	}()
+	sched, err = fn()
+	return
+}
+
+func TestMonthlyWeekday_Prop_DelegationParity(t *testing.T) {
+	p := newCronParser()
+	specs := []string{
+		"* * * * *",
+		"0 0 1 * *",
+		"*/5 * * * *",
+		"@hourly", "@daily", "@midnight", "@weekly", "@monthly", "@yearly", "@annually",
+		"@every 1h30m", "@every 90m", "@every 0s",
+		"CRON_TZ=UTC * * * * *",
+		"CRON_TZ=America/New_York 0 9 * * 1",
+		"TZ=Europe/Stockholm 0 0 * * *",
+		"CRON_TZ=Bad/Zone * * * * *",
+		"* * * *",     // too few
+		"* * * * * *", // too many (standard = 5)
+		"@bogus",
+		"",
+		"   ",
+		"@every notaduration",
+		"60 * * * *", // minute out of range
+		"* 24 * * *", // hour out of range
+		"* * 0 * *",  // dom below min
+		"1-5/0 * * * *",
+		"0 0 * * MON-FRI",
+		"0 0 * * 7", // dow 7
+		"\t* * * * *\t",
+		"  * * * * *  ",
+		"CRON_TZ=UTC\t* * * * *", // tab after tz prefix
+	}
+
+	type div struct {
+		spec                string
+		featOK, stdOK       bool
+		featErr, stdErr     string
+		featPanic, stdPanic bool
+	}
+	var divergences []div
+
+	for _, spec := range specs {
+		fs, fe, fp := safeParse(func() (cron.Schedule, error) { return p.Parse(spec) })
+		ss, se, sp := safeParse(func() (cron.Schedule, error) { return cron.ParseStandard(spec) })
+
+		featOK := fe == nil && !fp
+		stdOK := se == nil && !sp
+
+		// Record any difference in accept/reject or any panic.
+		if featOK != stdOK || fp || sp {
+			d := div{spec: spec, featOK: featOK, stdOK: stdOK, featPanic: fp, stdPanic: sp}
+			if fe != nil {
+				d.featErr = fe.Error()
+			}
+			if se != nil {
+				d.stdErr = se.Error()
+			}
+			divergences = append(divergences, d)
+		}
+
+		// For specs both accept, compare Next over several steps.
+		if featOK && stdOK {
+			cur := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+			for i := 0; i < 5; i++ {
+				fn := fs.Next(cur)
+				sn := ss.Next(cur)
+				assert.Truef(t, fn.Equal(sn),
+					"Next diverges for %q at step %d: feat=%s std=%s", spec, i, fn, sn)
+				cur = sn
+				if cur.IsZero() {
+					break
+				}
+			}
+		}
+	}
+
+	for _, d := range divergences {
+		t.Logf("DIVERGENCE spec=%q feat(ok=%v panic=%v err=%q) std(ok=%v panic=%v err=%q)",
+			d.spec, d.featOK, d.featPanic, d.featErr, d.stdOK, d.stdPanic, d.stdErr)
+	}
+
+	// The only *acceptable* divergences are ones where the feature is SAFER:
+	// it returns a clean error where robfig ParseStandard panics. Any case where
+	// feature accepts and std rejects (or vice versa) WITHOUT a std panic is a
+	// real regression.
+	for _, d := range divergences {
+		if d.stdPanic {
+			assert.False(t, d.featPanic, "feature also panics on %q (should be clean error)", d.spec)
+			assert.False(t, d.featOK, "feature accepts %q that std panics on", d.spec)
+			continue
+		}
+		assert.Failf(t, "accept/reject regression", "on %q: feat=%v std=%v", d.spec, d.featOK, d.stdOK)
+	}
+}
+
+// TestMonthlyWeekday_Prop_OldValidatePanicked demonstrates the pre-change ValidateCronFormat
+// (cron.ParseStandard) PANICS on a TZ prefix with no following field, while the
+// new parser returns a clean error — a latent DoS in the old validate path.
+func TestMonthlyWeekday_Prop_OldValidatePanicked(t *testing.T) {
+	_, _, oldPanic := safeParse(func() (cron.Schedule, error) { return cron.ParseStandard("TZ=UTC") })
+	assert.True(t, oldPanic, "expected robfig ParseStandard to panic on \"TZ=UTC\"")
+
+	// New parser (backs both validate and fire) must NOT panic and must reject.
+	_, newErr, newPanic := safeParse(func() (cron.Schedule, error) { return newCronParser().Parse("TZ=UTC") })
+	assert.False(t, newPanic, "new parser must not panic on \"TZ=UTC\"")
+	assert.Error(t, newErr, "new parser must reject \"TZ=UTC\"")
+
+	// And ValidateCronFormat itself must be panic-free.
+	assert.NotPanics(t, func() { _ = ValidateCronFormat("TZ=UTC") })
+	assert.NotPanics(t, func() { _ = ValidateCronFormat("CRON_TZ=Europe/Paris") })
+}
+
+// ---- grammar fuzzing: no panic, only in-range accepts ----------------------
+
+func TestMonthlyWeekday_Prop_GrammarNoPanicAndClassify(t *testing.T) {
+	cases := []string{
+		"@monthly-weekday 99999999999999999999 wed",
+		"@monthly-weekday 3 wed offset 99999999999999999999",
+		"@monthly-weekday -3 wed",
+		"@monthly-weekday +3 wed",
+		"@monthly-weekday 3 wed at 9:5",
+		"@monthly-weekday 3 wed at 09:5",
+		"@monthly-weekday 3 wed at 9:05",
+		"@monthly-weekday 3 wed at 24:00",
+		"@monthly-weekday 3 wed at 23:60",
+		"@monthly-weekday 3 wed at 23:59",
+		"@monthly-weekday 3 wed offset -0",
+		"@monthly-weekday 3 wed offset +5",
+		"@monthly-weekday 3 WED AT 09:00",
+		"@MONTHLY-WEEKDAY 3 wed",
+		"@monthly-weekday 3 wed offset 1 at 09:00 extra",
+		"@monthly-weekday 3 wed at 09:00 offset 1 offset 2",
+		"@monthly-weekday 3 wed at :00",
+		"@monthly-weekday 3 wed at 09:",
+		"@monthly-weekday 3 wed at 09:00:00",
+		"@monthly-weekday    3    wed",       // extra spaces
+		"@monthly-weekday\t3\twed",           // tabs
+		"@monthly-weekday 3 wed offset  2",   // double space before value
+		"@monthly-weekday 3 wed offset",      // offset no value
+		"@monthly-weekday 3 wed at",          // at no value
+		"@monthly-weekday 3 wed offset 1 at", // trailing at no value
+		"@monthly-weekday ３ wed",             // fullwidth digit
+		"@monthly-weekday 3 wed at ０９:００",    // fullwidth time
+		"@monthly-weekday 5 sun offset 28 at 23:59",
+		"@monthly-weekday last sat offset -28",
+		"@monthly-weekday 0x3 wed",
+		"@monthly-weekday 3 wed offset 0x2",
+	}
+	for _, spec := range cases {
+		spec := spec
+		t.Run(spec, func(t *testing.T) {
+			var (
+				sched monthlyWeekdaySchedule
+				err   error
+			)
+			assert.NotPanics(t, func() { sched, err = parseMonthlyWeekday(spec, time.UTC) },
+				"parseMonthlyWeekday panicked on %q", spec)
+			// Also route through the wrapping parser to ensure no panic there.
+			assert.NotPanics(t, func() { _, _ = newCronParser().Parse(spec) })
+			if err == nil {
+				// If accepted, it must produce sane, evaluable schedule fields.
+				assert.True(t, sched.ordinal == ordinalLast || (sched.ordinal >= 1 && sched.ordinal <= 5), "bad ordinal %d for %q", sched.ordinal, spec)
+				assert.True(t, sched.hour >= 0 && sched.hour <= 23, "bad hour")
+				assert.True(t, sched.minute >= 0 && sched.minute <= 59, "bad minute")
+				assert.True(t, sched.offsetDays >= -28 && sched.offsetDays <= 28, "bad offset")
+				// Evaluating must not panic and must yield a non-zero next.
+				var n time.Time
+				assert.NotPanics(t, func() { n = sched.Next(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) })
+				assert.False(t, n.IsZero(), "accepted spec %q never fires", spec)
+				t.Logf("ACCEPTED %q -> ord=%d wd=%v off=%d %02d:%02d", spec, sched.ordinal, sched.weekday, sched.offsetDays, sched.hour, sched.minute)
+			} else {
+				t.Logf("rejected %q: %v", spec, err)
+			}
+		})
+	}
+}
+
+// ---- helpers --------------------------------------------------------------
+
+func descOf(s monthlyWeekdaySchedule) string {
+	ord := fmt.Sprintf("%d", s.ordinal)
+	if s.ordinal == ordinalLast {
+		ord = "last"
+	}
+	z := "ambient"
+	if s.loc != nil {
+		z = s.loc.String()
+	}
+	return fmt.Sprintf("@mw ord=%s wd=%v off=%d %02d:%02d [%s]", ord, s.weekday, s.offsetDays, s.hour, s.minute, z)
+}
+
+func fmtT(t time.Time) string {
+	if t.IsZero() {
+		return "<zero>"
+	}
+	return t.Format("2006-01-02T15:04:05Z07:00")
+}

--- a/services/schedules/monthly_weekday_property_test.go
+++ b/services/schedules/monthly_weekday_property_test.go
@@ -108,6 +108,9 @@ func combos(loc *time.Location) []monthlyWeekdaySchedule {
 // independent oracle. Also feeds occurrence instants back in to exercise the
 // strict-after boundary.
 func TestMonthlyWeekday_Prop_BruteForceOracle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping exhaustive oracle sweep in -short mode")
+	}
 	loc := time.UTC
 	refs := []time.Time{}
 	// Dense sampling across ~6 years, including odd hours/minutes and
@@ -144,6 +147,9 @@ func TestMonthlyWeekday_Prop_BruteForceOracle(t *testing.T) {
 // before t" assumption with the worst-case offsets and last/5th ordinals at
 // year rollover.
 func TestMonthlyWeekday_Prop_OneMonthBackSufficiency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping two-year sufficiency sweep in -short mode")
+	}
 	loc := time.UTC
 	worst := []monthlyWeekdaySchedule{
 		{ordinal: ordinalLast, weekday: time.Friday, offsetDays: 28, hour: 23, minute: 59, loc: loc},

--- a/services/schedules/monthly_weekday_property_test.go
+++ b/services/schedules/monthly_weekday_property_test.go
@@ -285,6 +285,8 @@ func TestMonthlyWeekday_Prop_ValidatePreviewMatchesFire(t *testing.T) {
 
 // ---- delegation is a pure superset of ParseStandard ------------------------
 
+// safeParse runs fn and reports whether it panicked, so a panic becomes a
+// comparable outcome instead of a test failure.
 func safeParse(fn func() (cron.Schedule, error)) (sched cron.Schedule, err error, panicked bool) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -296,6 +298,8 @@ func safeParse(fn func() (cron.Schedule, error)) (sched cron.Schedule, err error
 	return
 }
 
+// TestMonthlyWeekday_Prop_DelegationParity checks the wrapper accepts, rejects
+// and schedules ordinary cron expressions exactly like cron.ParseStandard.
 func TestMonthlyWeekday_Prop_DelegationParity(t *testing.T) {
 	p := newCronParser()
 	specs := []string{
@@ -406,6 +410,8 @@ func TestMonthlyWeekday_Prop_OldValidatePanicked(t *testing.T) {
 
 // ---- grammar fuzzing: no panic, only in-range accepts ----------------------
 
+// TestMonthlyWeekday_Prop_GrammarNoPanicAndClassify feeds hostile inputs to the
+// grammar: none may panic, and every accepted one yields in-range fields.
 func TestMonthlyWeekday_Prop_GrammarNoPanicAndClassify(t *testing.T) {
 	cases := []string{
 		"@monthly-weekday 99999999999999999999 wed",
@@ -471,6 +477,7 @@ func TestMonthlyWeekday_Prop_GrammarNoPanicAndClassify(t *testing.T) {
 
 // ---- helpers --------------------------------------------------------------
 
+// descOf renders a schedule as a short string for failure messages.
 func descOf(s monthlyWeekdaySchedule) string {
 	ord := fmt.Sprintf("%d", s.ordinal)
 	if s.ordinal == ordinalLast {
@@ -483,6 +490,7 @@ func descOf(s monthlyWeekdaySchedule) string {
 	return fmt.Sprintf("@mw ord=%s wd=%v off=%d %02d:%02d [%s]", ord, s.weekday, s.offsetDays, s.hour, s.minute, z)
 }
 
+// fmtT formats a time for failure messages, or "<zero>" for the zero time.
 func fmtT(t time.Time) string {
 	if t.IsZero() {
 		return "<zero>"

--- a/services/schedules/monthly_weekday_regression_test.go
+++ b/services/schedules/monthly_weekday_regression_test.go
@@ -14,6 +14,9 @@ import (
 // over several steps. The only permitted difference is that where ParseStandard
 // PANICS, the wrapper returns a clean error (never the reverse).
 func TestDiffSweep_NoRegressionVsParseStandard(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping ~23k-spec differential sweep in -short mode")
+	}
 	safe := func(fn func() (cron.Schedule, error)) (s cron.Schedule, err error, panicked bool) {
 		defer func() {
 			if r := recover(); r != nil {

--- a/services/schedules/monthly_weekday_regression_test.go
+++ b/services/schedules/monthly_weekday_regression_test.go
@@ -1,0 +1,103 @@
+package schedules
+
+import (
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDiffSweep_NoRegressionVsParseStandard is a large differential: for a broad
+// generated set of expressions, the wrapper must make the SAME accept/reject
+// decision as cron.ParseStandard and, when accepted, produce the SAME Next()
+// over several steps. The only permitted difference is that where ParseStandard
+// PANICS, the wrapper returns a clean error (never the reverse).
+func TestDiffSweep_NoRegressionVsParseStandard(t *testing.T) {
+	safe := func(fn func() (cron.Schedule, error)) (s cron.Schedule, err error, panicked bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		s, err = fn()
+		return
+	}
+
+	minutes := []string{"*", "0", "59", "*/5", "0,30", "15-45", "1-59/2", "5"}
+	hours := []string{"*", "0", "23", "*/2", "9-17", "0,12", "8"}
+	doms := []string{"*", "1", "31", "*/10", "1-15", "15", "L-not"} // "L-not" is invalid -> both reject
+	months := []string{"*", "1", "12", "JAN", "DEC", "*/3", "1-6", "JAN-MAR"}
+	dows := []string{"*", "0", "6", "7", "MON", "SUN", "MON-FRI", "1-5", "0,6"}
+	prefixes := []string{"", "TZ=UTC ", "CRON_TZ=America/New_York ", "CRON_TZ=Asia/Tokyo ", "CRON_TZ=Bad/Zone "}
+
+	p := newCronParser()
+	ref := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+
+	var checked, accepted int
+	for _, pfx := range prefixes {
+		for _, mi := range minutes {
+			for _, h := range hours {
+				// Keep dom/month/dow varied but bounded to keep the sweep sane.
+				for _, dm := range doms {
+					for _, mo := range []string{months[0], months[3], months[6]} {
+						for _, dw := range []string{dows[0], dows[3], dows[6], dows[8]} {
+							spec := pfx + mi + " " + h + " " + dm + " " + mo + " " + dw
+							checked++
+
+							ws, werr, wpanic := safe(func() (cron.Schedule, error) { return p.Parse(spec) })
+							ss, serr, spanic := safe(func() (cron.Schedule, error) { return cron.ParseStandard(spec) })
+
+							require.False(t, wpanic, "wrapper PANICKED on %q", spec)
+
+							wOK := werr == nil && !wpanic
+							sOK := serr == nil && !spanic
+
+							if spanic {
+								// The only allowed asymmetry: std panics, wrapper errors cleanly.
+								require.False(t, wOK, "wrapper accepted %q that ParseStandard panics on", spec)
+								continue
+							}
+
+							require.Equalf(t, sOK, wOK,
+								"accept/reject REGRESSION on %q: std=%v wrapper=%v (werr=%v serr=%v)",
+								spec, sOK, wOK, werr, serr)
+
+							if wOK && sOK {
+								accepted++
+								wt, st := ref, ref
+								for i := 0; i < 6; i++ {
+									wt = ws.Next(wt)
+									st = ss.Next(st)
+									require.Truef(t, wt.Equal(st),
+										"Next DIVERGES on %q step %d: wrapper=%s std=%s", spec, i, wt, st)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	t.Logf("swept %d specs, %d accepted by both, zero Next divergences", checked, accepted)
+}
+
+// TestDiffSweep_Descriptors confirms robfig's own @-descriptors are unchanged by
+// the wrapper (accept + identical Next), and only the new @monthly-weekday is
+// additive.
+func TestDiffSweep_Descriptors(t *testing.T) {
+	p := newCronParser()
+	ref := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+	for _, d := range []string{"@yearly", "@annually", "@monthly", "@weekly", "@daily", "@midnight", "@hourly", "@every 1h30m", "@every 45m"} {
+		ws, werr := p.Parse(d)
+		ss, serr := cron.ParseStandard(d)
+		require.NoError(t, werr, d)
+		require.NoError(t, serr, d)
+		wt, st := ref, ref
+		for i := 0; i < 6; i++ {
+			wt = ws.Next(wt)
+			st = ss.Next(st)
+			require.Truef(t, wt.Equal(st), "descriptor %q Next diverges at %d: %s vs %s", d, i, wt, st)
+		}
+	}
+}

--- a/services/schedules/monthly_weekday_test.go
+++ b/services/schedules/monthly_weekday_test.go
@@ -1,0 +1,341 @@
+package schedules
+
+import (
+	"testing"
+	"time"
+
+	"github.com/semaphoreui/semaphore/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupScheduleConfig points util.Config.Schedule at a fixed timezone for the
+// duration of a test and restores the previous value afterwards.
+func setupScheduleConfig(t *testing.T, tz string) {
+	t.Helper()
+	if util.Config == nil {
+		util.Config = &util.ConfigType{}
+	}
+	orig := util.Config.Schedule
+	t.Cleanup(func() { util.Config.Schedule = orig })
+	util.Config.Schedule = &util.ScheduleConfig{Timezone: tz}
+}
+
+// mustParse parses a descriptor and fails the test immediately if it is
+// rejected — used only for specs that are expected to be valid.
+func mustParse(t *testing.T, spec string) monthlyWeekdaySchedule {
+	t.Helper()
+	sched, err := parseMonthlyWeekday(spec, time.UTC)
+	require.NoError(t, err)
+	return sched
+}
+
+// TestMonthlyWeekday_ThirdWednesday walks a full year and asserts the third
+// Wednesday of every month, at the configured time, in UTC.
+func TestMonthlyWeekday_ThirdWednesday(t *testing.T) {
+	sched := mustParse(t, "@monthly-weekday 3 wed at 09:00")
+
+	// Third Wednesdays of 2026, verified against a calendar.
+	expected := []string{
+		"2026-01-21T09:00:00Z",
+		"2026-02-18T09:00:00Z",
+		"2026-03-18T09:00:00Z",
+		"2026-04-15T09:00:00Z",
+		"2026-05-20T09:00:00Z",
+		"2026-06-17T09:00:00Z",
+		"2026-07-15T09:00:00Z",
+		"2026-08-19T09:00:00Z",
+		"2026-09-16T09:00:00Z",
+		"2026-10-21T09:00:00Z",
+		"2026-11-18T09:00:00Z",
+		"2026-12-16T09:00:00Z",
+	}
+
+	cur := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	for _, want := range expected {
+		next := sched.Next(cur)
+		assert.Equal(t, want, next.Format(time.RFC3339))
+		cur = next
+	}
+}
+
+// TestMonthlyWeekday_FirstWednesdayAfterPatchTuesday is the headline case:
+// second Tuesday + 1 day. The offset date is sometimes the second and sometimes
+// the third Wednesday, which is exactly why no fixed-ordinal rule expresses it.
+func TestMonthlyWeekday_FirstWednesdayAfterPatchTuesday(t *testing.T) {
+	sched := mustParse(t, "@monthly-weekday 2 tue offset 1 at 03:00")
+
+	expected := []string{
+		"2026-01-14T03:00:00Z", // 2nd Tue Jan 13 -> Wed 14
+		"2026-02-11T03:00:00Z", // 2nd Tue Feb 10 -> Wed 11
+		"2026-03-11T03:00:00Z",
+		"2026-04-15T03:00:00Z", // 2nd Tue Apr 14 -> Wed 15 (the 3rd Wednesday)
+		"2026-05-13T03:00:00Z",
+		"2026-06-10T03:00:00Z",
+		"2026-07-15T03:00:00Z",
+		"2026-08-12T03:00:00Z",
+		"2026-09-09T03:00:00Z", // 2nd Tue Sep 8 -> Wed 9 (the 2nd Wednesday)
+		"2026-10-14T03:00:00Z",
+		"2026-11-11T03:00:00Z",
+		"2026-12-09T03:00:00Z",
+	}
+
+	cur := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	for _, want := range expected {
+		next := sched.Next(cur)
+		assert.Equal(t, want, next.Format(time.RFC3339))
+		cur = next
+	}
+}
+
+func TestMonthlyWeekday_LastFriday(t *testing.T) {
+	sched := mustParse(t, "@monthly-weekday last fri at 22:30")
+
+	tests := []struct {
+		name string
+		from string
+		want string
+	}{
+		{"from month start", "2026-02-01T00:00:00Z", "2026-02-27T22:30:00Z"},
+		{"31-day month", "2026-01-01T00:00:00Z", "2026-01-30T22:30:00Z"},
+		{"last friday is the 31st", "2026-07-01T00:00:00Z", "2026-07-31T22:30:00Z"},
+		{"leap february", "2028-02-01T00:00:00Z", "2028-02-25T22:30:00Z"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from, err := time.Parse(time.RFC3339, tt.from)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, sched.Next(from).Format(time.RFC3339))
+		})
+	}
+}
+
+// TestMonthlyWeekday_FifthOccurrenceSkipsMonthsWithout confirms that a fifth
+// weekday that does not exist in a month is skipped, not clamped.
+func TestMonthlyWeekday_FifthOccurrenceSkipsMonthsWithout(t *testing.T) {
+	sched := mustParse(t, "@monthly-weekday 5 sun at 12:00")
+
+	// 2026: fifth Sundays occur in Mar(29), May(31), Aug(30), Nov(29).
+	from := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	expected := []string{
+		"2026-03-29T12:00:00Z",
+		"2026-05-31T12:00:00Z",
+		"2026-08-30T12:00:00Z",
+		"2026-11-29T12:00:00Z",
+	}
+	for _, want := range expected {
+		next := sched.Next(from)
+		assert.Equal(t, want, next.Format(time.RFC3339))
+		from = next
+	}
+}
+
+// TestMonthlyWeekday_OffsetCrossesMonthBoundary checks that a positive offset
+// from a late-month anchor lands in the following month and is still found when
+// the reference time is already in that following month.
+func TestMonthlyWeekday_OffsetCrossesMonthBoundary(t *testing.T) {
+	// Last Sunday of Feb 2026 is the 22nd; +7 days -> Mar 1.
+	sched := mustParse(t, "@monthly-weekday last sun offset 7 at 08:00")
+
+	// Reference already past the anchor but before the offset date.
+	from := time.Date(2026, time.February, 25, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, "2026-03-01T08:00:00Z", sched.Next(from).Format(time.RFC3339))
+}
+
+func TestMonthlyWeekday_NegativeOffset(t *testing.T) {
+	// Second Tuesday of March 2026 is the 10th; offset -2 -> Sunday the 8th.
+	sched := mustParse(t, "@monthly-weekday 2 tue offset -2 at 00:00")
+	from := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, "2026-03-08T00:00:00Z", sched.Next(from).Format(time.RFC3339))
+}
+
+func TestMonthlyWeekday_DefaultsToMidnight(t *testing.T) {
+	sched := mustParse(t, "@monthly-weekday 1 mon")
+	from := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, "2026-01-05T00:00:00Z", sched.Next(from).Format(time.RFC3339))
+}
+
+// A single-digit hour with a 2-digit minute is unambiguous and accepted.
+func TestMonthlyWeekday_AcceptsSingleDigitHour(t *testing.T) {
+	sched := mustParse(t, "@monthly-weekday 1 mon at 9:00")
+	from := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, "2026-01-05T09:00:00Z", sched.Next(from).Format(time.RFC3339))
+}
+
+func TestMonthlyWeekday_ClausesEitherOrder(t *testing.T) {
+	a := mustParse(t, "@monthly-weekday 2 tue offset 1 at 03:00")
+	b := mustParse(t, "@monthly-weekday 2 tue at 03:00 offset 1")
+	from := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, a.Next(from), b.Next(from))
+}
+
+// TestMonthlyWeekday_DST verifies the two properties that matter across a DST
+// boundary: the wall-clock time of day is preserved, and the zone (hence the
+// UTC instant) tracks DST. 09:00 is used because it is never inside a
+// spring-forward gap, so the assertions are well-defined.
+func TestMonthlyWeekday_DST(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	// Second Sunday at 09:00 local. 2026 DST runs Mar 8 – Nov 1.
+	sched, err := parseMonthlyWeekday("@monthly-weekday 2 sun at 09:00", ny)
+	require.NoError(t, err)
+
+	// January is EST; the second Sunday is the 11th.
+	fromJan := time.Date(2026, time.January, 1, 0, 0, 0, 0, ny)
+	nextJan := sched.Next(fromJan)
+	assert.Equal(t, "2026-01-11T09:00:00", nextJan.Format("2006-01-02T15:04:05"))
+	assert.Equal(t, "EST", nextJan.Format("MST"))
+
+	// April is EDT; the second Sunday is the 12th — same wall clock, different
+	// zone, so a different UTC instant.
+	fromApr := time.Date(2026, time.April, 1, 0, 0, 0, 0, ny)
+	nextApr := sched.Next(fromApr)
+	assert.Equal(t, "2026-04-12T09:00:00", nextApr.Format("2006-01-02T15:04:05"))
+	assert.Equal(t, "EDT", nextApr.Format("MST"))
+}
+
+// TestMonthlyWeekday_AmbientTimezone confirms a prefix-less schedule evaluates
+// in the location of the time passed to Next, mirroring robfig/cron and letting
+// the pool's WithLocation drive the effective zone.
+func TestMonthlyWeekday_AmbientTimezone(t *testing.T) {
+	sched := mustParseAmbient(t, "@monthly-weekday 3 wed at 09:00")
+
+	ny, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	from := time.Date(2026, time.January, 1, 0, 0, 0, 0, ny)
+	next := sched.Next(from)
+	// 09:00 in New York, not UTC.
+	assert.Equal(t, "2026-01-21T09:00:00", next.In(ny).Format("2006-01-02T15:04:05"))
+	assert.Equal(t, "EST", next.In(ny).Format("MST"))
+}
+
+func mustParseAmbient(t *testing.T, spec string) monthlyWeekdaySchedule {
+	t.Helper()
+	sched, err := parseMonthlyWeekday(spec, nil)
+	require.NoError(t, err)
+	return sched
+}
+
+func TestParseMonthlyWeekday_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		spec string
+		msg  string
+	}{
+		{"missing weekday", "@monthly-weekday 3", "requires an ordinal and a weekday"},
+		{"ordinal zero", "@monthly-weekday 0 wed", "ordinal must be 1..5 or 'last'"},
+		{"ordinal too big", "@monthly-weekday 6 wed", "ordinal must be 1..5 or 'last'"},
+		{"ordinal not a number", "@monthly-weekday x wed", "ordinal must be 1..5 or 'last'"},
+		{"unknown weekday", "@monthly-weekday 3 funday", "unknown weekday"},
+		{"offset without value", "@monthly-weekday 3 wed offset", "offset requires a number"},
+		{"offset not a number", "@monthly-weekday 3 wed offset abc", "offset must be an integer"},
+		{"offset out of range", "@monthly-weekday 3 wed offset 40", "within ±28 days"},
+		{"at without value", "@monthly-weekday 3 wed at", "at requires a HH:MM"},
+		{"time not HH:MM", "@monthly-weekday 3 wed at 9", "time must be HH:MM"},
+		{"ambiguous single-digit minute", "@monthly-weekday 3 wed at 9:5", "time must be HH:MM"},
+		{"single-digit minute padded hour", "@monthly-weekday 3 wed at 09:5", "time must be HH:MM"},
+		{"time with seconds", "@monthly-weekday 3 wed at 09:00:00", "time must be HH:MM"},
+		{"time with sign", "@monthly-weekday 3 wed at +9:00", "time must be HH:MM"},
+		{"hour out of range", "@monthly-weekday 3 wed at 24:00", "hour must be 0..23"},
+		{"minute out of range", "@monthly-weekday 3 wed at 09:60", "minute must be 0..59"},
+		{"duplicate offset", "@monthly-weekday 3 wed offset 1 offset 2", "duplicate offset"},
+		{"duplicate at", "@monthly-weekday 3 wed at 09:00 at 10:00", "duplicate at"},
+		{"unexpected token", "@monthly-weekday 3 wed frequently", "unexpected token"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseMonthlyWeekday(tt.spec, time.UTC)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.msg)
+		})
+	}
+}
+
+func TestParseMonthlyWeekday_AcceptsWeekdaySpellings(t *testing.T) {
+	spellings := map[string]time.Weekday{
+		"sun": time.Sunday, "SUNDAY": time.Sunday,
+		"Mon": time.Monday, "tue": time.Tuesday, "tues": time.Tuesday,
+		"WED": time.Wednesday, "thurs": time.Thursday,
+		"Fri": time.Friday, "saturday": time.Saturday,
+	}
+	for spelling, want := range spellings {
+		t.Run(spelling, func(t *testing.T) {
+			sched, err := parseMonthlyWeekday("@monthly-weekday 1 "+spelling, time.UTC)
+			require.NoError(t, err)
+			assert.Equal(t, want, sched.weekday)
+		})
+	}
+}
+
+// TestCronParser_DelegatesAndDetects verifies the wrapping parser routes
+// descriptors to the monthly-weekday grammar, delegates ordinary cron and
+// built-in descriptors to the standard parser, and honours a CRON_TZ prefix on
+// a monthly-weekday descriptor.
+func TestCronParser_DelegatesAndDetects(t *testing.T) {
+	p := newCronParser()
+
+	t.Run("monthly-weekday", func(t *testing.T) {
+		sched, err := p.Parse("@monthly-weekday 3 wed at 09:00")
+		require.NoError(t, err)
+		_, ok := sched.(monthlyWeekdaySchedule)
+		assert.True(t, ok, "expected a monthlyWeekdaySchedule")
+	})
+
+	t.Run("standard cron still works", func(t *testing.T) {
+		sched, err := p.Parse("* * 1 * *")
+		require.NoError(t, err)
+		assert.NotNil(t, sched)
+	})
+
+	t.Run("builtin descriptor still works", func(t *testing.T) {
+		sched, err := p.Parse("@hourly")
+		require.NoError(t, err)
+		assert.NotNil(t, sched)
+	})
+
+	t.Run("CRON_TZ prefix on descriptor pins the zone", func(t *testing.T) {
+		sched, err := p.Parse("CRON_TZ=America/New_York @monthly-weekday 3 wed at 09:00")
+		require.NoError(t, err)
+		mw, ok := sched.(monthlyWeekdaySchedule)
+		require.True(t, ok)
+		require.NotNil(t, mw.loc)
+		assert.Equal(t, "America/New_York", mw.loc.String())
+	})
+
+	t.Run("bad zone prefix is rejected", func(t *testing.T) {
+		_, err := p.Parse("CRON_TZ=Bad/Zone @monthly-weekday 3 wed")
+		require.Error(t, err)
+	})
+
+	t.Run("descriptor errors surface", func(t *testing.T) {
+		_, err := p.Parse("@monthly-weekday 9 wed")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "ordinal")
+	})
+}
+
+// TestValidateCronFormat_Extended confirms validation and firing share the one
+// grammar: the descriptor is accepted, ordinary cron still is, and garbage is
+// still rejected.
+func TestValidateCronFormat_Extended(t *testing.T) {
+	assert.NoError(t, ValidateCronFormat("@monthly-weekday 2 tue offset 1 at 03:00"))
+	assert.NoError(t, ValidateCronFormat("* * 1 * *"))
+	assert.Error(t, ValidateCronFormat("* * * *"))
+	assert.Error(t, ValidateCronFormat("@monthly-weekday 3 funday"))
+}
+
+func TestNextRunTimes(t *testing.T) {
+	setupScheduleConfig(t, "UTC")
+
+	runs, err := NextRunTimes("@monthly-weekday 3 wed at 09:00", 3)
+	require.NoError(t, err)
+	require.Len(t, runs, 3)
+	// Strictly increasing and all in the future.
+	assert.True(t, runs[0].After(time.Now()))
+	assert.True(t, runs[1].After(runs[0]))
+	assert.True(t, runs[2].After(runs[1]))
+
+	_, err = NextRunTimes("not a cron", 3)
+	assert.Error(t, err)
+}

--- a/services/schedules/monthly_weekday_test.go
+++ b/services/schedules/monthly_weekday_test.go
@@ -210,6 +210,8 @@ func TestMonthlyWeekday_AmbientTimezone(t *testing.T) {
 	assert.Equal(t, "EST", next.In(ny).Format("MST"))
 }
 
+// mustParseAmbient parses a descriptor with no pinned timezone (evaluated in the
+// ambient location) and fails the test if it is rejected.
 func mustParseAmbient(t *testing.T, spec string) monthlyWeekdaySchedule {
 	t.Helper()
 	sched, err := parseMonthlyWeekday(spec, nil)

--- a/web/src/components/ScheduleForm.vue
+++ b/web/src/components/ScheduleForm.vue
@@ -205,7 +205,80 @@
           </div>
         </div>
 
-        <div>
+        <div v-if="timing === 'monthlyWeekday'">
+          <div class="d-flex mt-4" style="gap: 12px;">
+            <v-select
+              v-model="mwOrdinal"
+              :items="ORDINALS"
+              item-value="id"
+              item-text="title"
+              label="Occurrence"
+              :disabled="formSaving"
+              @change="refreshCron()"
+              outlined
+              hide-details
+              dense
+            />
+            <v-select
+              v-model="mwWeekday"
+              :items="WEEKDAYS"
+              item-value="id"
+              item-text="title"
+              label="Weekday"
+              :disabled="formSaving"
+              @change="refreshCron()"
+              outlined
+              hide-details
+              dense
+            />
+            <v-text-field
+              v-model.number="mwOffset"
+              type="number"
+              label="Offset (days)"
+              hint="e.g. Second Tuesday + 1 = first Wednesday after Patch Tuesday"
+              persistent-hint
+              :disabled="formSaving"
+              @input="refreshCron()"
+              outlined
+              dense
+            />
+          </div>
+
+          <div class="mt-4 d-flex justify-space-between">
+            <span>Hours</span>
+            <b style="color: red;">{{ timezone + ' time' }}</b>
+          </div>
+          <div class="d-flex flex-wrap">
+            <v-checkbox
+              class="mr-2 mt-0 ScheduleCheckbox"
+              v-for="h in 24"
+              :key="h - 1"
+              :value="h - 1"
+              :label="`${h - 1}`"
+              v-model="mwHours"
+              color="white"
+              :class="{'ScheduleCheckbox--active': mwHours.includes(h - 1)}"
+              @change="selectMwHour()"
+            ></v-checkbox>
+          </div>
+
+          <div class="mt-4">Minutes</div>
+          <div class="d-flex flex-wrap">
+            <v-checkbox
+              class="mr-2 mt-0 ScheduleCheckbox"
+              v-for="m in MINUTES"
+              :key="m.id"
+              :value="m.id"
+              :label="m.title"
+              v-model="mwMinutes"
+              color="white"
+              :class="{'ScheduleCheckbox--active': mwMinutes.includes(m.id)}"
+              @change="selectMwMinute()"
+            ></v-checkbox>
+          </div>
+        </div>
+
+        <div v-if="timing !== 'monthlyWeekday'">
           <div class="mt-4">Minutes</div>
           <div class="d-flex flex-wrap">
             <v-checkbox
@@ -368,6 +441,9 @@ const TIMINGS = [{
   id: 'monthly',
   title: 'Monthly',
 }, {
+  id: 'monthlyWeekday',
+  title: 'Monthly (by weekday)',
+}, {
   id: 'weekly',
   title: 'Weekly',
 }, {
@@ -377,6 +453,21 @@ const TIMINGS = [{
   id: 'hourly',
   title: 'Hourly',
 }];
+
+// Ordinals for the "Monthly (by weekday)" builder. 'last' selects the final
+// occurrence of the weekday in the month.
+const ORDINALS = [
+  { id: 1, title: 'First' },
+  { id: 2, title: 'Second' },
+  { id: 3, title: 'Third' },
+  { id: 4, title: 'Fourth' },
+  { id: 5, title: 'Fifth' },
+  { id: 'last', title: 'Last' },
+];
+
+// Short weekday names understood by the @monthly-weekday descriptor, indexed by
+// the same ids the WEEKDAYS list uses (0 = Sunday).
+const WEEKDAY_NAMES = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
 
 const WEEKDAYS = [{
   id: 0,
@@ -468,6 +559,7 @@ export default {
       templates: null,
       timing: 'hourly',
       TIMINGS,
+      ORDINALS,
       MONTHS,
       WEEKDAYS,
       MINUTES,
@@ -476,6 +568,18 @@ export default {
       days: [],
       months: [],
       weekdays: [],
+      // "Monthly (by weekday)" builder state. Hour/minute are single-element
+      // arrays so they can reuse the same chip grids as the other timings while
+      // the descriptor still carries exactly one time of day.
+      mwOrdinal: 1,
+      mwWeekday: 1,
+      mwOffset: 0,
+      mwHours: [0],
+      mwMinutes: [0],
+      // Backend-computed upcoming activations, used for the "Next run time"
+      // preview of formats the JS cron parser cannot evaluate (e.g. the
+      // @monthly-weekday descriptor).
+      backendNextRuns: [],
       rawCron: false,
       disableRawCron: false,
       showInfo: true,
@@ -603,13 +707,19 @@ export default {
           tz: this.timezone,
         }).next().toDate();
       } catch {
+        // Formats the JS cron parser cannot evaluate (e.g. the
+        // @monthly-weekday descriptor) fall back to the backend-computed
+        // preview populated by validateCronFormat().
+        if (this.backendNextRuns.length > 0) {
+          return this.backendNextRuns[0];
+        }
         return null;
       }
     },
 
     async validateCronFormat(cronFormat) {
       try {
-        await axios({
+        const res = await axios({
           method: 'post',
           url: `/api/project/${this.projectId}/schedules/validate`,
           responseType: 'json',
@@ -618,10 +728,78 @@ export default {
             cron_format: cronFormat,
           },
         });
+        const runs = (res.data && res.data.next_run) || [];
+        this.backendNextRuns = runs
+          .map((s) => new Date(s))
+          .filter((d) => !Number.isNaN(d.getTime()));
         return null;
       } catch (err) {
+        this.backendNextRuns = [];
         return getErrorMessage(err);
       }
+    },
+
+    weekdayName(id) {
+      return WEEKDAY_NAMES[id] ?? 'sun';
+    },
+
+    // The hour/minute chip grids are single-select for this timing (the
+    // descriptor carries one time of day), so keep only the most recent pick.
+    selectMwHour() {
+      if (this.mwHours.length > 1) {
+        this.mwHours = this.mwHours.slice(-1);
+      }
+      this.refreshCron();
+    },
+
+    selectMwMinute() {
+      if (this.mwMinutes.length > 1) {
+        this.mwMinutes = this.mwMinutes.slice(-1);
+      }
+      this.refreshCron();
+    },
+
+    // buildMonthlyWeekday renders the current builder state into a
+    // @monthly-weekday descriptor string.
+    buildMonthlyWeekday() {
+      const offset = Number.isFinite(this.mwOffset) ? this.mwOffset : 0;
+      let s = `@monthly-weekday ${this.mwOrdinal} ${this.weekdayName(this.mwWeekday)}`;
+      if (offset !== 0) {
+        s += ` offset ${offset}`;
+      }
+      const hour = this.mwHours.length ? this.mwHours[this.mwHours.length - 1] : 0;
+      const minute = this.mwMinutes.length ? this.mwMinutes[this.mwMinutes.length - 1] : 0;
+      s += ` at ${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+      return s;
+    },
+
+    // parseMonthlyWeekday loads a descriptor into the builder state and selects
+    // the monthlyWeekday timing. Returns false if the string is not a
+    // recognisable descriptor, so the caller can fall back to the cron parser.
+    parseMonthlyWeekday(s) {
+      const m = /^@monthly-weekday\s+(\S+)\s+(\S+)(.*)$/i.exec((s || '').trim());
+      if (!m) {
+        return false;
+      }
+
+      const ord = m[1].toLowerCase();
+      const weekday = WEEKDAY_NAMES.indexOf(m[2].toLowerCase().slice(0, 3));
+      if (weekday < 0) {
+        return false;
+      }
+      this.mwOrdinal = ord === 'last' ? 'last' : parseInt(ord, 10);
+      this.mwWeekday = weekday;
+
+      const rest = m[3] || '';
+      const offMatch = /offset\s+(-?\d+)/i.exec(rest);
+      this.mwOffset = offMatch ? parseInt(offMatch[1], 10) : 0;
+
+      const atMatch = /at\s+(\d{1,2}):(\d{2})/i.exec(rest);
+      this.mwHours = [atMatch ? parseInt(atMatch[1], 10) : 0];
+      this.mwMinutes = [atMatch ? parseInt(atMatch[2], 10) : 0];
+
+      this.timing = 'monthlyWeekday';
+      return true;
     },
 
     async refreshCheckboxes() {
@@ -652,6 +830,12 @@ export default {
         this.cronFormatError = cronError;
         this.rawCron = true;
         this.disableRawCron = true;
+        return;
+      }
+
+      // The @monthly-weekday descriptor has its own builder and is not
+      // understood by the JS cron parser; load it directly.
+      if (this.parseMonthlyWeekday(cronFormat)) {
         return;
       }
 
@@ -766,6 +950,13 @@ export default {
     },
 
     refreshCron() {
+      if (this.timing === 'monthlyWeekday') {
+        this.item.cron_format = this.buildMonthlyWeekday();
+        // Refresh the backend-authoritative preview for the descriptor.
+        this.validateCronFormat(this.item.cron_format);
+        return;
+      }
+
       const fields = {};
 
       switch (this.timing) {

--- a/web/src/components/ScheduleForm.vue
+++ b/web/src/components/ScheduleForm.vue
@@ -238,6 +238,8 @@
               hint="e.g. Second Tuesday + 1 = first Wednesday after Patch Tuesday"
               persistent-hint
               :disabled="formSaving"
+              :error="cronFormatError != null"
+              :error-messages="cronFormatError"
               @input="refreshCron()"
               outlined
               dense
@@ -728,12 +730,18 @@ export default {
             cron_format: cronFormat,
           },
         });
+        if (cronFormat !== this.item.cron_format) {
+          return null; // stale response — a newer value is already in flight
+        }
         const runs = (res.data && res.data.next_run) || [];
         this.backendNextRuns = runs
           .map((s) => new Date(s))
           .filter((d) => !Number.isNaN(d.getTime()));
         return null;
       } catch (err) {
+        if (cronFormat !== this.item.cron_format) {
+          return null; // stale response — ignore
+        }
         this.backendNextRuns = [];
         return getErrorMessage(err);
       }
@@ -949,11 +957,17 @@ export default {
       return /^[^*]\S*\s\S+\s\S+\s\S+\s\S+$/.test(s);
     },
 
-    refreshCron() {
+    async refreshCron() {
       if (this.timing === 'monthlyWeekday') {
-        this.item.cron_format = this.buildMonthlyWeekday();
-        // Refresh the backend-authoritative preview for the descriptor.
-        this.validateCronFormat(this.item.cron_format);
+        const cronFormat = this.buildMonthlyWeekday();
+        this.item.cron_format = cronFormat;
+        // Backend-authoritative preview; a rejection (reachable through the
+        // free-input offset) must surface, not silently blank the preview.
+        const cronError = await this.validateCronFormat(cronFormat);
+        if (cronFormat !== this.item.cron_format) {
+          return; // the value changed while validating, ignore stale result
+        }
+        this.cronFormatError = cronError;
         return;
       }
 

--- a/web/src/components/ScheduleForm.vue
+++ b/web/src/components/ScheduleForm.vue
@@ -822,7 +822,9 @@ export default {
       const atMatch = /at\s+(\d{1,2}):(\d{2})/i.exec(rest);
       const hour = atMatch ? parseInt(atMatch[1], 10) : 0;
       const minute = atMatch ? parseInt(atMatch[2], 10) : 0;
-      if (!Number.isFinite(hour) || hour < 0 || hour > 23 || !Number.isFinite(minute) || minute < 0 || minute > 59) {
+      const badHour = !Number.isFinite(hour) || hour < 0 || hour > 23;
+      const badMinute = !Number.isFinite(minute) || minute < 0 || minute > 59;
+      if (badHour || badMinute) {
         return false;
       }
       this.mwHours = [hour];
@@ -830,6 +832,7 @@ export default {
 
       this.timing = 'monthlyWeekday';
       return true;
+    },
 
     async refreshCheckboxes() {
       if (this.type === 'run_at') {

--- a/web/src/components/ScheduleForm.vue
+++ b/web/src/components/ScheduleForm.vue
@@ -792,25 +792,44 @@ export default {
         return false;
       }
 
-      const ord = m[1].toLowerCase();
+      const ordRaw = m[1].toLowerCase();
       const weekday = WEEKDAY_NAMES.indexOf(m[2].toLowerCase().slice(0, 3));
       if (weekday < 0) {
         return false;
       }
-      this.mwOrdinal = ord === 'last' ? 'last' : parseInt(ord, 10);
+
+      let ordinal;
+      if (ordRaw === 'last') {
+        ordinal = 'last';
+      } else {
+        const n = parseInt(ordRaw, 10);
+        if (!Number.isFinite(n) || n < 1 || n > 5) {
+          return false;
+        }
+        ordinal = n;
+      }
+      this.mwOrdinal = ordinal;
       this.mwWeekday = weekday;
 
       const rest = m[3] || '';
       const offMatch = /offset\s+(-?\d+)/i.exec(rest);
-      this.mwOffset = offMatch ? parseInt(offMatch[1], 10) : 0;
+      const off = offMatch ? parseInt(offMatch[1], 10) : 0;
+      if (!Number.isFinite(off) || off < -28 || off > 28) {
+        return false;
+      }
+      this.mwOffset = off;
 
       const atMatch = /at\s+(\d{1,2}):(\d{2})/i.exec(rest);
-      this.mwHours = [atMatch ? parseInt(atMatch[1], 10) : 0];
-      this.mwMinutes = [atMatch ? parseInt(atMatch[2], 10) : 0];
+      const hour = atMatch ? parseInt(atMatch[1], 10) : 0;
+      const minute = atMatch ? parseInt(atMatch[2], 10) : 0;
+      if (!Number.isFinite(hour) || hour < 0 || hour > 23 || !Number.isFinite(minute) || minute < 0 || minute > 59) {
+        return false;
+      }
+      this.mwHours = [hour];
+      this.mwMinutes = [minute];
 
       this.timing = 'monthlyWeekday';
       return true;
-    },
 
     async refreshCheckboxes() {
       if (this.type === 'run_at') {

--- a/web/src/components/ScheduleForm.vue
+++ b/web/src/components/ScheduleForm.vue
@@ -234,13 +234,15 @@
             <v-text-field
               v-model.number="mwOffset"
               type="number"
+              min="-28"
+              max="28"
               label="Offset (days)"
               hint="e.g. Second Tuesday + 1 = first Wednesday after Patch Tuesday"
               persistent-hint
               :disabled="formSaving"
               :error="cronFormatError != null"
               :error-messages="cronFormatError"
-              @input="refreshCron()"
+              @change="refreshCron()"
               outlined
               dense
             />


### PR DESCRIPTION
A suggestion on how to add support for scheduling tasks like "the third Wednesday of the month" or "the first Wednesday after Patch Tuesday," which standard cron can't express.

You write it as a simple schedule descriptor in the existing cron field:

@monthly-weekday <ordinal> <weekday> [offset <days>] [at <HH:MM>]

Examples:
- @monthly-weekday 3 wed at 09:00 → third Wednesday, 9am
- @monthly-weekday 2 tue offset 1 at 03:00 → first Wednesday after Patch Tuesday
- @monthly-weekday last fri at 22:30 → last Friday

There's also a "Monthly (by weekday)" option in the schedule form - its Hours/Minutes use the same chip grids as the existing Monthly builder, plus Occurrence, Weekday, and an Offset (days) field - and the "Next run time" preview works for it. The offset makes patch-Tuesday-relative windows easy (Second Tuesday + 1 = the Wednesday after Patch Tuesday), which is handy when patching Windows servers.

Addresses #3600, #2349, #2241, #1172 - all requests for this (first Tuesday, third Friday, last Wednesday, first Monday of the month), which people have been working around with uggly hacks and external cron.

Notes
- Reuses the existing cron_format field - no DB migrations needed.
- No new dependency so it should work in HA mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monthly weekday scheduling with ordinal or last-weekday options, offsets, custom times, and timezone support.
  * Added schedule form controls and upcoming-run previews.
  * Added validation with the next five activation times for valid schedules.
  * Added support for standard cron expressions, descriptors, and timezone prefixes.
* **Bug Fixes**
  * Improved handling and error messages for invalid scheduling formats.
  * Preserved existing cron behavior while supporting the new scheduling options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->