### PR TITLE
Semaphore UI one-click deployment on Cloudzy 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ You can install Semaphore using the following methods:
 * [Docker](https://semaphoreui.com/install/docker)
 * Deploy a VM from a marketplace:
   * [AWS](https://aws.amazon.com/marketplace/pp/prodview-xavlsdkqybxtq)
+  * [Cloudzy](https://cloudzy.com/marketplace/semaphore-ui)
   * [DigitalOcean](https://marketplace.digitalocean.com/apps/semaphore?refcode=b55d7c0077b8&action=deploy)
   * [Vultr](https://www.vultr.com/marketplace/apps/semaphore)
   * [Yandex Cloud](https://yandex.cloud/ru/marketplace/products/fastlix/semaphore)


### PR DESCRIPTION
Adds Cloudzy as a one-click deployment option for Semaphore UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Cloudzy as a marketplace option in the VM installation methods listed in the Getting Started section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->