### PR TITLE
feat: survey variable for multi select (carry forward #3351)

### DIFF
--- a/db/Template.go
+++ b/db/Template.go
@@ -1,7 +1,9 @@
 package db
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/semaphoreui/semaphore/pkg/common_errors"
@@ -65,10 +67,11 @@ func (t TemplateApp) IsTerraform() bool {
 type SurveyVarType string
 
 const (
-	SurveyVarStr  TemplateType = ""
-	SurveyVarInt  TemplateType = "int"
-	SurveyVarEnum TemplateType = "enum"
-	SurveyVarText TemplateType = "text"
+	SurveyVarStr    SurveyVarType = ""
+	SurveyVarInt    SurveyVarType = "int"
+	SurveyVarEnum   SurveyVarType = "enum"
+	SurveyVarText   SurveyVarType = "text"
+	SurveyVarSelect SurveyVarType = "select"
 )
 
 type SurveyVarTarget string
@@ -80,6 +83,57 @@ const (
 	// SurveyVarTargetEnv passes the variable as a process environment variable.
 	SurveyVarTargetEnv SurveyVarTarget = "env"
 )
+
+// SurveyVarDefaultValue supports both a single string or an array of strings in JSON.
+// It preserves whether the original JSON was an array so encoding will keep the
+// original shape when possible (single value -> string, multiple -> array).
+type SurveyVarDefaultValue struct {
+	Values           []string `json:"-"`
+	originalWasArray bool     `json:"-"`
+}
+
+func (d *SurveyVarDefaultValue) UnmarshalJSON(b []byte) error {
+	if len(bytes.TrimSpace(b)) == 0 || bytes.Equal(bytes.TrimSpace(b), []byte("null")) {
+		d.Values = nil
+		d.originalWasArray = false
+		return nil
+	}
+
+	// try string
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		d.Values = []string{s}
+		d.originalWasArray = false
+		return nil
+	}
+
+	// try []string
+	var arr []string
+	if err := json.Unmarshal(b, &arr); err == nil {
+		d.Values = arr
+		d.originalWasArray = true
+		return nil
+	}
+
+	return fmt.Errorf("invalid default_value: must be string or []string")
+}
+
+func (d SurveyVarDefaultValue) MarshalJSON() ([]byte, error) {
+	if d.Values == nil {
+		return []byte("null"), nil
+	}
+	if len(d.Values) == 1 && !d.originalWasArray {
+		return json.Marshal(d.Values[0])
+	}
+	return json.Marshal(d.Values)
+}
+
+func (d SurveyVarDefaultValue) String() string {
+	if len(d.Values) == 0 {
+		return ""
+	}
+	return d.Values[0]
+}
 
 type AnsibleTemplateParams struct {
 	AllowDebug             bool     `json:"allow_debug"`
@@ -113,14 +167,14 @@ type SurveyVarEnumValue struct {
 }
 
 type SurveyVar struct {
-	Name         string               `json:"name" backup:"name"`
-	Title        string               `json:"title" backup:"title"`
-	Required     bool                 `json:"required,omitempty" backup:"required"`
-	Type         SurveyVarType        `json:"type,omitempty" backup:"type"`
-	Target       SurveyVarTarget      `json:"target,omitempty" backup:"target"`
-	Description  string               `json:"description,omitempty" backup:"description"`
-	Values       []SurveyVarEnumValue `json:"values,omitempty" backup:"values"`
-	DefaultValue string               `json:"default_value,omitempty" backup:"default_value"`
+	Name         string                 `json:"name" backup:"name"`
+	Title        string                 `json:"title" backup:"title"`
+	Required     bool                   `json:"required,omitempty" backup:"required"`
+	Type         SurveyVarType          `json:"type,omitempty" backup:"type"`
+	Target       SurveyVarTarget        `json:"target,omitempty" backup:"target"`
+	Description  string                 `json:"description,omitempty" backup:"description"`
+	Values       []SurveyVarEnumValue   `json:"values,omitempty" backup:"values"`
+	DefaultValue *SurveyVarDefaultValue `json:"default_value,omitempty" backup:"default_value"`
 }
 
 type TemplateFilter struct {

--- a/db/Template.go
+++ b/db/Template.go
@@ -135,6 +135,82 @@ func (d SurveyVarDefaultValue) String() string {
 	return d.Values[0]
 }
 
+// IsArray reports whether the value was decoded from a JSON array.
+// Used by ValidateSurveyVar to enforce type/default_value compatibility.
+func (d SurveyVarDefaultValue) IsArray() bool {
+	return d.originalWasArray
+}
+
+// ValidateSurveyVar enforces compatibility between a SurveyVar's Type and
+// its DefaultValue. The custom SurveyVarDefaultValue codec preserves the
+// original JSON shape (string vs []string), which means a client can submit
+// a default_value that does not match the declared type (e.g. an array for
+// an "int" var, or a scalar for a "select" var). Without this check, bad
+// data lands in the DB and surfaces as UI glitches or runtime errors much
+// later.
+//
+// Rules:
+//   - For SurveyVarSelect: default_value must be array-shaped (or nil).
+//     A single scalar string is accepted and normalised to [scalar] to
+//     stay backward-compatible with clients that predate the select type.
+//   - For all other types: default_value must be scalar-shaped (or nil).
+//     An array with exactly one element is accepted and the caller is
+//     expected to read it via .String(); an array with >1 element is
+//     rejected.
+//   - For SurveyVarEnum and SurveyVarSelect: every value in default_value
+//     must be present in the var's Values list (matched by Value field).
+func ValidateSurveyVar(v SurveyVar) error {
+	switch v.Type {
+	case SurveyVarSelect:
+		if v.DefaultValue != nil {
+			if !v.DefaultValue.IsArray() {
+				// Accept legacy scalar string for backward compat;
+				// it is normalised into [scalar] by the caller on save.
+				if len(v.DefaultValue.Values) > 1 {
+					return common_errors.NewValidationError(
+						"survey variable \"" + v.Name + "\": default_value must be an array for select type")
+				}
+			}
+			// Verify every default value is present in Values.
+			allowed := make(map[string]struct{}, len(v.Values))
+			for _, ev := range v.Values {
+				allowed[ev.Value] = struct{}{}
+			}
+			for _, dv := range v.DefaultValue.Values {
+				if _, ok := allowed[dv]; !ok {
+					return common_errors.NewValidationError(
+						"survey variable \"" + v.Name + "\": default_value \"" + dv + "\" is not in values list")
+				}
+			}
+		}
+	case SurveyVarEnum:
+		if v.DefaultValue != nil {
+			if v.DefaultValue.IsArray() && len(v.DefaultValue.Values) > 1 {
+				return common_errors.NewValidationError(
+					"survey variable \"" + v.Name + "\": default_value must be a string for enum type")
+			}
+			if len(v.DefaultValue.Values) > 0 {
+				allowed := make(map[string]struct{}, len(v.Values))
+				for _, ev := range v.Values {
+					allowed[ev.Value] = struct{}{}
+				}
+				dv := v.DefaultValue.Values[0]
+				if _, ok := allowed[dv]; !ok {
+					return common_errors.NewValidationError(
+						"survey variable \"" + v.Name + "\": default_value \"" + dv + "\" is not in values list")
+				}
+			}
+		}
+	default:
+		// String, int, text, secret: scalar only.
+		if v.DefaultValue != nil && v.DefaultValue.IsArray() && len(v.DefaultValue.Values) > 1 {
+			return common_errors.NewValidationError(
+				"survey variable \"" + v.Name + "\": default_value must be a string for type \"" + string(v.Type) + "\"")
+		}
+	}
+	return nil
+}
+
 type AnsibleTemplateParams struct {
 	AllowDebug             bool     `json:"allow_debug"`
 	AllowOverrideInventory bool     `json:"allow_override_inventory"`
@@ -357,7 +433,11 @@ func (tpl *Template) Validate() error {
 		switch v.Target {
 		case SurveyVarTargetDefault, SurveyVarTargetEnv:
 		default:
-			return &common_errors.ValidationError{"invalid survey variable target: " + string(v.Target)}
+			return &common_errors.ValidationError{Message: "invalid survey variable target: " + string(v.Target)}
+		}
+
+		if err := ValidateSurveyVar(v); err != nil {
+			return err
 		}
 	}
 

--- a/db/Template_test.go
+++ b/db/Template_test.go
@@ -69,6 +69,124 @@ func TestTemplateNormalizedExecutorImage(t *testing.T) {
 	})
 }
 
+func TestSurveyVarDefaultValue_JSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantArray bool
+		wantVals  []string
+		wantOut   string
+	}{
+		{"null", `null`, false, nil, `null`},
+		{"scalar string", `"x"`, false, []string{"x"}, `"x"`},
+		{"empty string", `""`, false, []string{""}, `""`},
+		{"single-element array", `["x"]`, true, []string{"x"}, `["x"]`},
+		{"multi-element array", `["x","y"]`, true, []string{"x", "y"}, `["x","y"]`},
+		{"empty array", `[]`, true, []string{}, `[]`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d SurveyVarDefaultValue
+			require.NoError(t, json.Unmarshal([]byte(tt.input), &d))
+			assert.Equal(t, tt.wantArray, d.IsArray())
+			assert.Equal(t, tt.wantVals, d.Values)
+
+			out, err := json.Marshal(d)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.wantOut, string(out))
+		})
+	}
+}
+
+func TestSurveyVarDefaultValue_JSONRoundTrip_RejectsNonString(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"number", `42`},
+		{"array of numbers", `[1,2,3]`},
+		{"object", `{"k":"v"}`},
+		{"bool", `true`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d SurveyVarDefaultValue
+			assert.Error(t, json.Unmarshal([]byte(tt.input), &d))
+		})
+	}
+}
+
+func TestValidateSurveyVar(t *testing.T) {
+	strVal := func(s string) *SurveyVarDefaultValue {
+		return &SurveyVarDefaultValue{Values: []string{s}}
+	}
+	arrVal := func(s ...string) *SurveyVarDefaultValue {
+		return &SurveyVarDefaultValue{Values: s, originalWasArray: true}
+	}
+	enumValues := []SurveyVarEnumValue{{Name: "A", Value: "a"}, {Name: "B", Value: "b"}}
+
+	tests := []struct {
+		name    string
+		v       SurveyVar
+		wantErr string // substring; empty = no error
+	}{
+		// --- select type ---
+		{"select: nil default ok", SurveyVar{Name: "V", Type: SurveyVarSelect, Values: enumValues}, ""},
+		{"select: empty array ok", SurveyVar{Name: "V", Type: SurveyVarSelect, Values: enumValues, DefaultValue: arrVal()}, ""},
+		{"select: single value in list ok", SurveyVar{Name: "V", Type: SurveyVarSelect, Values: enumValues, DefaultValue: arrVal("a")}, ""},
+		{"select: multi values in list ok", SurveyVar{Name: "V", Type: SurveyVarSelect, Values: enumValues, DefaultValue: arrVal("a", "b")}, ""},
+		{"select: legacy scalar ok (backward compat)", SurveyVar{Name: "V", Type: SurveyVarSelect, Values: enumValues, DefaultValue: strVal("a")}, ""},
+		{"select: value not in list rejected", SurveyVar{Name: "V", Type: SurveyVarSelect, Values: enumValues, DefaultValue: arrVal("zzz")}, "not in values list"},
+		{"select: one of multi not in list rejected", SurveyVar{Name: "V", Type: SurveyVarSelect, Values: enumValues, DefaultValue: arrVal("a", "zzz")}, "not in values list"},
+		{"select: legacy multi-scalar rejected", SurveyVar{Name: "V", Type: SurveyVarSelect, Values: enumValues, DefaultValue: &SurveyVarDefaultValue{Values: []string{"a", "b"}}}, "must be an array"},
+
+		// --- enum type ---
+		{"enum: nil default ok", SurveyVar{Name: "V", Type: SurveyVarEnum, Values: enumValues}, ""},
+		{"enum: scalar in list ok", SurveyVar{Name: "V", Type: SurveyVarEnum, Values: enumValues, DefaultValue: strVal("a")}, ""},
+		{"enum: scalar not in list rejected", SurveyVar{Name: "V", Type: SurveyVarEnum, Values: enumValues, DefaultValue: strVal("zzz")}, "not in values list"},
+		{"enum: array of one ok (lenient)", SurveyVar{Name: "V", Type: SurveyVarEnum, Values: enumValues, DefaultValue: arrVal("a")}, ""},
+		{"enum: array of multi rejected", SurveyVar{Name: "V", Type: SurveyVarEnum, Values: enumValues, DefaultValue: arrVal("a", "b")}, "must be a string for enum"},
+
+		// --- string / int / text / secret types ---
+		{"string: nil default ok", SurveyVar{Name: "V", Type: SurveyVarStr}, ""},
+		{"string: scalar ok", SurveyVar{Name: "V", Type: SurveyVarStr, DefaultValue: strVal("hello")}, ""},
+		{"string: array of one ok (lenient)", SurveyVar{Name: "V", Type: SurveyVarStr, DefaultValue: arrVal("hello")}, ""},
+		{"string: array of multi rejected", SurveyVar{Name: "V", Type: SurveyVarStr, DefaultValue: arrVal("a", "b")}, "must be a string for type"},
+		{"int: scalar ok", SurveyVar{Name: "V", Type: SurveyVarInt, DefaultValue: strVal("42")}, ""},
+		{"int: array of multi rejected", SurveyVar{Name: "V", Type: SurveyVarInt, DefaultValue: arrVal("1", "2")}, "must be a string for type"},
+		{"text: scalar ok", SurveyVar{Name: "V", Type: SurveyVarText, DefaultValue: strVal("long text")}, ""},
+		{"secret: scalar ok", SurveyVar{Name: "V", Type: SurveyVarText, DefaultValue: strVal("s3cr3t")}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSurveyVar(tt.v)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTemplateValidate_SurveyVarDefaultValue(t *testing.T) {
+	// Validate() must surface ValidateSurveyVar errors end-to-end.
+	tpl := Template{
+		Name:       "test",
+		Playbook:   "playbook.yml",
+		SurveyVars: []SurveyVar{
+			{
+				Name:         "BAD",
+				Title:        "Bad",
+				Type:         SurveyVarStr,
+				DefaultValue: &SurveyVarDefaultValue{Values: []string{"a", "b"}, originalWasArray: true},
+			},
+		},
+	}
+	err := tpl.Validate()
+	assert.ErrorContains(t, err, "must be a string for type")
+}
+
 func strPtr(s string) *string {
 	return &s
 }

--- a/services/tasks/local_executor.go
+++ b/services/tasks/local_executor.go
@@ -223,6 +223,26 @@ func (t *LocalExecutor) getEnvironmentENV() (res []string, err error) {
 	return
 }
 
+// formatVarValue renders a survey/extra var value for single-string contexts
+// (process env vars, terraform -var). Arrays and objects (produced by
+// multi-select survey vars) are JSON-encoded so lists survive the round-trip
+// instead of degrading to Go's fmt representation like "[1 2]". JSON is also
+// what terraform expects for list/object values passed via -var.
+func formatVarValue(val any) string {
+	switch v := val.(type) {
+	case string:
+		return v
+	case []any, map[string]any:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return string(b)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
 // getSurveyEnvVars returns NAME=value pairs for survey vars with Target "env".
 // Values are read from the merged task environment (Environment.JSON) and the
 // Secret field — the same sources getEnvironmentExtraVars reads, which excludes
@@ -249,7 +269,7 @@ func (t *LocalExecutor) getSurveyEnvVars() (res []string, err error) {
 			continue
 		}
 		if val, ok := vars[v.Name]; ok {
-			res = append(res, fmt.Sprintf("%s=%v", v.Name, val))
+			res = append(res, fmt.Sprintf("%s=%s", v.Name, formatVarValue(val)))
 		}
 	}
 
@@ -363,7 +383,7 @@ func (t *LocalExecutor) getTerraformArgs(username string, incomingVersion *strin
 		if name == "semaphore_vars" {
 			continue
 		}
-		varArgs = append(varArgs, "-var", fmt.Sprintf("%s=%s", name, value))
+		varArgs = append(varArgs, "-var", fmt.Sprintf("%s=%s", name, formatVarValue(value)))
 	}
 
 	templateArgsMap, taskArgsMap, err := t.getCLIArgsMap()

--- a/services/tasks/local_executor_test.go
+++ b/services/tasks/local_executor_test.go
@@ -134,3 +134,71 @@ func TestGetSurveyEnvVars(t *testing.T) {
 	assert.Contains(t, envVars, "SECRET_ENV_VAR=s3cr3t")
 	assert.Len(t, envVars, 2, "CLI-target and valueless vars must not be included")
 }
+
+// TestFormatVarValue verifies values from multi-select survey vars (arrays)
+// are JSON-encoded instead of degrading to Go's fmt representation.
+func TestFormatVarValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{"string", "hello", "hello"},
+		{"array", []any{"1", "2"}, `["1","2"]`},
+		{"empty array", []any{}, `[]`},
+		{"object", map[string]any{"k": "v"}, `{"k":"v"}`},
+		{"number", float64(42), "42"},
+		{"bool", true, "true"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatVarValue(tt.input))
+		})
+	}
+}
+
+// TestGetSurveyEnvVars_MultiSelect verifies env-target multi-select survey
+// vars are delivered as JSON arrays, not Go-formatted slices like "[1 2]".
+func TestGetSurveyEnvVars_MultiSelect(t *testing.T) {
+	setupExecutorConfig(t)
+
+	exec := &LocalExecutor{
+		Template: db.Template{
+			SurveyVars: []db.SurveyVar{
+				{Name: "MULTI_VAR", Type: db.SurveyVarSelect, Target: db.SurveyVarTargetEnv},
+			},
+		},
+		Environment: db.Environment{JSON: `{"MULTI_VAR":["1","2"]}`},
+	}
+
+	envVars, err := exec.getSurveyEnvVars()
+	require.NoError(t, err)
+
+	assert.Contains(t, envVars, `MULTI_VAR=["1","2"]`)
+}
+
+// TestGetTerraformArgs_MultiSelect verifies multi-select survey vars reach
+// terraform as -var name=<JSON list>, which terraform parses as a list value.
+func TestGetTerraformArgs_MultiSelect(t *testing.T) {
+	setupExecutorConfig(t)
+
+	exec := &LocalExecutor{
+		Template: db.Template{
+			Type: db.TemplateTask,
+			App:  db.AppTerraform,
+		},
+		Environment: db.Environment{JSON: `{"multi_var":["1","2"]}`},
+	}
+
+	argsMap, err := exec.getTerraformArgs("admin", nil)
+	require.NoError(t, err)
+
+	defaultArgs := argsMap["default"]
+	found := false
+	for i, arg := range defaultArgs {
+		if arg == "-var" && i+1 < len(defaultArgs) && defaultArgs[i+1] == `multi_var=["1","2"]` {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected -var multi_var=[\"1\",\"2\"] in %v", defaultArgs)
+}

--- a/web/src/components/SurveyVars.vue
+++ b/web/src/components/SurveyVars.vue
@@ -369,14 +369,14 @@ export default {
 
       if (this.editedVar.type === 'enum' || this.editedVar.type === 'select') {
         if (this.editedValues.length === 0) {
-          this.formError = '${typeLabel} must have values.';
+          this.formError = `${typeLabel} must have values.`;
           return;
         }
 
         const uniq = new Set(this.editedValues.map((v) => v.name));
 
         if (this.editedValues.length !== uniq.size) {
-          this.formError = '${typeLabel} must have unique names.';
+          this.formError = `${typeLabel} must have unique names.`;
           return;
         }
 

--- a/web/src/components/SurveyVars.vue
+++ b/web/src/components/SurveyVars.vue
@@ -43,7 +43,6 @@
                   item-text="name"
                   dense
                   outlined
-                  @change="onTypeChange"
                 ></v-select>
               </v-col>
               <v-col cols="7">
@@ -257,6 +256,26 @@ export default {
     vars(val) {
       this.var = val || [];
     },
+
+    'editedVar.type': {
+      handler(newType, oldType) {
+        if (!this.editedVar || newType === oldType) {
+          return;
+        }
+
+        if (newType === 'select') {
+          this.$set(this.editedVar, 'default_value', []);
+        } else {
+          this.$set(this.editedVar, 'default_value', '');
+        }
+
+        const isNotListType = newType !== 'enum' && newType !== 'select';
+        if (isNotListType) {
+          this.editedValues = [];
+          this.editedVar.values = this.editedValues;
+        }
+      },
+    },
   },
 
   created() {
@@ -335,19 +354,10 @@ export default {
       this.editedValues.push(...(this.editedVar.values || []));
       this.editedVar.values = this.editedValues;
 
-      // normalize default_value for select vs enum
-      if (this.editedVar.type === 'select') {
-        if (this.editedVar.default_value == null) {
-          this.editedVar.default_value = [];
-        } else if (!Array.isArray(this.editedVar.default_value)) {
-          const dv = this.editedVar.default_value;
-          this.editedVar.default_value = dv === '' ? [] : [dv];
-        }
-      } else if (Array.isArray(this.editedVar.default_value)) {
-        this.editedVar.default_value = this.editedVar.default_value.length > 0
-          ? this.editedVar.default_value[0]
-          : '';
-      }
+      this.editedVar.default_value = this.normalizeDefaultValue(
+        this.editedVar.type,
+        this.editedVar.default_value,
+      );
 
       this.editedVarIndex = index;
 
@@ -393,17 +403,10 @@ export default {
         this.editedVar.values = [];
       }
 
-      // normalize default_value before saving: select keeps array, others use string
-      if (this.editedVar.type === 'select') {
-        if (!Array.isArray(this.editedVar.default_value)) {
-          const dv = this.editedVar.default_value;
-          this.editedVar.default_value = dv == null || dv === '' ? [] : [dv];
-        }
-      } else if (Array.isArray(this.editedVar.default_value)) {
-        this.editedVar.default_value = this.editedVar.default_value.length > 0
-          ? this.editedVar.default_value[0]
-          : '';
-      }
+      this.editedVar.default_value = this.normalizeDefaultValue(
+        this.editedVar.type,
+        this.editedVar.default_value,
+      );
 
       if (this.editedVarIndex != null) {
         this.modifiedVars[this.editedVarIndex] = this.editedVar;
@@ -440,18 +443,15 @@ export default {
       return (found && found.name) || String(item);
     },
 
-    onTypeChange(newType) {
-      if (!this.editedVar) return;
-      if (newType === 'select') {
-        if (!Array.isArray(this.editedVar.default_value)) {
-          const dv = this.editedVar.default_value;
-          this.editedVar.default_value = dv == null || dv === '' ? [] : [dv];
-        }
-      } else if (Array.isArray(this.editedVar.default_value)) {
-        this.editedVar.default_value = this.editedVar.default_value.length > 0
-          ? this.editedVar.default_value[0]
-          : '';
+    normalizeDefaultValue(type, value) {
+      if (type === 'select') {
+        if (Array.isArray(value)) return value;
+        return value == null || value === '' ? [] : [value];
       }
+      if (Array.isArray(value)) {
+        return value.length > 0 ? value[0] : '';
+      }
+      return value ?? '';
     },
 
     onDragEnd() {

--- a/web/src/components/SurveyVars.vue
+++ b/web/src/components/SurveyVars.vue
@@ -43,6 +43,7 @@
                   item-text="name"
                   dense
                   outlined
+                  @change="onTypeChange"
                 ></v-select>
               </v-col>
               <v-col cols="7">
@@ -59,7 +60,7 @@
             </v-row>
 
             <v-card
-              v-if="editedVar.type === 'enum'"
+              v-if="editedVar.type === 'enum' || editedVar.type === 'select'"
               style="background: var(--highlighted-card-bg-color)"
               class="mb-4 pt-3"
             >
@@ -129,7 +130,20 @@
                   dense
                   outlined
                   hide-details
-                ></v-select>
+                  :multiple="editedVar.type === 'select'"
+                  :chips="editedVar.type === 'select'"
+                >
+                  <template
+                    v-slot:selection="{ item, index }"
+                    v-if="editedVar.type === 'select'">
+                    <v-chip
+                      small
+                      close
+                      @click:close="removeDefaultItem(index)"
+                      >{{ selectedItemLabel(item) }}
+                    </v-chip>
+                  </template>
+                </v-select>
               </v-card-text>
             </v-card>
 
@@ -277,6 +291,10 @@ export default {
           id: 'text',
           name: 'Text',
         },
+        {
+          id: 'select',
+          name: 'Select',
+        },
       ],
       varTargets: [
         {
@@ -317,6 +335,20 @@ export default {
       this.editedValues.push(...(this.editedVar.values || []));
       this.editedVar.values = this.editedValues;
 
+      // normalize default_value for select vs enum
+      if (this.editedVar.type === 'select') {
+        if (this.editedVar.default_value == null) {
+          this.editedVar.default_value = [];
+        } else if (!Array.isArray(this.editedVar.default_value)) {
+          const dv = this.editedVar.default_value;
+          this.editedVar.default_value = dv === '' ? [] : [dv];
+        }
+      } else if (Array.isArray(this.editedVar.default_value)) {
+        this.editedVar.default_value = this.editedVar.default_value.length > 0
+          ? this.editedVar.default_value[0]
+          : '';
+      }
+
       this.editedVarIndex = index;
 
       if (this.$refs.form) {
@@ -333,7 +365,7 @@ export default {
         return;
       }
 
-      if (this.editedVar.type === 'enum') {
+      if (this.editedVar.type === 'enum' || this.editedVar.type === 'select') {
         if (this.editedValues.length === 0) {
           this.formError = 'Enumeration must have values.';
           return;
@@ -359,6 +391,18 @@ export default {
         this.editedVar.values = [];
       }
 
+      // normalize default_value before saving: select keeps array, others use string
+      if (this.editedVar.type === 'select') {
+        if (!Array.isArray(this.editedVar.default_value)) {
+          const dv = this.editedVar.default_value;
+          this.editedVar.default_value = dv == null || dv === '' ? [] : [dv];
+        }
+      } else if (Array.isArray(this.editedVar.default_value)) {
+        this.editedVar.default_value = this.editedVar.default_value.length > 0
+          ? this.editedVar.default_value[0]
+          : '';
+      }
+
       if (this.editedVarIndex != null) {
         this.modifiedVars[this.editedVarIndex] = this.editedVar;
       } else {
@@ -373,6 +417,39 @@ export default {
     deleteVar(index) {
       this.modifiedVars.splice(index, 1);
       this.$emit('change', this.modifiedVars);
+    },
+
+    // remove one selected default item (for multiple select)
+    removeDefaultItem(index) {
+      if (!this.editedVar || !Array.isArray(this.editedVar.default_value)) {
+        return;
+      }
+
+      if (index >= 0 && index < this.editedVar.default_value.length) {
+        this.editedVar.default_value.splice(index, 1);
+      }
+    },
+
+    // label shown in selection chips - item could be the value or an object
+    selectedItemLabel(item) {
+      if (!item) return '';
+      if (typeof item === 'object' && item.name) return item.name;
+      const found = this.editedValues.find((v) => v.value === item || v.name === item);
+      return (found && found.name) || String(item);
+    },
+
+    onTypeChange(newType) {
+      if (!this.editedVar) return;
+      if (newType === 'select') {
+        if (!Array.isArray(this.editedVar.default_value)) {
+          const dv = this.editedVar.default_value;
+          this.editedVar.default_value = dv == null || dv === '' ? [] : [dv];
+        }
+      } else if (Array.isArray(this.editedVar.default_value)) {
+        this.editedVar.default_value = this.editedVar.default_value.length > 0
+          ? this.editedVar.default_value[0]
+          : '';
+      }
     },
 
     onDragEnd() {

--- a/web/src/components/SurveyVars.vue
+++ b/web/src/components/SurveyVars.vue
@@ -365,16 +365,18 @@ export default {
         return;
       }
 
+      const typeLabel = this.editedVar.type === 'select' ? 'Select' : 'Enumeration';
+
       if (this.editedVar.type === 'enum' || this.editedVar.type === 'select') {
         if (this.editedValues.length === 0) {
-          this.formError = 'Enumeration must have values.';
+          this.formError = '${typeLabel} must have values.';
           return;
         }
 
         const uniq = new Set(this.editedValues.map((v) => v.name));
 
         if (this.editedValues.length !== uniq.size) {
-          this.formError = 'Enumeration values must have unique names.';
+          this.formError = '${typeLabel} must have unique names.';
           return;
         }
 

--- a/web/src/components/TaskForm.vue
+++ b/web/src/components/TaskForm.vue
@@ -102,7 +102,7 @@
           close
           @click:close="deleteItem(v.name, index)"
         >
-          {{ item.name }}
+          {{ item && item.name ? item.name : String(item) }}
         </v-chip>
       </template>
     </v-select>

--- a/web/src/components/TaskForm.vue
+++ b/web/src/components/TaskForm.vue
@@ -86,7 +86,8 @@
         v-model="editedEnvironment[v.name]"
         :required="v.required"
         :rules="[
-          val => !v.required || val != null || v.title + ' ' + $t('isRequired')
+          val => !v.required || (Array.isArray(val) ? val.length > 0 : val != null)
+          || v.title + ' ' + $t('isRequired')
         ]"
         :items="v.values"
         item-text="name"

--- a/web/src/components/TaskForm.vue
+++ b/web/src/components/TaskForm.vue
@@ -80,7 +80,7 @@
 
       <v-select
         clearable
-        v-else-if="v.type === 'enum'"
+        v-else-if="v.type === 'enum' || v.type === 'select'"
         :label="v.title + (v.required ? ' *' : '')"
         :hint="v.description"
         v-model="editedEnvironment[v.name]"
@@ -93,7 +93,19 @@
         item-value="value"
         outlined
         dense
-      />
+        :multiple="v.type === 'select'"
+        :chips="v.type === 'select'"
+      >
+      <template v-if="v.type === 'select'" v-slot:selection="{ item, index }">
+        <v-chip
+          small
+          close
+          @click:close="deleteItem(v.name, index)"
+        >
+          {{ item.name }}
+        </v-chip>
+      </template>
+    </v-select>
 
       <v-textarea
         v-else-if="v.type === 'text'"
@@ -302,6 +314,12 @@ export default {
 
     setArgs(args) {
       this.item.arguments = JSON.stringify(args || []);
+    },
+
+    deleteItem(name, index) {
+      if (Array.isArray(this.editedEnvironment?.[name])) {
+        this.editedEnvironment[name].splice(index, 1);
+      }
     },
 
     getTaskMessage(task) {

--- a/web/src/components/TaskForm.vue
+++ b/web/src/components/TaskForm.vue
@@ -351,6 +351,8 @@ export default {
       this.editedEnvironment = JSON.parse(v.environment || '{}');
       this.editedSecretEnvironment = JSON.parse(v.secret || '{}');
       this.hasCommit = v.commit_hash != null;
+
+      this.normalizeSelectValues();  
     },
 
     isLoaded() {
@@ -422,6 +424,8 @@ export default {
         ...defaultVars,
         ...this.editedEnvironment,
       };
+
+      this.normalizeSelectValues(); 
     },
 
     getInventoryUrl() {
@@ -439,6 +443,19 @@ export default {
 
     getItemsUrl() {
       return `/api/project/${this.projectId}/tasks`;
+    },
+
+    normalizeSelectValues() {
+      if (!this.template || !this.template.survey_vars) return;
+      this.template.survey_vars.forEach((sv) => {
+        if (sv.type !== 'select') return;
+        const cur = this.editedEnvironment[sv.name];
+        if (cur == null || cur === '') {
+          this.$set(this.editedEnvironment, sv.name, []);
+        } else if (!Array.isArray(cur)) {
+          this.$set(this.editedEnvironment, sv.name, [cur]);
+          }
+      });
     },
   },
 };

--- a/web/src/components/TaskForm.vue
+++ b/web/src/components/TaskForm.vue
@@ -352,7 +352,7 @@ export default {
       this.editedSecretEnvironment = JSON.parse(v.secret || '{}');
       this.hasCommit = v.commit_hash != null;
 
-      this.normalizeSelectValues();  
+      this.normalizeSelectValues();
     },
 
     isLoaded() {
@@ -425,7 +425,7 @@ export default {
         ...this.editedEnvironment,
       };
 
-      this.normalizeSelectValues(); 
+      this.normalizeSelectValues();
     },
 
     getInventoryUrl() {
@@ -454,7 +454,7 @@ export default {
           this.$set(this.editedEnvironment, sv.name, []);
         } else if (!Array.isArray(cur)) {
           this.$set(this.editedEnvironment, sv.name, [cur]);
-          }
+        }
       });
     },
   },

--- a/web/src/components/TaskParamsForm.vue
+++ b/web/src/components/TaskParamsForm.vue
@@ -37,7 +37,7 @@
             close
             @click:close="removeSelectedItem(v.name, index)"
           >
-            {{ item.name }}
+            {{ item && item.name ? item.name : String(item) }}
           </v-chip>
         </template>
       </v-select>

--- a/web/src/components/TaskParamsForm.vue
+++ b/web/src/components/TaskParamsForm.vue
@@ -22,7 +22,8 @@
         :hint="v.description"
         v-model="editedEnvironment[v.name]"
         :required="v.required"
-        :rules="[(val) => !v.required || val != null || v.title + ' ' + $t('isRequired')]"
+        :rules="[(val) => !v.required || (Array.isArray(val) ? val.length > 0 : val != null) ||
+         v.title + ' ' + $t('isRequired')]"
         :items="v.values"
         item-text="name"
         item-value="value"

--- a/web/src/components/TaskParamsForm.vue
+++ b/web/src/components/TaskParamsForm.vue
@@ -17,7 +17,7 @@
 
       <v-select
         clearable
-        v-else-if="v.type === 'enum'"
+        v-else-if="v.type === 'enum' || v.type === 'select'"
         :label="v.title + (v.required ? ' *' : '')"
         :hint="v.description"
         v-model="editedEnvironment[v.name]"
@@ -26,9 +26,21 @@
         :items="v.values"
         item-text="name"
         item-value="value"
+        :multiple="v.type === 'select'"
+        :chips="v.type === 'select'"
         outlined
         dense
-      />
+      >
+        <template v-if="v.type === 'select'" v-slot:selection="{ item, index }">
+          <v-chip
+            small
+            close
+            @click:close="removeSelectedItem(v.name, index)"
+          >
+            {{ item.name }}
+          </v-chip>
+        </template>
+      </v-select>
 
       <v-textarea
         v-else-if="v.type === 'text'"
@@ -259,6 +271,18 @@ export default {
 
       this.editedEnvironment = JSON.parse(v.environment || '{}');
       this.editedSecretEnvironment = JSON.parse(v.secret || '{}');
+
+      // Normalize select type variables to ensure they are arrays
+      if (this.template && this.template.survey_vars) {
+        this.template.survey_vars.forEach((surveyVar) => {
+          if (surveyVar.type === 'select' && this.editedEnvironment[surveyVar.name] !== undefined) {
+            const currentValue = this.editedEnvironment[surveyVar.name];
+            if (!Array.isArray(currentValue)) {
+              this.editedEnvironment[surveyVar.name] = currentValue == null || currentValue === '' ? [] : [currentValue];
+            }
+          }
+        });
+      }
     },
 
     isLoaded() {
@@ -320,10 +344,14 @@ export default {
           {},
         );
 
-      this.editedEnvironment = {
-        ...defaultVars,
-        ...this.editedEnvironment,
-      };
+      this.editedEnvironment = { ...defaultVars, ...this.editedEnvironment };
+
+      // Ensure select type variables without values are initialized as empty arrays
+      (this.template.survey_vars || []).forEach((surveyVar) => {
+        if (surveyVar.type === 'select' && this.editedEnvironment[surveyVar.name] === undefined) {
+          this.editedEnvironment[surveyVar.name] = [];
+        }
+      });
     },
 
     getInventoryUrl() {
@@ -337,6 +365,17 @@ export default {
           break;
       }
       return res;
+    },
+
+    removeSelectedItem(varName, index) {
+      const env = this.editedEnvironment;
+      if (!Object.prototype.hasOwnProperty.call(env, varName) || !Array.isArray(env[varName])) {
+        return;
+      }
+
+      if (index < env[varName].length) {
+        env[varName].splice(index, 1);
+      }
     },
   },
 };

--- a/web/src/components/TaskParamsForm.vue
+++ b/web/src/components/TaskParamsForm.vue
@@ -349,8 +349,12 @@ export default {
 
       // Ensure select type variables without values are initialized as empty arrays
       (this.template.survey_vars || []).forEach((surveyVar) => {
-        if (surveyVar.type === 'select' && this.editedEnvironment[surveyVar.name] === undefined) {
+        if (surveyVar.type !== 'select') return;
+        const cur = this.editedEnvironment[surveyVar.name];
+        if (cur == null || cur === '') {
           this.editedEnvironment[surveyVar.name] = [];
+        } else if (!Array.isArray(cur)) {
+          this.editedEnvironment[surveyVar.name] = [cur];
         }
       });
     },

--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -152,6 +152,7 @@ export default {
   key: '{expr}',
   surveyVariables: 'Survey Variables',
   addVariable: 'Add variable',
+  allowMultipleValues: 'Allow multiple values',
   vaultName: 'Vault ID (optional)',
   vaultNameDefault: 'Only one `default` (empty) name may exist',
   default_value: 'Default value',


### PR DESCRIPTION
## What

Carries forward #3351 by @blackb1rd, which adds a new **Select** survey variable type allowing users to pick multiple values when launching a task.

The original PR went stale due to merge conflicts (see [this comment](https://github.com/semaphoreui/semaphore/pull/3351#issuecomment-5139350343)). This PR rebases the change onto current `develop`, resolves the conflicts, and keeps attribution via `Co-authored-by`.

## Changes from #3351

- New `select` survey var type: multi-value selection in the task launch dialog, values edited like `enum`, defaults support multiple values (rendered as removable chips).
- `SurveyVar.DefaultValue` becomes `*SurveyVarDefaultValue`, a JSON type that accepts both a single string and an array of strings, preserving the original shape on re-encode.
- Frontend normalizes `default_value` between string (enum & others) and array (select) when the type is switched.

## Conflict resolution notes

- `db/Template.go`: kept the current `SurveyVarTarget` field and `text` type from `develop`; fixed the constants to be typed `SurveyVarType` (they were `TemplateType`), but kept `SurveyVarStr = ""` (the original PR renamed it to `"str"`, which would break existing templates).
- `SurveyVars.vue` / `TaskParamsForm.vue`: re-applied the select-type UI on top of the reworked template form (highlighted card layout, dense/outlined fields, drag-and-drop chips, `target` selector).
- Wired up the previously-unwired `onTypeChange` handler so `default_value` is normalized immediately when switching the variable type in the dialog.

## Additional fix on top of #3351

The original PR only handled arrays in the ansible `--extra-vars` path (whole map is JSON-marshaled). Arrays degraded to Go's fmt representation (`[1 2]`) in two other paths, fixed here by JSON-encoding non-scalar values (`formatVarValue`):

- survey vars with `target: env` → now delivered as `NAME=["1","2"]`
- terraform `-var name=...` → now `-var 'name=["1","2"]'`, which terraform parses as a list

(The shell CLI-args path still stringifies arrays the old way; left untouched to keep this PR focused.)

## Testing

- `go build ./...`, `go test ./services/tasks/ ./db/` pass; added unit tests for `formatVarValue`, env-target delivery, and terraform args.
- Manually verified in the UI: select var editing with multiple defaults, task launch with multi-select, ansible receives the value as a list (`type_debug` → `list`), env target receives JSON-encoded value.
- Verified `enum` / `string` / `int` / `text` / `secret` survey vars still behave as before.

## Tested also locally

<img width="1676" height="1000" alt="task template" src="https://github.com/user-attachments/assets/0688740e-fddc-473e-9d4d-b95955a3dda4" />
<img width="1666" height="997" alt="run" src="https://github.com/user-attachments/assets/e7bfa0e1-5bb0-4d13-82e2-3db0af289ac4" />
<img width="1672" height="1000" alt="check-log" src="https://github.com/user-attachments/assets/e55499ec-c430-4b41-88ff-5c20a9fb5d3a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multi-select survey variables.
  * Users can choose multiple values, view selections as removable chips, and set multiple default values.
  * Added “Allow multiple values” labeling in the interface.

* **Bug Fixes**
  * Improved validation and handling of structured survey values, including arrays and objects.
  * Multi-select values are preserved when running tasks and passed correctly to environment variables and Terraform configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->