### PR TITLE
fix(tasks): delegate to global default runner on offline project match and retain queue state

### DIFF
--- a/services/tasks/RemoteJob.go
+++ b/services/tasks/RemoteJob.go
@@ -131,6 +131,20 @@ func selectRunner(
 	return nil
 }
 
+func appendUniqueRunners(target []db.Runner, source []db.Runner) []db.Runner {
+	seen := make(map[int]struct{}, len(target))
+	for _, r := range target {
+		seen[r.ID] = struct{}{}
+	}
+	for _, r := range source {
+		if _, exists := seen[r.ID]; !exists {
+			target = append(target, r)
+			seen[r.ID] = struct{}{}
+		}
+	}
+	return target
+}
+
 func (t *RemoteJob) Run(username string, incomingVersion *string, alias string) (err error) {
 	tsk, err := t.taskPool.GetTask(t.Task.ID)
 
@@ -165,14 +179,44 @@ func (t *RemoteJob) Run(username string, incomingVersion *string, alias string) 
 		return
 	}
 
-	runners = append(runners, shuffleRunners(projectRunners)...)
-	runners = append(runners, shuffleRunners(globalRunners)...)
+	runners = appendUniqueRunners(runners, shuffleRunners(projectRunners))
+	runners = appendUniqueRunners(runners, shuffleRunners(globalRunners))
 
