### PR TITLE
fix: add missing env tag for SEMAPHORE_RUNNER_EXECUTOR

### DIFF
--- a/util/config.go
+++ b/util/config.go
@@ -168,7 +168,7 @@ type RunnerConfig struct {
 
 	Connection *RunnerConnectionConfig `json:"connection,omitempty"`
 
-	Executor *ExecutorConfig `json:"executor,omitempty"`
+	Executor *ExecutorConfig `json:"executor,omitempty" env:"SEMAPHORE_RUNNER_EXECUTOR"`
 }
 
 // RunnerK8sConfig holds runner-side configuration for the Kubernetes executor. Field

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -141,6 +141,24 @@ func TestLoadEnvironmentToObject_Map(t *testing.T) {
 	}
 }
 
+func TestLoadEnvironmentToObject_RunnerExecutor(t *testing.T) {
+	var val RunnerConfig
+
+	require.NoError(t, os.Setenv("SEMAPHORE_RUNNER_EXECUTOR", `{"type":"docker","docker":{"image":"example.com/job:1"}}`))
+	require.NoError(t, os.Setenv("SEMAPHORE_RUNNER_DOCKER_NETWORK", "host"))
+	defer os.Unsetenv("SEMAPHORE_RUNNER_EXECUTOR")
+	defer os.Unsetenv("SEMAPHORE_RUNNER_DOCKER_NETWORK")
+
+	_, err := loadEnvironmentToObject(&val)
+	require.NoError(t, err)
+
+	require.NotNil(t, val.Executor)
+	assert.Equal(t, ExecutorTypeDocker, val.Executor.Type)
+	assert.Equal(t, "example.com/job:1", val.Executor.Docker.Image)
+	// individual executor env vars still override fields of the JSON object
+	assert.Equal(t, "host", val.Executor.Docker.Network)
+}
+
 func TestLoadEnvironmentToObject_SensitiveEnvs(t *testing.T) {
 	type sub struct {
 		Field string `json:"field"`


### PR DESCRIPTION
Hi @fiftin,

This PR adds a missing `env` tag so that you can configure the executor config with an environment variable (`SEMAPHORE_RUNNER_EXECUTOR`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the runner executor through the `SEMAPHORE_RUNNER_EXECUTOR` environment variable.
  * Environment-based configuration can now override executor settings, including type, Docker image, and network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->