### PR TITLE
Login: lower case email address

### DIFF
--- a/api/login.go
+++ b/api/login.go
@@ -136,7 +136,7 @@ func tryFindLDAPUser(provider util.LdapProvider, username, password string) (*db
 		Username: strings.ToLower(claims.username),
 		Created:  tz.Now(),
 		Name:     claims.name,
-		Email:    claims.email,
+		Email:    strings.ToLower(claims.email),
 		External: true,
 		Alert:    false,
 	}


### PR DESCRIPTION
Hello,

Sometimes email address casing changes and users are recreated.

DB migration script needed to avoid breaking existing installations, e.g.:
```
update `user` set `email` = lower(`email`)
```

Thank you

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LDAP-derived email addresses are now consistently converted to lowercase during account creation and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->