-	if err != nil {
-		return
+	var globalDefaultRunners []db.Runner
+	if t.RunnerTag != nil {
+		globalDefaultRunners, err = t.taskPool.store.GetAllRunners(true, true, db.RunnerFilterIsDefault, nil)
+		if err != nil {
+			return
+		}
+		runners = appendUniqueRunners(runners, shuffleRunners(globalDefaultRunners))
 	}
 
 	if len(runners) == 0 {
+		var allProjectRunners []db.Runner
+		allProjectRunners, err = t.taskPool.store.GetRunners(t.Task.ProjectID, false, tagFilterMode, t.RunnerTag)
+		if err != nil {
+			return
+		}
+
+		var allGlobalRunners []db.Runner
+		allGlobalRunners, err = t.taskPool.store.GetAllRunners(false, true, tagFilterMode, t.RunnerTag)
+		if err != nil {
+			return
+		}
+
+		var allGlobalDefaultRunners []db.Runner
+		if t.RunnerTag != nil {
+			allGlobalDefaultRunners, err = t.taskPool.store.GetAllRunners(false, true, db.RunnerFilterIsDefault, nil)
+			if err != nil {
+				return
+			}
+		}
+
+		if len(allProjectRunners) > 0 || len(allGlobalRunners) > 0 || len(allGlobalDefaultRunners) > 0 {
+			err = ErrAllRunnersBusy
+			return
+		}
+
 		err = fmt.Errorf("no runners available")
 		return
 	}

--- a/services/tasks/RemoteJob_test.go
+++ b/services/tasks/RemoteJob_test.go
@@ -1,0 +1,291 @@
+package tasks
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/semaphoreui/semaphore/db"
+	"github.com/semaphoreui/semaphore/db/sql"
+	"github.com/semaphoreui/semaphore/pkg/task_logger"
+	"github.com/semaphoreui/semaphore/pkg/tz"
+	"github.com/semaphoreui/semaphore/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestTaskPool(t *testing.T) (*sql.SqlDb, *TaskPool, db.Project, db.Task) {
+	prevCfg := util.Config
+	t.Cleanup(func() { util.Config = prevCfg })
+	util.Config = &util.ConfigType{}
+
+	store := sql.InitConfigCreateTestStore()
+	proj, err := store.CreateProject(db.Project{Name: "Test Proj"})
+	require.NoError(t, err)
+
+	key, err := store.CreateAccessKey(db.AccessKey{ProjectID: &proj.ID, Type: db.AccessKeyNone})
+	require.NoError(t, err)
+
+	repo, err := store.CreateRepository(db.Repository{
+		ProjectID: proj.ID,
+		SSHKeyID:  key.ID,
+		Name:      "Test Repo",
+		GitURL:    "git@example.com:test/test",
+		GitBranch: "master",
+	})
+	require.NoError(t, err)
+
+	inv, err := store.CreateInventory(db.Inventory{ProjectID: proj.ID})
+	require.NoError(t, err)
+
+	tpl, err := store.CreateTemplate(db.Template{
+		Name:         "Test Template",
+		Playbook:     "test.yml",
+		ProjectID:    proj.ID,
+		RepositoryID: repo.ID,
+		InventoryID:  &inv.ID,
+	})
+	require.NoError(t, err)
+
+	task, err := store.CreateTask(db.Task{
+		ProjectID:  proj.ID,
+		TemplateID: tpl.ID,
+		Status:     task_logger.TaskWaitingStatus,
+	}, 0)
+	require.NoError(t, err)
+
+	state := NewMemoryTaskStateStore()
+	pool := &TaskPool{
+		store:  store,
+		state:  state,
+		logger: make(chan logRecord, 1000),
+	}
+
+	taskRunner := &TaskRunner{
+		Task:     task,
+		Template: tpl,
+		pool:     pool,
+	}
+	state.Enqueue(taskRunner)
+
+	return store, pool, proj, task
+}
+
+func TestRemoteJob_ProjectRunnerMatchOnline(t *testing.T) {
+	store, pool, proj, task := setupTestTaskPool(t)
+
+	pTag := "P11"
+	r, err := store.CreateRunner(db.Runner{
+		ProjectID: &proj.ID,
+		Name:      "project-runner-1",
+		Active:    true,
+		Token:     "token-proj-1",
+		Tags:      []string{pTag},
+	})
+	require.NoError(t, err)
+	err = store.TouchRunner(r)
+	require.NoError(t, err)
+
+	job := &RemoteJob{
+		RunnerTag: &pTag,
+		Task:      task,
+		taskPool:  pool,
+	}
+
+	err = job.Run("user", nil, "")
+	assert.NoError(t, err)
+
+	updatedTask, err := store.GetTask(proj.ID, task.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updatedTask.RunnerID)
+	assert.Equal(t, r.ID, *updatedTask.RunnerID)
+}
+
+func TestRemoteJob_GlobalDefaultFallbackWhenProjectRunnerOffline(t *testing.T) {
+	store, pool, proj, task := setupTestTaskPool(t)
+
+	pTag := "P11"
+	// Project runner exists and is active, but offline (touched is nil)
+	projRunner, err := store.CreateRunner(db.Runner{
+		ProjectID: &proj.ID,
+		Name:      "project-runner-offline",
+		Active:    true,
+		Token:     "token-proj-offline",
+		Tags:      []string{pTag},
+	})
+	require.NoError(t, err)
+	assert.False(t, projRunner.IsOnline(tz.Now(), util.Config.RunnersOfflineTimeout()))
+
+	// Global runner with is_default=true and online
+	globalRunner, err := store.CreateRunner(db.Runner{
+		ProjectID: nil,
+		Name:      "global-runner-default",
+		Active:    true,
+		IsDefault: true,
+		Token:     "token-global-default",
+		Tags:      []string{"G1"},
+	})
+	require.NoError(t, err)
+	err = store.TouchRunner(globalRunner)
+	require.NoError(t, err)
+
+	job := &RemoteJob{
+		RunnerTag: &pTag,
+		Task:      task,
+		taskPool:  pool,
+	}
+
+	err = job.Run("user", nil, "")
+	assert.NoError(t, err)
+
+	updatedTask, err := store.GetTask(proj.ID, task.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updatedTask.RunnerID)
+	assert.Equal(t, globalRunner.ID, *updatedTask.RunnerID, "should delegate to global default runner when project runner is offline")
+}
+
+func TestRemoteJob_GlobalTaggedFallbackWhenProjectOffline(t *testing.T) {
+	store, pool, proj, task := setupTestTaskPool(t)
+
+	pTag := "P11"
+	// Project runner exists, but offline
+	_, err := store.CreateRunner(db.Runner{
+		ProjectID: &proj.ID,
+		Name:      "project-runner-offline",
+		Active:    true,
+		Token:     "token-proj-offline",
+		Tags:      []string{pTag},
+	})
+	require.NoError(t, err)
+
+	// Global runner with same tag "P11" is online
+	globalRunner, err := store.CreateRunner(db.Runner{
+		ProjectID: nil,
+		Name:      "global-runner-p11",
+		Active:    true,
+		Token:     "token-global-p11",
+		Tags:      []string{pTag},
+	})
+	require.NoError(t, err)
+	err = store.TouchRunner(globalRunner)
+	require.NoError(t, err)
+
+	job := &RemoteJob{
+		RunnerTag: &pTag,
+		Task:      task,
+		taskPool:  pool,
+	}
+
+	err = job.Run("user", nil, "")
+	assert.NoError(t, err)
+
+	updatedTask, err := store.GetTask(proj.ID, task.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updatedTask.RunnerID)
+	assert.Equal(t, globalRunner.ID, *updatedTask.RunnerID)
+}
+
+func TestRemoteJob_OfflineRunnersKeepTaskWaiting(t *testing.T) {
+	store, pool, proj, task := setupTestTaskPool(t)
+
+	pTag := "P11"
+	// Project runner tagged P11 is offline
+	_, err := store.CreateRunner(db.Runner{
+		ProjectID: &proj.ID,
+		Name:      "project-runner-offline",
+		Active:    true,
+		Token:     "token-proj-offline",
+		Tags:      []string{pTag},
+	})
+	require.NoError(t, err)
+
+	// Global default runner is also offline
+	_, err = store.CreateRunner(db.Runner{
+		ProjectID: nil,
+		Name:      "global-runner-offline",
+		Active:    true,
+		IsDefault: true,
+		Token:     "token-global-offline",
+	})
+	require.NoError(t, err)
+
+	job := &RemoteJob{
+		RunnerTag: &pTag,
+		Task:      task,
+		taskPool:  pool,
+	}
+
+	err = job.Run("user", nil, "")
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAllRunnersBusy), "expected ErrAllRunnersBusy, got %v", err)
+}
+
+func TestRemoteJob_DisabledRunnersKeepTaskWaiting(t *testing.T) {
+	store, pool, proj, task := setupTestTaskPool(t)
+
+	pTag := "P11"
+	// Project runner tagged P11 exists in DB, but Active = false
+	_, err := store.CreateRunner(db.Runner{
+		ProjectID: &proj.ID,
+		Name:      "project-runner-disabled",
+		Active:    false,
+		Token:     "token-proj-disabled",
+		Tags:      []string{pTag},
+	})
+	require.NoError(t, err)
+
+	job := &RemoteJob{
+		RunnerTag: &pTag,
+		Task:      task,
+		taskPool:  pool,
+	}
+
+	err = job.Run("user", nil, "")
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAllRunnersBusy), "expected ErrAllRunnersBusy for disabled matching runner, got %v", err)
+}
+
+func TestRemoteJob_NoRunnersConfiguredFailsImmediately(t *testing.T) {
+	_, pool, _, task := setupTestTaskPool(t)
+
+	nonExistentTag := "non-existent-tag"
+	job := &RemoteJob{
+		RunnerTag: &nonExistentTag,
+		Task:      task,
+		taskPool:  pool,
+	}
+
+	err := job.Run("user", nil, "")
+	assert.Error(t, err)
+	assert.False(t, errors.Is(err, ErrAllRunnersBusy))
+	assert.Contains(t, err.Error(), "no runners available")
+}
+
+func TestRemoteJob_NoTagSpecified_ProjectAndGlobalDefault(t *testing.T) {
+	store, pool, proj, task := setupTestTaskPool(t)
+
+	// Global default runner is online
+	globalRunner, err := store.CreateRunner(db.Runner{
+		ProjectID: nil,
+		Name:      "global-default",
+		Active:    true,
+		IsDefault: true,
+		Token:     "token-global-default",
+	})
+	require.NoError(t, err)
+	err = store.TouchRunner(globalRunner)
+	require.NoError(t, err)
+
+	job := &RemoteJob{
+		RunnerTag: nil,
+		Task:      task,
+		taskPool:  pool,
+	}
+
+	err = job.Run("user", nil, "")
+	assert.NoError(t, err)
+
+	updatedTask, err := store.GetTask(proj.ID, task.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updatedTask.RunnerID)
+	assert.Equal(t, globalRunner.ID, *updatedTask.RunnerID)
+}


