### PR TITLE
fix(tasks): preserve output from short shell commands

### DIFF
--- a/db_lib/AnsiblePlaybook.go
+++ b/db_lib/AnsiblePlaybook.go
@@ -44,16 +44,15 @@ func (p AnsiblePlaybook) makeCmd(command string, args []string, environmentVars 
 
 func (p AnsiblePlaybook) runCmd(command string, args []string, environmentVars []string) error {
 	cmd := p.makeCmd(command, args, environmentVars)
-	p.Logger.LogCmd(cmd)
-	err := cmd.Run()
-	// Wait for all log processing to complete before returning
-	p.Logger.WaitLog()
-	return err
+	finishLog := p.Logger.LogCmd(cmd)
+	defer finishLog()
+	return cmd.Run()
 }
 
 func (p AnsiblePlaybook) RunPlaybook(args []string, environmentVars []string, inputs map[string]string, cb func(*os.Process)) error {
 	cmd := p.makeCmd("ansible-playbook", args, environmentVars)
-	p.Logger.LogCmd(cmd)
+	finishLog := p.Logger.LogCmd(cmd)
+	defer finishLog()
 
 	ptmx, err := pty.Start(cmd)
 
@@ -88,8 +87,6 @@ func (p AnsiblePlaybook) RunPlaybook(args []string, environmentVars []string, in
 	defer func() { _ = ptmx.Close() }()
 	cb(cmd.Process)
 	err = cmd.Wait()
-	// Wait for all log processing to complete before returning
-	p.Logger.WaitLog()
 	return err
 }
 

--- a/db_lib/CmdGitClient.go
+++ b/db_lib/CmdGitClient.go
@@ -71,7 +71,8 @@ func (c CmdGitClient) run(r GitRepository, targetDir GitRepositoryDirType, args 
 
 	cmd := c.makeCmd(r, targetDir, keyInstallation, args...)
 
-	r.Logger.LogCmd(cmd)
+	finishLog := r.Logger.LogCmd(cmd)
+	defer finishLog()
 
 	return cmd.Run()
 }

--- a/db_lib/ShellApp.go
+++ b/db_lib/ShellApp.go
@@ -120,8 +120,8 @@ func (t *ShellApp) Run(args LocalAppRunningArgs) error {
 		return err
 	}
 	args.Callback(cmd.Process)
-	err = cmd.Wait()
-	// Wait for all log processing to complete before returning
+	// Drain stdout/stderr before calling Wait, because it releases any resources
+	// associated with the Cmd.
 	t.Logger.WaitLog()
-	return err
+	return cmd.Wait()
 }

--- a/db_lib/ShellApp.go
+++ b/db_lib/ShellApp.go
@@ -1,9 +1,9 @@
 package db_lib
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/semaphoreui/semaphore/db"
@@ -52,12 +52,6 @@ func (t *ShellApp) makeCmd(command string, args []string, environmentVars []stri
 	cmd.SysProcAttr = util.Config.GetAppSysProcAttr()
 
 	return cmd
-}
-
-func (t *ShellApp) runCmd(command string, args []string) error {
-	cmd := t.makeCmd(command, args, nil)
-	t.Logger.LogCmd(cmd)
-	return cmd.Run()
 }
 
 func (t *ShellApp) GetFullPath() (path string) {
@@ -112,16 +106,21 @@ func (t *ShellApp) Run(args LocalAppRunningArgs) error {
 	// Use "default" key for backward compatibility
 	cliArgs := args.CliArgs["default"]
 	cmd := t.makeShellCmd(cliArgs, args.EnvironmentVars)
-	t.Logger.LogCmd(cmd)
-	//cmd.Stdin = &t.reader
-	cmd.Stdin = strings.NewReader("")
+	cmd.WaitDelay = 250 * time.Millisecond
+	finishLog := t.Logger.LogCmd(cmd)
+	defer finishLog()
+
 	err := cmd.Start()
 	if err != nil {
 		return err
 	}
 	args.Callback(cmd.Process)
-	// Drain stdout/stderr before calling Wait, because it releases any resources
-	// associated with the Cmd.
-	t.Logger.WaitLog()
-	return cmd.Wait()
+
+	err = cmd.Wait()
+	finishLog() // Flush command output before logging the wait result.
+	if errors.Is(err, exec.ErrWaitDelay) {
+		t.Logger.Logf("shell command output draining exceeded %s and was stopped", cmd.WaitDelay)
+		return nil
+	}
+	return err
 }

--- a/db_lib/ShellApp_test.go
+++ b/db_lib/ShellApp_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sync"
 	"testing"
 
 	"github.com/semaphoreui/semaphore/db"
@@ -13,21 +14,41 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type stdoutCaptureLogger struct {
+type outputCaptureLogger struct {
 	task_logger.NopLogger
-	pipe   io.ReadCloser
-	output []byte
-	err    error
+	wg        sync.WaitGroup
+	stdout    []byte
+	stderr    []byte
+	stdoutErr error
+	stderrErr error
 }
 
-func (l *stdoutCaptureLogger) LogCmd(cmd *exec.Cmd) {
-	l.pipe, l.err = cmd.StdoutPipe()
-}
-
-func (l *stdoutCaptureLogger) WaitLog() {
-	if l.err == nil {
-		l.output, l.err = io.ReadAll(l.pipe)
+func (l *outputCaptureLogger) LogCmd(cmd *exec.Cmd) {
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		l.stdoutErr = err
+		return
 	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		l.stderrErr = err
+		return
+	}
+
+	l.wg.Add(2)
+	go func() {
+		defer l.wg.Done()
+		l.stdout, l.stdoutErr = io.ReadAll(stdout)
+	}()
+	go func() {
+		defer l.wg.Done()
+		l.stderr, l.stderrErr = io.ReadAll(stderr)
+	}()
+}
+
+func (l *outputCaptureLogger) WaitLog() {
+	l.wg.Wait()
 }
 
 func TestShellApp_RunDrainsOutputBeforeWait(t *testing.T) {
@@ -42,7 +63,7 @@ func TestShellApp_RunDrainsOutputBeforeWait(t *testing.T) {
 	}
 	t.Cleanup(func() { util.Config = previousConfig })
 
-	logger := &stdoutCaptureLogger{}
+	logger := &outputCaptureLogger{}
 	app := &ShellApp{
 		Logger:     logger,
 		Template:   db.Template{ID: 1},
@@ -51,11 +72,13 @@ func TestShellApp_RunDrainsOutputBeforeWait(t *testing.T) {
 	}
 
 	err := app.Run(LocalAppRunningArgs{
-		CliArgs:  map[string][]string{"default": {"-c", "printf 'stdout message'"}},
+		CliArgs:  map[string][]string{"default": {"-c", "printf 'stdout message'; printf 'stderr message' >&2"}},
 		Callback: func(*os.Process) {},
 	})
 
 	require.NoError(t, err)
-	require.NoError(t, logger.err)
-	assert.Equal(t, "stdout message", string(logger.output))
+	require.NoError(t, logger.stdoutErr)
+	require.NoError(t, logger.stderrErr)
+	assert.Equal(t, "stdout message", string(logger.stdout))
+	assert.Equal(t, "stderr message", string(logger.stderr))
 }

--- a/db_lib/ShellApp_test.go
+++ b/db_lib/ShellApp_test.go
@@ -1,11 +1,11 @@
 package db_lib
 
 import (
-	"io"
+	"bytes"
 	"os"
 	"os/exec"
-	"sync"
 	"testing"
+	"time"
 
 	"github.com/semaphoreui/semaphore/db"
 	"github.com/semaphoreui/semaphore/pkg/task_logger"
@@ -16,39 +16,14 @@ import (
 
 type outputCaptureLogger struct {
 	task_logger.NopLogger
-	wg        sync.WaitGroup
-	stdout    []byte
-	stderr    []byte
-	stdoutErr error
-	stderrErr error
+	stdout bytes.Buffer
+	stderr bytes.Buffer
 }
 
-func (l *outputCaptureLogger) LogCmd(cmd *exec.Cmd) {
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		l.stdoutErr = err
-		return
-	}
-
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		l.stderrErr = err
-		return
-	}
-
-	l.wg.Add(2)
-	go func() {
-		defer l.wg.Done()
-		l.stdout, l.stdoutErr = io.ReadAll(stdout)
-	}()
-	go func() {
-		defer l.wg.Done()
-		l.stderr, l.stderrErr = io.ReadAll(stderr)
-	}()
-}
-
-func (l *outputCaptureLogger) WaitLog() {
-	l.wg.Wait()
+func (l *outputCaptureLogger) LogCmd(cmd *exec.Cmd) func() {
+	cmd.Stdout = &l.stdout
+	cmd.Stderr = &l.stderr
+	return func() {}
 }
 
 func TestShellApp_RunDrainsOutputBeforeWait(t *testing.T) {
@@ -77,8 +52,39 @@ func TestShellApp_RunDrainsOutputBeforeWait(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.NoError(t, logger.stdoutErr)
-	require.NoError(t, logger.stderrErr)
-	assert.Equal(t, "stdout message", string(logger.stdout))
-	assert.Equal(t, "stderr message", string(logger.stderr))
+	assert.Equal(t, "stdout message", logger.stdout.String())
+	assert.Equal(t, "stderr message", logger.stderr.String())
+}
+
+func TestShellApp_RunBoundsOutputDrainWhenBackgroundChildKeepsPipesOpen(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	previousConfig := util.Config
+	util.Config = &util.ConfigType{
+		Process: &util.ConfigProcess{},
+	}
+	t.Cleanup(func() { util.Config = previousConfig })
+
+	logger := &outputCaptureLogger{}
+	app := &ShellApp{
+		Logger:     logger,
+		Template:   db.Template{ID: 1},
+		Repository: db.Repository{GitURL: t.TempDir()},
+		App:        db.AppBash,
+	}
+
+	startedAt := time.Now()
+	err := app.Run(LocalAppRunningArgs{
+		CliArgs: map[string][]string{
+			"default": {"-c", "printf 'stdout message'; printf 'stderr message' >&2; sleep 2 &"},
+		},
+		Callback: func(*os.Process) {},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "stdout message", logger.stdout.String())
+	assert.Equal(t, "stderr message", logger.stderr.String())
+	assert.Less(t, time.Since(startedAt), 1500*time.Millisecond)
 }

--- a/db_lib/ShellApp_test.go
+++ b/db_lib/ShellApp_test.go
@@ -1,0 +1,61 @@
+package db_lib
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/semaphoreui/semaphore/db"
+	"github.com/semaphoreui/semaphore/pkg/task_logger"
+	"github.com/semaphoreui/semaphore/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stdoutCaptureLogger struct {
+	task_logger.NopLogger
+	pipe   io.ReadCloser
+	output []byte
+	err    error
+}
+
+func (l *stdoutCaptureLogger) LogCmd(cmd *exec.Cmd) {
+	l.pipe, l.err = cmd.StdoutPipe()
+}
+
+func (l *stdoutCaptureLogger) WaitLog() {
+	if l.err == nil {
+		l.output, l.err = io.ReadAll(l.pipe)
+	}
+}
+
+func TestShellApp_RunDrainsOutputBeforeWait(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	// ShellApp reads the global config; do not run this test in parallel.
+	previousConfig := util.Config
+	util.Config = &util.ConfigType{
+		Process: &util.ConfigProcess{},
+	}
+	t.Cleanup(func() { util.Config = previousConfig })
+
+	logger := &stdoutCaptureLogger{}
+	app := &ShellApp{
+		Logger:     logger,
+		Template:   db.Template{ID: 1},
+		Repository: db.Repository{GitURL: t.TempDir()},
+		App:        db.AppBash,
+	}
+
+	err := app.Run(LocalAppRunningArgs{
+		CliArgs:  map[string][]string{"default": {"-c", "printf 'stdout message'"}},
+		Callback: func(*os.Process) {},
+	})
+
+	require.NoError(t, err)
+	require.NoError(t, logger.err)
+	assert.Equal(t, "stdout message", string(logger.output))
+}

--- a/db_lib/TerraformApp.go
+++ b/db_lib/TerraformApp.go
@@ -112,7 +112,8 @@ func (t *TerraformApp) makeCmd(command string, args []string, environmentVars []
 
 func (t *TerraformApp) runCmd(command string, args []string) error {
 	cmd := t.makeCmd(command, args, nil)
-	t.Logger.LogCmd(cmd)
+	finishLog := t.Logger.LogCmd(cmd)
+	defer finishLog()
 	return cmd.Run()
 }
 
@@ -157,7 +158,8 @@ func (t *TerraformApp) init(environmentVars []string, keyInstaller AccessKeyInst
 
 	cmd := t.makeCmd(t.Name, args, environmentVars)
 	cmd.Env = append(cmd.Env, keyInstallation.GetGitEnv()...)
-	t.Logger.LogCmd(cmd)
+	finishLog := t.Logger.LogCmd(cmd)
+	defer finishLog()
 
 	t.Logger.AddLogListener(func(new time.Time, msg string) {
 		s := strings.TrimSpace(msg)
@@ -180,7 +182,6 @@ func (t *TerraformApp) init(environmentVars []string, keyInstaller AccessKeyInst
 		return err
 	}
 
-	t.Logger.WaitLog()
 	return nil
 }
 
@@ -216,7 +217,8 @@ func (t *TerraformApp) selectWorkspace(workspace string, environmentVars []strin
 		args = append(tgArgs, args...)
 	}
 	cmd := t.makeCmd(t.Name, args, environmentVars)
-	t.Logger.LogCmd(cmd)
+	finishLog := t.Logger.LogCmd(cmd)
+	defer finishLog()
 
 	err := cmd.Start()
 	if err != nil {
@@ -228,7 +230,6 @@ func (t *TerraformApp) selectWorkspace(workspace string, environmentVars []strin
 		return err
 	}
 
-	t.Logger.WaitLog()
 	return nil
 }
 
@@ -298,7 +299,8 @@ func (t *TerraformApp) Plan(args []string, environmentVars []string, inputs map[
 	planArgs := []string{"plan", "-lock=false"}
 	planArgs = append(planArgs, args...)
 	cmd := t.makeCmd(t.Name, planArgs, environmentVars)
-	t.Logger.LogCmd(cmd)
+	finishLog := t.Logger.LogCmd(cmd)
+	defer finishLog()
 
 	t.reader.logger.AddLogListener(func(new time.Time, msg string) {
 		if strings.Contains(msg, "No changes.") {
@@ -319,7 +321,6 @@ func (t *TerraformApp) Plan(args []string, environmentVars []string, inputs map[
 		return err
 	}
 
-	t.Logger.WaitLog()
 	return nil
 }
 
@@ -327,7 +328,8 @@ func (t *TerraformApp) Apply(args []string, environmentVars []string, inputs map
 	applyArgs := []string{"apply", "-auto-approve", "-lock=false"}
 	applyArgs = append(applyArgs, args...)
 	cmd := t.makeCmd(t.Name, applyArgs, environmentVars)
-	t.Logger.LogCmd(cmd)
+	finishLog := t.Logger.LogCmd(cmd)
+	defer finishLog()
 	cmd.Stdin = strings.NewReader("")
 	err := cmd.Start()
 	if err != nil {
@@ -340,7 +342,6 @@ func (t *TerraformApp) Apply(args []string, environmentVars []string, inputs map
 		return err
 	}
 
-	t.Logger.WaitLog()
 	return nil
 }
 

--- a/pkg/task_logger/task_logger.go
+++ b/pkg/task_logger/task_logger.go
@@ -132,14 +132,14 @@ type Logger interface {
 	Logf(format string, a ...any)
 	LogWithTime(now time.Time, msg string)
 	LogfWithTime(now time.Time, format string, a ...any)
-	LogCmd(cmd *exec.Cmd)
+	// LogCmd attaches output logging and returns an idempotent finalizer that
+	// must be called after the command stops writing, including if Start fails.
+	LogCmd(cmd *exec.Cmd) func()
 	SetStatus(status TaskStatus)
 	AddStatusListener(l StatusListener)
 	AddLogListener(l LogListener)
 
 	SetCommit(hash, message string)
-
-	WaitLog()
 }
 
 // NopLogger is a no-op Logger, useful for git operations triggered outside of
@@ -151,9 +151,8 @@ func (NopLogger) Log(string)                             {}
 func (NopLogger) Logf(string, ...any)                    {}
 func (NopLogger) LogWithTime(time.Time, string)          {}
 func (NopLogger) LogfWithTime(time.Time, string, ...any) {}
-func (NopLogger) LogCmd(*exec.Cmd)                       {}
+func (NopLogger) LogCmd(*exec.Cmd) func()                { return func() {} }
 func (NopLogger) SetStatus(TaskStatus)                   {}
 func (NopLogger) AddStatusListener(StatusListener)       {}
 func (NopLogger) AddLogListener(LogListener)             {}
 func (NopLogger) SetCommit(string, string)               {}
-func (NopLogger) WaitLog()                               {}

--- a/services/runners/running_job.go
+++ b/services/runners/running_job.go
@@ -85,6 +85,9 @@ func (p *runningJob) LogCmd(cmd *exec.Cmd) {
 	stderr, _ := cmd.StderrPipe()
 	stdout, _ := cmd.StdoutPipe()
 
+	// A positive Add on a zero counter must happen before Wait, and typically
+	// before starting the goroutines: https://pkg.go.dev/sync#WaitGroup.Add.
+	p.logWG.Add(2)
 	go p.logPipe(stderr)
 	go p.logPipe(stdout)
 }
@@ -156,7 +159,6 @@ func (p *runningJob) ackLogRecords(sent int) (pending int) {
 }
 
 func (p *runningJob) logPipe(reader io.Reader) {
-	p.logWG.Add(1)
 	defer p.logWG.Done()
 
 	scanner := bufio.NewScanner(reader)

--- a/services/runners/running_job.go
+++ b/services/runners/running_job.go
@@ -35,8 +35,6 @@ type runningJob struct {
 
 	statusListeners []task_logger.StatusListener
 	logListeners    []task_logger.LogListener
-
-	logWG sync.WaitGroup
 }
 
 func (p *runningJob) AddStatusListener(l task_logger.StatusListener) {
@@ -81,19 +79,32 @@ func (p *runningJob) LogfWithTime(now time.Time, format string, a ...any) {
 	p.LogWithTime(now, fmt.Sprintf(format, a...))
 }
 
-func (p *runningJob) LogCmd(cmd *exec.Cmd) {
-	stderr, _ := cmd.StderrPipe()
-	stdout, _ := cmd.StdoutPipe()
+func (p *runningJob) LogCmd(cmd *exec.Cmd) func() {
+	// io.PipeWriter is not *os.File, so os/exec owns and waits for output copying.
+	stderr, stderrWriter := io.Pipe()
+	stdout, stdoutWriter := io.Pipe()
+	cmd.Stderr = stderrWriter
+	cmd.Stdout = stdoutWriter
 
-	// A positive Add on a zero counter must happen before Wait, and typically
-	// before starting the goroutines: https://pkg.go.dev/sync#WaitGroup.Add.
-	p.logWG.Add(2)
-	go p.logPipe(stderr)
-	go p.logPipe(stdout)
-}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		p.logPipe(stderr)
+	}()
+	go func() {
+		defer wg.Done()
+		p.logPipe(stdout)
+	}()
 
-func (p *runningJob) WaitLog() {
-	p.logWG.Wait()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			_ = stderrWriter.Close()
+			_ = stdoutWriter.Close()
+			wg.Wait()
+		})
+	}
 }
 
 func (p *runningJob) SetCommit(hash, message string) {
@@ -159,7 +170,9 @@ func (p *runningJob) ackLogRecords(sent int) (pending int) {
 }
 
 func (p *runningJob) logPipe(reader io.Reader) {
-	defer p.logWG.Done()
+	if closer, ok := reader.(io.Closer); ok {
+		defer closer.Close()
+	}
 
 	scanner := bufio.NewScanner(reader)
 	const maxCapacity = 10 * 1024 * 1024 // 10 MB

--- a/services/runners/running_job_test.go
+++ b/services/runners/running_job_test.go
@@ -2,6 +2,7 @@ package runners
 
 import (
 	"fmt"
+	"os/exec"
 	"sync"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/semaphoreui/semaphore/pkg/task_logger"
 	"github.com/semaphoreui/semaphore/services/tasks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newTestRunningJob wires a runningJob to a LocalJob whose Logger points back at
@@ -82,6 +84,29 @@ func TestRunningJob_AckLogRecords(t *testing.T) {
 			assert.Len(t, logs, tt.wantPending)
 		})
 	}
+}
+
+func TestRunningJob_LogCmdUsesWaitDelayForInheritedPipes(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	rj := newTestRunningJob(1)
+	cmd := exec.Command("bash", "-c", "printf 'stdout'; printf 'stderr' >&2; sleep 2 &")
+	cmd.WaitDelay = 50 * time.Millisecond
+	finishLog := rj.LogCmd(cmd)
+	defer finishLog()
+
+	startedAt := time.Now()
+	err := cmd.Run()
+	finishLog()
+
+	require.ErrorIs(t, err, exec.ErrWaitDelay)
+	assert.Less(t, time.Since(startedAt), 1500*time.Millisecond)
+
+	_, logs, _ := rj.getProgress()
+	require.Len(t, logs, 2)
+	assert.ElementsMatch(t, []string{"stdout", "stderr"}, []string{logs[0].Message, logs[1].Message})
 }
 
 func TestRunningJob_GetProgressReturnsCopy(t *testing.T) {

--- a/services/tasks/TaskRunner.go
+++ b/services/tasks/TaskRunner.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 
 	"github.com/semaphoreui/semaphore/db_lib"
@@ -64,8 +63,6 @@ type TaskRunner struct {
 	// Alias uses if task require an alias for run.
 	// For example, terraform task require an alias for run.
 	Alias string
-
-	logWG sync.WaitGroup
 
 	// dispatching is true while this process owns a live goroutine that is
 	// dispatching/running the task (set in runTask). A TaskRunner restored from

--- a/services/tasks/TaskRunner_logging.go
+++ b/services/tasks/TaskRunner_logging.go
@@ -61,6 +61,9 @@ func (t *TaskRunner) LogCmd(cmd *exec.Cmd) {
 	stderr, _ := cmd.StderrPipe()
 	stdout, _ := cmd.StdoutPipe()
 
+	// A positive Add on a zero counter must happen before Wait, and typically
+	// before starting the goroutines: https://pkg.go.dev/sync#WaitGroup.Add.
+	t.logWG.Add(2)
 	go t.logPipe(stderr)
 	go t.logPipe(stdout)
 }
@@ -156,8 +159,6 @@ func (t *TaskRunner) panicOnError(err error, msg string) {
 }
 
 func (t *TaskRunner) logPipe(reader io.Reader) {
-	t.logWG.Add(1)
-
 	linesCh := make(chan string, 100000)
 
 	go func() {

--- a/services/tasks/TaskRunner_logging.go
+++ b/services/tasks/TaskRunner_logging.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"sync"
 	"time"
 
 	"github.com/semaphoreui/semaphore/pkg/tz"
@@ -57,19 +58,32 @@ func (t *TaskRunner) LogfWithTime(now time.Time, format string, a ...any) {
 	t.LogWithTime(now, fmt.Sprintf(format, a...))
 }
 
-func (t *TaskRunner) LogCmd(cmd *exec.Cmd) {
-	stderr, _ := cmd.StderrPipe()
-	stdout, _ := cmd.StdoutPipe()
+func (t *TaskRunner) LogCmd(cmd *exec.Cmd) func() {
+	// io.PipeWriter is not *os.File, so os/exec owns and waits for output copying.
+	stderr, stderrWriter := io.Pipe()
+	stdout, stdoutWriter := io.Pipe()
+	cmd.Stderr = stderrWriter
+	cmd.Stdout = stdoutWriter
 
-	// A positive Add on a zero counter must happen before Wait, and typically
-	// before starting the goroutines: https://pkg.go.dev/sync#WaitGroup.Add.
-	t.logWG.Add(2)
-	go t.logPipe(stderr)
-	go t.logPipe(stdout)
-}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		t.logPipe(stderr)
+	}()
+	go func() {
+		defer wg.Done()
+		t.logPipe(stdout)
+	}()
 
-func (t *TaskRunner) WaitLog() {
-	t.logWG.Wait()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			_ = stderrWriter.Close()
+			_ = stdoutWriter.Close()
+			wg.Wait()
+		})
+	}
 }
 
 func (t *TaskRunner) SetCommit(hash, message string) {
@@ -160,14 +174,20 @@ func (t *TaskRunner) panicOnError(err error, msg string) {
 
 func (t *TaskRunner) logPipe(reader io.Reader) {
 	linesCh := make(chan string, 100000)
+	if closer, ok := reader.(io.Closer); ok {
+		defer closer.Close()
+	}
 
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
-		defer t.logWG.Done()
+		defer wg.Done()
 
 		for line := range linesCh {
 			t.Log(line)
 		}
 	}()
+	defer wg.Wait()
 
 	scanner := bufio.NewScanner(reader)
 	const maxCapacity = 10 * 1024 * 1024 // 10 MB


### PR DESCRIPTION
> **Disclosure:** I used an LLM to help organize and edit this description. The investigation, ideas, and technical conclusions are my own.

Fixes #3078.  
Also addresses #3700.

## Summary

Preserve complete command stdout/stderr without allowing shell tasks to hang when a background descendant inherits their output descriptors.

This fixes short-lived Bash tasks that complete successfully but sometimes appear not to run because their output is missing from the task log.

## Problem and solution

The task loggers used `Cmd.StdoutPipe` and `Cmd.StderrPipe` while separate goroutines scanned the returned readers. This creates two competing lifecycle requirements:

- Calling `Cmd.Wait` before the readers finish can close the pipes before all output is logged.
- Waiting for EOF before calling `Cmd.Wait` can hang indefinitely when a background descendant retains stdout or stderr.

There was also a WaitGroup sequencing race in `logPipe`: each newly launched goroutine called `Add(1)` itself, so `WaitLog` could run first, observe a zero counter, and return before either output reader had registered. The command could then finish and close its pipes while output was still pending.

The output path before this fix was:

```text
┌───────────────┐    ┌──────────────────────────┐    ┌─────────────┐
│ Child process │───▶│     OS pipe created      │───▶│  logPipe()  │
│ stdout/stderr │    │ by StdoutPipe/StderrPipe │    │ scanner/log │
└───────────────┘    └──────────────────────────┘    └─────────────┘
```

The Go implementations of [`StdoutPipe`](https://github.com/golang/go/blob/go1.26.4/src/os/exec/exec.go#L1082-L1101) and [`StderrPipe`](https://github.com/golang/go/blob/go1.26.4/src/os/exec/exec.go#L1107-L1126) create OS pipes, store their `*os.File` write ends in `Cmd.Stdout` and `Cmd.Stderr`, and return the read ends to the caller. When the command starts, [`writerDescriptor`](https://github.com/golang/go/blob/go1.26.4/src/os/exec/exec.go#L580-L605) returns an existing `*os.File` directly instead of creating a copying goroutine. Those write descriptors become the child's stdout and stderr. A background descendant can inherit them and prevent the readers from receiving EOF.

`WaitDelay` alone cannot make this flow safe. `StdoutPipe` and `StderrPipe` set the command streams to `*os.File`, so `os/exec` passes those descriptors directly to the child and does not create output-copying goroutines. `Cmd.Wait` therefore has no output-copy operation for `WaitDelay` to bound.

Calling `Cmd.Wait` first can close the caller-owned pipe readers before `logPipe` consumes all pending output. Waiting for `logPipe` first has the opposite failure mode: a background descendant can retain the writer, prevent EOF indefinitely, and block execution before `Cmd.Wait` has a chance to apply `WaitDelay`.

The fix assigns non-file `io.PipeWriter` destinations to the command. This makes `os/exec` create the OS pipes and copying goroutines itself, so `Cmd.Wait` owns the output-copy lifecycle and `WaitDelay` can bound it. After `Cmd.Wait` returns, the command-specific finalizer closes the `io.Pipe` writers and waits for `logPipe` to process all output already delivered by `os/exec`.

```text
┌───────────────┐    ┌─────────────────┐    ┌───────────────────┐    ┌─────────────────────────┐    ┌─────────────┐
│ Child process │───▶│ OS pipe created │───▶│      os/exec      │───▶│         io.Pipe         │───▶│  logPipe()  │
│ stdout/stderr │    │   by os/exec    │    │ copying goroutine │    │ PipeWriter | PipeReader │    │ scanner/log │
└───────────────┘    └─────────────────┘    └───────────────────┘    └─────────────────────────┘    └─────────────┘
```

This allows `Cmd.Wait` to run first without racing caller-owned pipe readers. If a descendant retains an output descriptor, the 250 ms `WaitDelay` stops the `os/exec` copy from blocking indefinitely; finalization then closes the logging pipes and waits for their readers to finish.

Each command registers both output readers before starting their goroutines, eliminating the WaitGroup sequencing race. The idempotent finalizer is deferred at every call site so cleanup also runs when command startup fails, while preserving live line-by-line logging.

## References

- [`exec.Cmd.Wait`](https://pkg.go.dev/os/exec#Cmd.Wait)
- [`exec.Cmd.StdoutPipe`](https://pkg.go.dev/os/exec#Cmd.StdoutPipe)
- [`exec.Cmd.StderrPipe`](https://pkg.go.dev/os/exec#Cmd.StderrPipe)
- [`sync.WaitGroup.Add`](https://pkg.go.dev/sync#WaitGroup.Add)
- [`Cmd.StdoutPipe` source](https://github.com/golang/go/blob/go1.26.4/src/os/exec/exec.go#L1082-L1101)
- [`Cmd.StderrPipe` source](https://github.com/golang/go/blob/go1.26.4/src/os/exec/exec.go#L1107-L1126)
- [`Cmd.writerDescriptor` source](https://github.com/golang/go/blob/go1.26.4/src/os/exec/exec.go#L580-L605)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution so standard output and error streams are fully captured before processes finish.
  * Prevented task logs from being missed, truncated, or returned incompletely.
  * Improved handling of command completion and output-reading errors.
  * Added safeguards to prevent commands from hanging when background processes keep output streams open.

* **Tests**
  * Added coverage confirming output from both standard streams is captured reliably before completion.
  * Added coverage for command completion within the expected timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->