### PR TITLE
feat(git): parallelize submodule fetches with git --jobs flag

### DIFF
--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -55,6 +55,11 @@ properties:
     enum: [go_git, cmd_git]
     default: cmd_git
     description: Git client implementation.
+  git_submodule_jobs:
+    type: integer
+    minimum: 1
+    default: 4
+    description: Number of submodules fetched in parallel by the command-line Git client.
   git_attempts:
     type: integer
     minimum: 1

--- a/db_lib/CmdGitClient.go
+++ b/db_lib/CmdGitClient.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/semaphoreui/semaphore/pkg/ssh"
@@ -113,6 +114,8 @@ func (c CmdGitClient) Clone(r GitRepository) error {
 	return c.run(r, GitRepositoryTmpPath,
 		"clone",
 		"--recursive",
+		"--jobs",
+		strconv.Itoa(util.Config.GitSubmoduleJobs),
 		"--branch",
 		r.Repository.GitBranch,
 		"--end-of-options",
@@ -127,7 +130,13 @@ func (c CmdGitClient) Pull(r GitRepository) error {
 	if err != nil {
 		return err
 	}
-	return c.run(r, GitRepositoryFullPath, "submodule", "update", "--init", "--recursive")
+	return c.run(r, GitRepositoryFullPath,
+		"submodule",
+		"update",
+		"--init",
+		"--recursive",
+		"--jobs",
+		strconv.Itoa(util.Config.GitSubmoduleJobs))
 }
 
 func (c CmdGitClient) Checkout(r GitRepository, target string) error {

--- a/util/config.go
+++ b/util/config.go
@@ -549,6 +549,10 @@ type ConfigType struct {
 
 	GitClientId string `json:"git_client,omitempty" rule:"^go_git|cmd_git$" env:"SEMAPHORE_GIT_CLIENT" default:"cmd_git"`
 
+	// GitSubmoduleJobs is how many submodules the command-line Git client
+	// fetches in parallel during clone and update operations.
+	GitSubmoduleJobs int `json:"git_submodule_jobs,omitempty" rule:"^[1-9][0-9]*$" env:"SEMAPHORE_GIT_SUBMODULE_JOBS" default:"4"`
+
 	// GitAttempts is how many times a git clone or pull is tried before the task
 	// fails, for git servers which are intermittently unavailable. 1 tries once
 	// and does not retry.

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -521,6 +521,9 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if Config.TmpPath != "/tmp/semaphore" {
 		t.Error(errMsg)
 	}
+	if Config.GitSubmoduleJobs != 4 {
+		t.Error(errMsg)
+	}
 }
 
 func ensureConfigValidationFailure(t *testing.T, attribute string, value any) {
@@ -551,6 +554,7 @@ func TestValidateConfig(t *testing.T) {
 	Config.CookieHash = testCookieHash
 	Config.MaxParallelTasks = testMaxParallelTasks
 	Config.GitClientId = GoGitClientId
+	Config.GitSubmoduleJobs = 4
 	Config.CookieEncryption = testCookieHash
 	Config.AccessKeyEncryption = testCookieHash
 	Config.EmailTlsMinVersion = testEmailTlsMinVersion
@@ -568,6 +572,10 @@ func TestValidateConfig(t *testing.T) {
 
 	ensureConfigValidationFailure(t, "MaxParallelTasks", Config.MaxParallelTasks)
 	Config.MaxParallelTasks = testMaxParallelTasks
+
+	Config.GitSubmoduleJobs = 0
+	ensureConfigValidationFailure(t, "GitSubmoduleJobs", Config.GitSubmoduleJobs)
+	Config.GitSubmoduleJobs = 4
 
 	// Config.CookieHash = "\"0Sn+edH3doJ4EO4Rl49Y0KrxjUkXuVtR5zKHGGWerxQ=\"" // invalid with quotes (can happen when supplied as env-var)
 	// ensureConfigValidationFailure(t, "CookieHash", Config.CookieHash)


### PR DESCRIPTION
Currently for projects with many submodules cloning and updating takes a lot of time. This PR adds configurable git_submodule_jobs concurrency with a default of 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration to control the number of Git submodules fetched in parallel.
  * The setting defaults to 4 and can be customized through configuration or the `SEMAPHORE_GIT_SUBMODULE_JOBS` environment variable.
  * Recursive repository cloning and submodule updates now use the configured parallelism.

* **Bug Fixes**
  * Added validation to prevent invalid non-positive parallelism values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->