### PR DESCRIPTION
## Summary
Resolves #SEMA-52: Task fails due to 'No runners available' when there is an enabled global runner.

### Problem
1. When a task ran with a runner tag (e.g. P11) and project runners were offline or disabled, RemoteJob.Run did not evaluate global default runners (is_default = true) as a fallback pool.
2. If candidate runners were disabled/unregistered in the DB, RemoteJob.Run immediately returned "no runners available", causing the task to fail rather than staying in waiting/queue state (ErrAllRunnersBusy).

### Solution
1. **Multi-tier Candidate Runner Resolution**: In RemoteJob.Run, candidates are collected and deduplicated in priority order:
   - Matching project runners
   - Matching global runners
   - Global default runners (is_default = true) as fallback
2. **Queue Retention (ErrAllRunnersBusy)**:
   - If candidate runners are offline or at max capacity, RemoteJob.Run returns ErrAllRunnersBusy, preserving the task in TaskWaitingStatus (queued) for retry.
   - If no active runners are returned initially, RemoteJob.Run checks whether matching or fallback runners exist in the DB (even if inactive/unregistered). If any exist, it returns ErrAllRunnersBusy.
   - Only when zero runners match the criteria in the DB does it return "no runners available".
3. **Comprehensive Unit & Integration Test Suite**:
   - Added services/tasks/RemoteJob_test.go with 7 test cases covering online project matching, global fallback, tagged global delegation, queue retention on offline/disabled runners, and no-runner error paths.

### Verification
- go vet ./services/tasks/...: PASS
- go test -v -run TestRemoteJob ./services/tasks/...: PASS (all 7 test cases pass)
- go test ./services/tasks/...: PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runner selection by avoiding duplicate runners.
  * Tagged tasks can now fall back to suitable global runners when project runners are unavailable.
  * Tasks remain waiting when runners are offline or busy, with clearer handling when no runners are configured.

* **Tests**
  * Added coverage for project and global runner selection, fallback behavior, unavailable runners, and tagged and untagged tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->