### PR TITLE
docs: add RepoCloud as a deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ You can install Semaphore using the following methods:
   * [DigitalOcean](https://marketplace.digitalocean.com/apps/semaphore?refcode=b55d7c0077b8&action=deploy)
   * [Vultr](https://www.vultr.com/marketplace/apps/semaphore)
   * [Yandex Cloud](https://yandex.cloud/ru/marketplace/products/fastlix/semaphore)
+  * [RepoCloud](https://repocloud.io/details/Semaphore/)
 * [Snap](http://snapcraft.io/semaphore)
 * [Binary file](https://semaphoreui.com/install/binary)
 * [Debian or RPM package](https://semaphoreui.com/install/binary)
-* [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Semaphore/)
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ You can install Semaphore using the following methods:
 * [Snap](http://snapcraft.io/semaphore)
 * [Binary file](https://semaphoreui.com/install/binary)
 * [Debian or RPM package](https://semaphoreui.com/install/binary)
+* [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Semaphore/)
 
 ### Docker
 


### PR DESCRIPTION
Adds [RepoCloud](https://repocloud.io) as a one-click deployment option
alongside the existing marketplace providers (AWS, Cloudzy, DigitalOcean, Vultr, Yandex Cloud).

RepoCloud provides managed cloud hosting for open-source applications
with one-click deployment.

- Adds RepoCloud to the "Deploy a VM from a marketplace" list in `README.md`
- Uses the same text link format as existing marketplace entries
- Links to: https://repocloud.io/details/Semaphore/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added RepoCloud as an additional Semaphore UI deployment option in the VM marketplace installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->