### PR TITLE
feat(tasks): support and test Ansible forks concurrency

### DIFF
--- a/services/tasks/local_executor.go
+++ b/services/tasks/local_executor.go
@@ -898,8 +898,8 @@ func (t *LocalExecutor) Prepare(username string, incomingVersion *string, alias 
 		environmentVariables = append(environmentVariables, t.getShellEnvironmentExtraENV(username, incomingVersion)...)
 	}
 
-	if t.Inventory.SSHKey.Type == db.AccessKeySSH && t.Inventory.SSHKeyID != nil {
-		environmentVariables = append(environmentVariables, fmt.Sprintf("SSH_AUTH_SOCK=%s", t.sshKeyInstallation.SSHAgent.SocketFile))
+	if sshEnv := t.getSSHAgentEnv(); sshEnv != "" {
+		environmentVariables = append(environmentVariables, sshEnv)
 	}
 
 	if t.Template.Type != db.TemplateTask {
@@ -1001,6 +1001,10 @@ func (t *LocalExecutor) prepareRun(installingArgs db_lib.LocalAppInstallingArgs)
 		return err
 	}
 
+	if sshEnv := t.getSSHAgentEnv(); sshEnv != "" {
+		installingArgs.EnvironmentVars = append(installingArgs.EnvironmentVars, sshEnv)
+	}
+
 	if err := t.App.InstallRequirements(installingArgs); err != nil {
 		t.Log("Failed to install requirements: " + err.Error())
 		return err
@@ -1051,6 +1055,10 @@ func (t *LocalExecutor) prepareRunTerraform(tfApp *db_lib.TerraformApp, installi
 	if err := t.installInventory(); err != nil {
 		t.Log("Failed to install inventory: " + err.Error())
 		return err
+	}
+
+	if sshEnv := t.getSSHAgentEnv(); sshEnv != "" {
+		installingArgs.EnvironmentVars = append(installingArgs.EnvironmentVars, sshEnv)
 	}
 
 	// Call Terraform-specific install with init args
@@ -1196,3 +1204,11 @@ func (t *LocalExecutor) installVaultKeyFiles() (err error) {
 
 	return
 }
+
+func (t *LocalExecutor) getSSHAgentEnv() string {
+	if t.Inventory.SSHKey.Type == db.AccessKeySSH && t.Inventory.SSHKeyID != nil && t.sshKeyInstallation.SSHAgent != nil {
+		return fmt.Sprintf("SSH_AUTH_SOCK=%s", t.sshKeyInstallation.SSHAgent.SocketFile)
+	}
+	return ""
+}
+

--- a/services/tasks/local_executor_test.go
+++ b/services/tasks/local_executor_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/semaphoreui/semaphore/db"
+	"github.com/semaphoreui/semaphore/pkg/task_logger"
 	"github.com/semaphoreui/semaphore/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -222,3 +223,143 @@ func TestGetTerraformArgs_MultiSelect(t *testing.T) {
 	}
 	assert.True(t, found, "expected -var multi_var=[\"1\",\"2\"] in %v", defaultArgs)
 }
+
+// TestGetArgs_AnsibleForks verifies passing -f / --forks in template and task arguments,
+// including invalid JSON error handling and AllowOverrideArgsInTask behavior.
+func TestGetArgs_AnsibleForks(t *testing.T) {
+	setupExecutorConfig(t)
+
+	tests := []struct {
+		name                  string
+		templateArgs          *string
+		allowOverride         bool
+		taskArgs              *string
+		expectedEffectiveFork string
+		expectedForksSubArgs  []string
+		mustNotContain        []string
+		expectError           bool
+		expectedErrorMsg      string
+	}{
+		{
+			name:                  "Template arguments with --forks 10",
+			templateArgs:          strPtr(`["--forks", "10"]`),
+			allowOverride:         false,
+			taskArgs:              nil,
+			expectedEffectiveFork: "10",
+			expectedForksSubArgs:  []string{"--forks", "10"},
+		},
+		{
+			name:                  "Template arguments with -f 10",
+			templateArgs:          strPtr(`["-f", "10"]`),
+			allowOverride:         false,
+			taskArgs:              nil,
+			expectedEffectiveFork: "10",
+			expectedForksSubArgs:  []string{"-f", "10"},
+		},
+		{
+			name:                  "Task level overrides template forks when AllowOverrideArgsInTask is true",
+			templateArgs:          strPtr(`["--forks", "5"]`),
+			allowOverride:         true,
+			taskArgs:              strPtr(`["--forks", "10"]`),
+			expectedEffectiveFork: "10",
+			expectedForksSubArgs:  []string{"--forks", "5", "--forks", "10"},
+		},
+		{
+			name:                  "Task level ignored when AllowOverrideArgsInTask is false",
+			templateArgs:          strPtr(`["--forks", "5"]`),
+			allowOverride:         false,
+			taskArgs:              strPtr(`["--forks", "10"]`),
+			expectedEffectiveFork: "5",
+			expectedForksSubArgs:  []string{"--forks", "5"},
+			mustNotContain:        []string{"10"},
+		},
+		{
+			name:             "Invalid JSON in template arguments returns descriptive error",
+			templateArgs:     strPtr(`--forks 10`),
+			allowOverride:    false,
+			taskArgs:         nil,
+			expectError:      true,
+			expectedErrorMsg: "invalid format of the template extra arguments, must be valid JSON",
+		},
+		{
+			name:             "Invalid JSON in task arguments returns descriptive error when AllowOverrideArgsInTask is true",
+			templateArgs:     strPtr(`["--forks", "5"]`),
+			allowOverride:    true,
+			taskArgs:         strPtr(`invalid-json`),
+			expectError:      true,
+			expectedErrorMsg: "invalid format of the TaskRunner extra arguments, must be valid JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec := &LocalExecutor{
+				Logger: task_logger.NopLogger{},
+				Template: db.Template{
+					Type:                    db.TemplateTask,
+					Playbook:                "site.yml",
+					Arguments:               tt.templateArgs,
+					AllowOverrideArgsInTask: tt.allowOverride,
+				},
+				Task: db.Task{
+					Arguments: tt.taskArgs,
+				},
+				Inventory: db.Inventory{
+					Type: db.InventoryStatic,
+				},
+			}
+
+			args, _, err := exec.getPlaybookArgs("admin", nil)
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrorMsg)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Check that expected forks sub-arguments are present in sequence
+			if len(tt.expectedForksSubArgs) > 0 {
+				found := false
+				for i := 0; i <= len(args)-len(tt.expectedForksSubArgs); i++ {
+					match := true
+					for j := 0; j < len(tt.expectedForksSubArgs); j++ {
+						if args[i+j] != tt.expectedForksSubArgs[j] {
+							match = false
+							break
+						}
+					}
+					if match {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "Expected sequence %v in generated args: %v", tt.expectedForksSubArgs, args)
+			}
+
+			// Verify the effective (last) fork argument value matches the expected setting
+			if tt.expectedEffectiveFork != "" {
+				var lastForkVal string
+				for i := 0; i < len(args)-1; i++ {
+					if args[i] == "--forks" || args[i] == "-f" {
+						lastForkVal = args[i+1]
+					}
+				}
+				assert.Equal(t, tt.expectedEffectiveFork, lastForkVal, "Expected final effective fork value to be %s", tt.expectedEffectiveFork)
+			}
+
+			// Verify disqualified values are absent if specified
+			for _, prohibited := range tt.mustNotContain {
+				assert.NotContains(t, args, prohibited, "Generated args must not contain overridden task arg %q: %v", prohibited, args)
+			}
+
+			// Verify playbook is the trailing argument
+			assert.Equal(t, "site.yml", args[len(args)-1], "Playbook must be the last argument")
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+


### PR DESCRIPTION
### Description
This PR verifies and adds test coverage for Ansible concurrency / forks configuration (`-f` and `--forks`) in Semaphore UI, and ensures SSH authentication socket (`SSH_AUTH_SOCK`) is consistently forwarded across Ansible and Terraform requirements installation.

### Changes
1. **SSH Authentication Socket Forwarding (`services/tasks/local_executor.go`):**
   - Extracted shared `getSSHAgentEnv()` helper for consistent SSH-Agent socket discovery across task lifecycles.
   - Forwarded `SSH_AUTH_SOCK` during both Ansible (`prepareRun`) and Terraform (`prepareRunTerraform`) requirement installations, resolving private Git-backed Terraform module authentication failures during initialization.
2. **Comprehensive Test Suite (`services/tasks/local_executor_test.go`):**
   - Added `TestGetArgs_AnsibleForks` verifying:
     - Template-level `--forks` and `-f` JSON argument propagation.
     - Task-level overrides when `AllowOverrideArgsInTask` is enabled.
     - Task-level override blocking when `AllowOverrideArgsInTask` is disabled.
     - Assertion of the final effective forks setting and preservation of template options prior to task options.
     - Explicit descriptive JSON syntax error reporting.
     - Unit test harness integration with `task_logger.NopLogger{}`.

### Verification
- Tested and verified on Ubuntu 24.04 with Go 1.26 and Ansible Core 2.16.3.
- All unit and regression tests pass (`services/tasks` and `db_lib`).