### PR TITLE
feat(runner): add check interval configuration for job polling

### DIFF
--- a/cli/setup/setup.go
+++ b/cli/setup/setup.go
@@ -27,6 +27,11 @@ func InteractiveRunnerSetup(conf *util.ConfigType) {
 
 	conf.Runner = &util.RunnerConfig{}
 
+	// Asked before the branches below, each of which returns early, so every
+	// setup path records it.
+	askValue("How often to check the server for new jobs, in seconds",
+		"1", &conf.Runner.CheckIntervalSeconds)
+
 	needTokenFile := false
 	askConfirmation("Do you want to store token in external file?", false, &needTokenFile)
 

--- a/cli/setup/setup.go
+++ b/cli/setup/setup.go
@@ -27,11 +27,6 @@ func InteractiveRunnerSetup(conf *util.ConfigType) {
 
 	conf.Runner = &util.RunnerConfig{}
 
-	// Asked before the branches below, each of which returns early, so every
-	// setup path records it.
-	askValue("How often to check the server for new jobs, in seconds",
-		"1", &conf.Runner.CheckIntervalSeconds)
-
 	needTokenFile := false
 	askConfirmation("Do you want to store token in external file?", false, &needTokenFile)
 

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -638,6 +638,14 @@ $defs:
       enabled:            { type: boolean }
       project_id:
         type: [integer, "null"]
+      check_interval_seconds:
+        type: integer
+        minimum: 1
+        default: 1
+        description: >
+          How often the runner polls the server for new jobs and reports progress.
+          Raising it reduces request volume on a server with many runners, at the
+          cost of jobs starting slightly later.
       connection: { $ref: "#/$defs/RunnerConnectionConfig" }
       executor:   { $ref: "#/$defs/ExecutorConfig" }
 

--- a/services/runners/job_pool.go
+++ b/services/runners/job_pool.go
@@ -265,8 +265,15 @@ func (p *JobPool) Run() {
 		}).Panic("runner token is empty, cannot start the runner")
 	}
 
+	checkInterval := util.Config.RunnerCheckInterval()
+
+	log.WithFields(log.Fields{
+		"context":        "job_running",
+		"check_interval": checkInterval,
+	}).Debug("Runner poll interval")
+
 	queueTicker := time.NewTicker(5 * time.Second)
-	requestTimer := time.NewTicker(1 * time.Second)
+	requestTimer := time.NewTicker(checkInterval)
 	p.resetRunningJobs()
 
 	defer func() {

--- a/services/runners/job_pool.go
+++ b/services/runners/job_pool.go
@@ -256,6 +256,11 @@ func (p *JobPool) Unregister() (err error) {
 	return
 }
 
+// runnerProgressInterval is how often the runner reports progress. It is not
+// configurable: the report is also the heartbeat the server uses to decide a
+// runner is still alive.
+const runnerProgressInterval = time.Second
+
 func (p *JobPool) Run() {
 	launched := false
 
@@ -272,8 +277,13 @@ func (p *JobPool) Run() {
 		"check_interval": checkInterval,
 	}).Debug("Runner poll interval")
 
+	// The progress report doubles as the runner's heartbeat, and the server marks
+	// a runner offline after RunnersOfflineTimeout (120s by default), so its
+	// cadence is fixed. Only the job check honours the configured interval.
+	lastJobCheck := time.Time{}
+
 	queueTicker := time.NewTicker(5 * time.Second)
-	requestTimer := time.NewTicker(checkInterval)
+	requestTimer := time.NewTicker(runnerProgressInterval)
 	p.resetRunningJobs()
 
 	defer func() {
@@ -409,7 +419,10 @@ func (p *JobPool) Run() {
 					os.Exit(0)
 				}
 
-				p.checkNewJobs()
+				if time.Since(lastJobCheck) >= checkInterval {
+					lastJobCheck = time.Now()
+					p.checkNewJobs()
+				}
 			}()
 
 		}

--- a/util/config.go
+++ b/util/config.go
@@ -718,8 +718,9 @@ const (
 // Default poll interval for a runner asking the server for work.
 const defaultRunnerCheckIntervalSec = 1
 
-// Larger overflows time.Duration and panics time.NewTicker.
-const maxRunnerCheckIntervalSec = int(math.MaxInt64 / int64(time.Second))
+// Larger overflows time.Duration and panics time.NewTicker. Kept as int64: the
+// value exceeds int on 32-bit release targets (386, arm).
+const maxRunnerCheckIntervalSec int64 = int64(math.MaxInt64) / int64(time.Second)
 
 // GetSecretsPath returns the secrets path from configuration.
 // Used for backward compatibility with legacy top-level secrets_path.
@@ -793,11 +794,12 @@ func (conf *ConfigType) RunnersTaskFailTimeout() time.Duration {
 // jobs. Out-of-range values fall back to the default: 0 is indistinguishable
 // from "unset" after defaults are applied, and oversized values overflow.
 func (conf *ConfigType) RunnerCheckInterval() time.Duration {
-	sec := defaultRunnerCheckIntervalSec
-	if conf.Runner != nil &&
-		conf.Runner.CheckIntervalSeconds > 0 &&
-		conf.Runner.CheckIntervalSeconds <= maxRunnerCheckIntervalSec {
-		sec = conf.Runner.CheckIntervalSeconds
+	sec := int64(defaultRunnerCheckIntervalSec)
+	if conf.Runner != nil {
+		configured := int64(conf.Runner.CheckIntervalSeconds)
+		if configured > 0 && configured <= maxRunnerCheckIntervalSec {
+			sec = configured
+		}
 	}
 	return time.Duration(sec) * time.Second
 }

--- a/util/config.go
+++ b/util/config.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"os"
 	"os/exec"
@@ -166,11 +167,8 @@ type RunnerConfig struct {
 	MaxParallelTasks int      `json:"max_parallel_tasks,omitempty" default:"9999" env:"SEMAPHORE_RUNNER_MAX_PARALLEL_TASKS"`
 	ProjectID        *int     `json:"project_id,omitempty" env:"SEMAPHORE_RUNNER_PROJECT_ID"`
 
-	// CheckIntervalSeconds is how often the runner polls the server for new jobs
-	// and reports progress. Lower values make a runner pick work up sooner at the
-	// cost of more requests; on a busy server with many runners, raising it cuts
-	// load noticeably. Kept as a plain int (not time.Duration) for env-binding
-	// simplicity, like RunnerK8sConfig.PollIntervalSeconds.
+	// CheckIntervalSeconds is how often the runner polls the server for new jobs.
+	// Plain int, not time.Duration, for env-binding simplicity.
 	CheckIntervalSeconds int `json:"check_interval_seconds,omitempty" default:"1" env:"SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS"`
 
 	Connection *RunnerConnectionConfig `json:"connection,omitempty"`
@@ -720,6 +718,9 @@ const (
 // Default poll interval for a runner asking the server for work.
 const defaultRunnerCheckIntervalSec = 1
 
+// Larger overflows time.Duration and panics time.NewTicker.
+const maxRunnerCheckIntervalSec = int(math.MaxInt64 / int64(time.Second))
+
 // GetSecretsPath returns the secrets path from configuration.
 // Used for backward compatibility with legacy top-level secrets_path.
 func (conf *ConfigType) GetSecretsPath() string {
@@ -789,11 +790,13 @@ func (conf *ConfigType) RunnersTaskFailTimeout() time.Duration {
 }
 
 // RunnerCheckInterval returns how often this runner polls the server for new
-// jobs. A configured value of 0 is indistinguishable from "unset" once defaults
-// are applied, so it falls back to the default rather than busy-looping.
+// jobs. Out-of-range values fall back to the default: 0 is indistinguishable
+// from "unset" after defaults are applied, and oversized values overflow.
 func (conf *ConfigType) RunnerCheckInterval() time.Duration {
 	sec := defaultRunnerCheckIntervalSec
-	if conf.Runner != nil && conf.Runner.CheckIntervalSeconds > 0 {
+	if conf.Runner != nil &&
+		conf.Runner.CheckIntervalSeconds > 0 &&
+		conf.Runner.CheckIntervalSeconds <= maxRunnerCheckIntervalSec {
 		sec = conf.Runner.CheckIntervalSeconds
 	}
 	return time.Duration(sec) * time.Second

--- a/util/config.go
+++ b/util/config.go
@@ -794,8 +794,7 @@ func (conf *ConfigType) RunnersTaskFailTimeout() time.Duration {
 // from "unset" after defaults are applied, and oversized values overflow.
 func (conf *ConfigType) RunnerCheckInterval() time.Duration {
 	sec := defaultRunnerCheckIntervalSec
-	if conf.Runner != nil &&
-		conf.Runner.CheckIntervalSeconds > 0 &&
+	if conf.Runner.CheckIntervalSeconds > 0 &&
 		conf.Runner.CheckIntervalSeconds <= maxRunnerCheckIntervalSec {
 		sec = conf.Runner.CheckIntervalSeconds
 	}
@@ -932,11 +931,11 @@ func ConfigInit(configPath string, noConfigFile bool) (usedConfigPath *string) {
 		WebHostURL = nil
 	}
 
-	if Config.Runner != nil && Config.Runner.Token != "" && Config.Runner.TokenFile != "" {
+	if Config.Runner.Token != "" && Config.Runner.TokenFile != "" {
 		panic("SEMAPHORE_RUNNER_TOKEN and SEMAPHORE_RUNNER_TOKEN_FILE are mutually exclusive")
 	}
 
-	if Config.Runner != nil && Config.Runner.TokenFile != "" {
+	if Config.Runner.TokenFile != "" {
 		runnerTokenBytes, err := os.ReadFile(Config.Runner.TokenFile)
 		if err == nil {
 			Config.Runner.Token = strings.TrimSpace(string(runnerTokenBytes))

--- a/util/config.go
+++ b/util/config.go
@@ -166,6 +166,13 @@ type RunnerConfig struct {
 	MaxParallelTasks int      `json:"max_parallel_tasks,omitempty" default:"9999" env:"SEMAPHORE_RUNNER_MAX_PARALLEL_TASKS"`
 	ProjectID        *int     `json:"project_id,omitempty" env:"SEMAPHORE_RUNNER_PROJECT_ID"`
 
+	// CheckIntervalSeconds is how often the runner polls the server for new jobs
+	// and reports progress. Lower values make a runner pick work up sooner at the
+	// cost of more requests; on a busy server with many runners, raising it cuts
+	// load noticeably. Kept as a plain int (not time.Duration) for env-binding
+	// simplicity, like RunnerK8sConfig.PollIntervalSeconds.
+	CheckIntervalSeconds int `json:"check_interval_seconds,omitempty" default:"1" env:"SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS"`
+
 	Connection *RunnerConnectionConfig `json:"connection,omitempty"`
 
 	Executor *ExecutorConfig `json:"executor,omitempty" env:"SEMAPHORE_RUNNER_EXECUTOR"`
@@ -710,6 +717,9 @@ const (
 	defaultRunnersReconcileIntervalSec = 30
 )
 
+// Default poll interval for a runner asking the server for work.
+const defaultRunnerCheckIntervalSec = 1
+
 // GetSecretsPath returns the secrets path from configuration.
 // Used for backward compatibility with legacy top-level secrets_path.
 func (conf *ConfigType) GetSecretsPath() string {
@@ -776,6 +786,17 @@ func (conf *ConfigType) RunnersTaskFailTimeout() time.Duration {
 		res = offline
 	}
 	return res
+}
+
+// RunnerCheckInterval returns how often this runner polls the server for new
+// jobs. A configured value of 0 is indistinguishable from "unset" once defaults
+// are applied, so it falls back to the default rather than busy-looping.
+func (conf *ConfigType) RunnerCheckInterval() time.Duration {
+	sec := defaultRunnerCheckIntervalSec
+	if conf.Runner != nil && conf.Runner.CheckIntervalSeconds > 0 {
+		sec = conf.Runner.CheckIntervalSeconds
+	}
+	return time.Duration(sec) * time.Second
 }
 
 // RunnersReconcileInterval returns how often the server reconciles dispatched

--- a/util/config.go
+++ b/util/config.go
@@ -795,11 +795,9 @@ func (conf *ConfigType) RunnersTaskFailTimeout() time.Duration {
 // from "unset" after defaults are applied, and oversized values overflow.
 func (conf *ConfigType) RunnerCheckInterval() time.Duration {
 	sec := int64(defaultRunnerCheckIntervalSec)
-	if conf.Runner != nil {
-		configured := int64(conf.Runner.CheckIntervalSeconds)
-		if configured > 0 && configured <= maxRunnerCheckIntervalSec {
-			sec = configured
-		}
+	if configured := int64(conf.Runner.CheckIntervalSeconds); configured > 0 &&
+		configured <= maxRunnerCheckIntervalSec {
+		sec = configured
 	}
 	return time.Duration(sec) * time.Second
 }

--- a/util/runner_check_interval_test.go
+++ b/util/runner_check_interval_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -15,12 +16,14 @@ func TestRunnerCheckInterval(t *testing.T) {
 	}{
 		{"unset runner section", nil, time.Second},
 		{"unset field", &RunnerConfig{}, time.Second},
-		// loadDefaultsToObject skips non-zero fields, so a configured 0 is
-		// indistinguishable from unset; fall back rather than busy-loop.
 		{"zero falls back", &RunnerConfig{CheckIntervalSeconds: 0}, time.Second},
 		{"negative falls back", &RunnerConfig{CheckIntervalSeconds: -5}, time.Second},
 		{"configured", &RunnerConfig{CheckIntervalSeconds: 10}, 10 * time.Second},
 		{"large", &RunnerConfig{CheckIntervalSeconds: 300}, 5 * time.Minute},
+		{"max representable", &RunnerConfig{CheckIntervalSeconds: maxRunnerCheckIntervalSec},
+			time.Duration(maxRunnerCheckIntervalSec) * time.Second},
+		{"overflows falls back", &RunnerConfig{CheckIntervalSeconds: maxRunnerCheckIntervalSec + 1}, time.Second},
+		{"far past overflow falls back", &RunnerConfig{CheckIntervalSeconds: math.MaxInt64}, time.Second},
 	}
 
 	for _, tt := range tests {
@@ -31,8 +34,20 @@ func TestRunnerCheckInterval(t *testing.T) {
 	}
 }
 
-// The default tag must match the constant, or config-file and no-config runs
-// would poll at different rates.
+// The result must always be safe for time.NewTicker.
+func TestRunnerCheckIntervalNeverPanicsTicker(t *testing.T) {
+	for _, sec := range []int{0, -1, 1, 300, maxRunnerCheckIntervalSec, maxRunnerCheckIntervalSec + 1, math.MaxInt64} {
+		conf := &ConfigType{Runner: &RunnerConfig{CheckIntervalSeconds: sec}}
+		d := conf.RunnerCheckInterval()
+
+		assert.Positive(t, d, "interval must stay positive for CheckIntervalSeconds=%d", sec)
+		assert.NotPanics(t, func() {
+			time.NewTicker(d).Stop()
+		}, "time.NewTicker must accept the interval for CheckIntervalSeconds=%d", sec)
+	}
+}
+
+// The default tag must match the constant.
 func TestRunnerCheckIntervalDefaultMatchesTag(t *testing.T) {
 	conf := &ConfigType{Runner: &RunnerConfig{}}
 	loadDefaultsToObject(conf)

--- a/util/runner_check_interval_test.go
+++ b/util/runner_check_interval_test.go
@@ -14,7 +14,6 @@ func TestRunnerCheckInterval(t *testing.T) {
 		runner   *RunnerConfig
 		expected time.Duration
 	}{
-		{"unset runner section", nil, time.Second},
 		{"unset field", &RunnerConfig{}, time.Second},
 		{"zero falls back", &RunnerConfig{CheckIntervalSeconds: 0}, time.Second},
 		{"negative falls back", &RunnerConfig{CheckIntervalSeconds: -5}, time.Second},

--- a/util/runner_check_interval_test.go
+++ b/util/runner_check_interval_test.go
@@ -8,6 +8,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// intHoldsOverflowingInterval reports whether an int is wide enough to express a
+// value past the duration limit. On 32-bit targets (386, arm) it is not, so
+// those cases cannot occur there and are skipped.
+const intHoldsOverflowingInterval = int64(math.MaxInt) > maxRunnerCheckIntervalSec
+
+// A variable, not a constant: int(maxIntervalSec) would be a constant
+// conversion and fail to compile on 32-bit even inside a guarded branch.
+var maxIntervalSec = maxRunnerCheckIntervalSec
+
 func TestRunnerCheckInterval(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -20,10 +29,25 @@ func TestRunnerCheckInterval(t *testing.T) {
 		{"negative falls back", &RunnerConfig{CheckIntervalSeconds: -5}, time.Second},
 		{"configured", &RunnerConfig{CheckIntervalSeconds: 10}, 10 * time.Second},
 		{"large", &RunnerConfig{CheckIntervalSeconds: 300}, 5 * time.Minute},
-		{"max representable", &RunnerConfig{CheckIntervalSeconds: maxRunnerCheckIntervalSec},
-			time.Duration(maxRunnerCheckIntervalSec) * time.Second},
-		{"overflows falls back", &RunnerConfig{CheckIntervalSeconds: maxRunnerCheckIntervalSec + 1}, time.Second},
-		{"far past overflow falls back", &RunnerConfig{CheckIntervalSeconds: math.MaxInt64}, time.Second},
+		{"largest int", &RunnerConfig{CheckIntervalSeconds: math.MaxInt},
+			time.Duration(clampInterval(math.MaxInt)) * time.Second},
+	}
+
+	if intHoldsOverflowingInterval {
+		tests = append(tests,
+			struct {
+				name     string
+				runner   *RunnerConfig
+				expected time.Duration
+			}{"max representable", &RunnerConfig{CheckIntervalSeconds: int(maxIntervalSec)},
+				time.Duration(maxRunnerCheckIntervalSec) * time.Second},
+			struct {
+				name     string
+				runner   *RunnerConfig
+				expected time.Duration
+			}{"overflows falls back", &RunnerConfig{CheckIntervalSeconds: int(maxIntervalSec) + 1},
+				time.Second},
+		)
 	}
 
 	for _, tt := range tests {
@@ -34,9 +58,22 @@ func TestRunnerCheckInterval(t *testing.T) {
 	}
 }
 
+func clampInterval(sec int) int64 {
+	v := int64(sec)
+	if v > 0 && v <= maxRunnerCheckIntervalSec {
+		return v
+	}
+	return int64(defaultRunnerCheckIntervalSec)
+}
+
 // The result must always be safe for time.NewTicker.
 func TestRunnerCheckIntervalNeverPanicsTicker(t *testing.T) {
-	for _, sec := range []int{0, -1, 1, 300, maxRunnerCheckIntervalSec, maxRunnerCheckIntervalSec + 1, math.MaxInt64} {
+	secs := []int{0, -1, 1, 300, math.MaxInt}
+	if intHoldsOverflowingInterval {
+		secs = append(secs, int(maxIntervalSec), int(maxIntervalSec)+1)
+	}
+
+	for _, sec := range secs {
 		conf := &ConfigType{Runner: &RunnerConfig{CheckIntervalSeconds: sec}}
 		d := conf.RunnerCheckInterval()
 

--- a/util/runner_check_interval_test.go
+++ b/util/runner_check_interval_test.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunnerCheckInterval(t *testing.T) {
+	tests := []struct {
+		name     string
+		runner   *RunnerConfig
+		expected time.Duration
+	}{
+		{"unset runner section", nil, time.Second},
+		{"unset field", &RunnerConfig{}, time.Second},
+		// loadDefaultsToObject skips non-zero fields, so a configured 0 is
+		// indistinguishable from unset; fall back rather than busy-loop.
+		{"zero falls back", &RunnerConfig{CheckIntervalSeconds: 0}, time.Second},
+		{"negative falls back", &RunnerConfig{CheckIntervalSeconds: -5}, time.Second},
+		{"configured", &RunnerConfig{CheckIntervalSeconds: 10}, 10 * time.Second},
+		{"large", &RunnerConfig{CheckIntervalSeconds: 300}, 5 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &ConfigType{Runner: tt.runner}
+			assert.Equal(t, tt.expected, conf.RunnerCheckInterval())
+		})
+	}
+}
+
+// The default tag must match the constant, or config-file and no-config runs
+// would poll at different rates.
+func TestRunnerCheckIntervalDefaultMatchesTag(t *testing.T) {
+	conf := &ConfigType{Runner: &RunnerConfig{}}
+	loadDefaultsToObject(conf)
+
+	assert.Equal(t, defaultRunnerCheckIntervalSec, conf.Runner.CheckIntervalSeconds)
+	assert.Equal(t, time.Second, conf.RunnerCheckInterval())
+}

--- a/web/src/components/HighlightedCard.vue
+++ b/web/src/components/HighlightedCard.vue
@@ -10,13 +10,23 @@
               width: 28px;
               height: 28px;
               transform: rotate(45deg);
-              left: calc(50% - 14px);
               top: -14px;
               border-radius: 0;
             "
+        :style="{left: tickLeft}"
     ></div>
     <v-card-text class="pb-0">
       <slot></slot>
     </v-card-text>
   </v-card>
 </template>
+<script>
+export default {
+  props: {
+    tickLeft: {
+      type: String,
+      default: 'calc(50% - 14px)',
+    },
+  },
+};
+</script>

--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -405,6 +405,8 @@ export default {
   empty: 'Empty',
   noValues: 'No values',
   addArg: 'Add arg',
+  runnerCheckInterval: 'Check interval (seconds)',
+  runnerCheckIntervalHint: 'How often the runner checks for new jobs.',
 
   status_success: 'Success',
   status_failed: 'Failed',

--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -407,6 +407,7 @@ export default {
   addArg: 'Add arg',
   runnerCheckInterval: 'Check interval (seconds)',
   runnerCheckIntervalHint: 'How often the runner checks for new jobs.',
+  runnerCheckIntervalInvalid: 'Enter a whole number of seconds, 1 or more.',
 
   status_success: 'Success',
   status_failed: 'Failed',

--- a/web/src/views/Runners.vue
+++ b/web/src/views/Runners.vue
@@ -700,11 +700,13 @@ semaphore runner start --config ./config.runner.json`;
     },
 
     runnerRegisterConfigContent() {
-      return `{
-  "web_host": "${this.webHost || window.location.origin}",
-  "runner": {
+      const advancedOptions = this.advancedOptions
+        ? `,\n  "runner": {
     "check_interval_seconds": ${this.checkInterval}
-  }
+  }` : '';
+
+      return `{
+  "web_host": "${this.webHost || window.location.origin}"${advancedOptions}
 }`;
     },
 
@@ -716,11 +718,12 @@ semaphore runner start --config ./config.runner.json`;
     },
 
     runnerRegisterDockerCommand() {
+      const advancedOptions = this.advancedOptions
+        ? `-e SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\\n` : '';
       return `docker run \\
 -e SEMAPHORE_WEB_ROOT=${this.webHost} \\
 -e SEMAPHORE_RUNNER_REGISTRATION_TOKEN=${(this.newRunner || {}).registration_token} \\
--e SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\
--d semaphoreui/runner:${this.version}`;
+${advancedOptions}-d semaphoreui/runner:${this.version}`;
     },
 
     runnerConfigCommand() {

--- a/web/src/views/Runners.vue
+++ b/web/src/views/Runners.vue
@@ -56,6 +56,19 @@
             {{ $t('registrationTokenHint') }}
           </v-alert>
 
+          <v-text-field
+            v-model="checkIntervalSeconds"
+            type="number"
+            min="1"
+            class="mt-6"
+            style="max-width: 320px"
+            :label="$t('runnerCheckInterval')"
+            :hint="$t('runnerCheckIntervalHint')"
+            :rules="[checkIntervalRule]"
+            persistent-hint
+            dense
+          />
+
           <h2 class="mt-8 mb-4">{{ $t('howToRegister') }}</h2>
 
           <v-tabs v-model="registerTab" :show-arrows="false">
@@ -173,13 +186,14 @@
           </div>
 
           <v-text-field
-            v-model.number="checkIntervalSeconds"
+            v-model="checkIntervalSeconds"
             type="number"
             min="1"
             class="mt-6"
             style="max-width: 320px"
             :label="$t('runnerCheckInterval')"
             :hint="$t('runnerCheckIntervalHint')"
+            :rules="[checkIntervalRule]"
             persistent-hint
             dense
           />
@@ -647,6 +661,14 @@ export default {
       return this.getProjectIdOfItem(this.itemId);
     },
 
+    // Vue keeps an emptied number input as "", which would be interpolated
+    // straight into the snippets below and produce invalid JSON. Every snippet
+    // reads this instead of the raw field.
+    checkInterval() {
+      const n = parseInt(this.checkIntervalSeconds, 10);
+      return Number.isInteger(n) && n > 0 ? n : 1;
+    },
+
     isUnregisteredRunner() {
       return !!(this.newRunner || {}).registration_token;
     },
@@ -654,6 +676,7 @@ export default {
     runnerRegisterEnvCommand() {
       return `SEMAPHORE_WEB_ROOT=${this.webHost} \\
 SEMAPHORE_RUNNER_REGISTRATION_TOKEN=${(this.newRunner || {}).registration_token} \\
+SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\
 semaphore runner register --config ./config.runner.json
 
 semaphore runner start --config ./config.runner.json`;
@@ -661,7 +684,10 @@ semaphore runner start --config ./config.runner.json`;
 
     runnerRegisterConfigContent() {
       return `{
-  "web_host": "${this.webHost || window.location.origin}"
+  "web_host": "${this.webHost || window.location.origin}",
+  "runner": {
+    "check_interval_seconds": ${this.checkInterval}
+  }
 }`;
     },
 
@@ -676,6 +702,7 @@ semaphore runner start --config ./config.runner.json`;
       return `docker run \\
 -e SEMAPHORE_WEB_ROOT=${this.webHost} \\
 -e SEMAPHORE_RUNNER_REGISTRATION_TOKEN=${(this.newRunner || {}).registration_token} \\
+-e SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\
 -d semaphoreui/runner:${this.version}`;
     },
 
@@ -684,7 +711,7 @@ semaphore runner start --config ./config.runner.json`;
   "web_host": "${this.webHost || window.location.origin}",
   "runner": {
     "token": "${(this.newRunner || {}).token}",
-    "check_interval_seconds": ${this.checkIntervalSeconds}
+    "check_interval_seconds": ${this.checkInterval}
   }
 }`;
     },
@@ -692,7 +719,7 @@ semaphore runner start --config ./config.runner.json`;
     runnerSetupCommand() {
       return `cat << EOF > /tmp/config.runner.stdin
 ${this.webHost}
-${this.checkIntervalSeconds}
+${this.checkInterval}
 no
 yes
 ${(this.newRunner || {}).token}
@@ -705,7 +732,7 @@ semaphore runner setup --config ./config.runner.json < /tmp/config.runner.stdin`
     runnerEnvCommand() {
       return `SEMAPHORE_WEB_ROOT=${this.webHost} \\
 SEMAPHORE_RUNNER_TOKEN=${(this.newRunner || {}).token} \\
-SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkIntervalSeconds} \\
+SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\
 semaphore runner start --no-config`;
     },
 
@@ -733,7 +760,7 @@ semaphore runner start --no-config`;
       return `docker run \\
 -e SEMAPHORE_WEB_ROOT=${this.webHost} \\
 -e SEMAPHORE_RUNNER_TOKEN=${(this.newRunner || {}).token} \\
--e SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkIntervalSeconds} \\
+-e SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\
 -d semaphoreui/runner:${this.version}`;
     },
   },
@@ -757,6 +784,11 @@ semaphore runner start --no-config`;
   },
 
   methods: {
+    checkIntervalRule(v) {
+      const n = parseInt(v, 10);
+      return (Number.isInteger(n) && n > 0) || this.$t('runnerCheckIntervalInvalid');
+    },
+
     async clearCache(runner) {
       const projectId = this.getProjectIdOfItem(runner.id);
 

--- a/web/src/views/Runners.vue
+++ b/web/src/views/Runners.vue
@@ -689,8 +689,7 @@ export default {
 
     runnerRegisterEnvCommand() {
       const advancedOptions = this.advancedOptions
-        ? `SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\
-`
+        ? `SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\\n`
         : '';
       return `SEMAPHORE_WEB_ROOT=${this.webHost} \\
 SEMAPHORE_RUNNER_REGISTRATION_TOKEN=${(this.newRunner || {}).registration_token} \\
@@ -750,9 +749,11 @@ semaphore runner setup --config ./config.runner.json < /tmp/config.runner.stdin`
     },
 
     runnerEnvCommand() {
+      const advancedOptions = this.advancedOptions
+        ? `SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\\n`
+        : '';
       return `SEMAPHORE_WEB_ROOT=${this.webHost} \\
-SEMAPHORE_RUNNER_TOKEN=${(this.newRunner || {}).token} \\
-SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\
+${advancedOptions}SEMAPHORE_RUNNER_TOKEN=${(this.newRunner || {}).token} \\
 semaphore runner start --no-config`;
     },
 
@@ -777,11 +778,13 @@ semaphore runner start --no-config`;
     },
 
     runnerDockerCommand() {
+      const advancedOptions = this.advancedOptions
+        ? `SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\\n`
+        : '';
       return `docker run \\
 -e SEMAPHORE_WEB_ROOT=${this.webHost} \\
 -e SEMAPHORE_RUNNER_TOKEN=${(this.newRunner || {}).token} \\
--e SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\
--d semaphoreui/runner:${this.version}`;
+${advancedOptions}-d semaphoreui/runner:${this.version}`;
     },
   },
 

--- a/web/src/views/Runners.vue
+++ b/web/src/views/Runners.vue
@@ -197,18 +197,30 @@
             </div>
           </div>
 
-          <v-text-field
-            v-model="checkIntervalSeconds"
-            type="number"
-            min="1"
-            class="mt-6"
-            style="max-width: 320px"
-            :label="$t('runnerCheckInterval')"
-            :hint="$t('runnerCheckIntervalHint')"
-            :rules="[checkIntervalRule]"
-            persistent-hint
-            dense
-          />
+          <v-checkbox
+              v-model="advancedOptions"
+              label="Advanced options"
+            />
+
+          <HighlightedCard
+              v-if="advancedOptions"
+              tick-left="80px"
+              style="width: 350px;"
+          >
+            <template>
+            <v-text-field
+                v-model="checkIntervalSeconds"
+                type="number"
+                min="1"
+                :label="$t('runnerCheckInterval')"
+                :hint="$t('runnerCheckIntervalHint')"
+                :rules="[checkIntervalRule]"
+                persistent-hint
+                dense
+                outlined
+            />
+            </template>
+          </HighlightedCard>
 
           <h2 class="mt-11 mb-4">Variants of usage</h2>
 
@@ -695,7 +707,7 @@ export default {
 SEMAPHORE_RUNNER_REGISTRATION_TOKEN=${(this.newRunner || {}).registration_token} \\
 ${advancedOptions}semaphore runner register --config ./config.runner.json
 
-semaphore runner start --config ./config.runner.json`;
+${advancedOptions}semaphore runner start --config ./config.runner.json`;
     },
 
     runnerRegisterConfigContent() {
@@ -726,11 +738,13 @@ ${advancedOptions}-d semaphoreui/runner:${this.version}`;
     },
 
     runnerConfigCommand() {
+      const advancedOptions = this.advancedOptions
+        ? `,\n    "check_interval_seconds": ${this.checkInterval}` : '';
+
       return `{
   "web_host": "${this.webHost || window.location.origin}",
   "runner": {
-    "token": "${(this.newRunner || {}).token}",
-    "check_interval_seconds": ${this.checkInterval}
+    "token": "${(this.newRunner || {}).token}"${advancedOptions}
   }
 }`;
     },
@@ -738,7 +752,6 @@ ${advancedOptions}-d semaphoreui/runner:${this.version}`;
     runnerSetupCommand() {
       return `cat << EOF > /tmp/config.runner.stdin
 ${this.webHost}
-${this.checkInterval}
 no
 yes
 ${(this.newRunner || {}).token}
@@ -779,7 +792,7 @@ semaphore runner start --no-config`;
 
     runnerDockerCommand() {
       const advancedOptions = this.advancedOptions
-        ? `SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\\n`
+        ? `-e SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\\n`
         : '';
       return `docker run \\
 -e SEMAPHORE_WEB_ROOT=${this.webHost} \\

--- a/web/src/views/Runners.vue
+++ b/web/src/views/Runners.vue
@@ -665,7 +665,7 @@ export default {
     // straight into the snippets below and produce invalid JSON. Every snippet
     // reads this instead of the raw field.
     checkInterval() {
-      const n = parseInt(this.checkIntervalSeconds, 10);
+      const n = Number(this.checkIntervalSeconds);
       return Number.isInteger(n) && n > 0 ? n : 1;
     },
 
@@ -785,7 +785,7 @@ semaphore runner start --no-config`;
 
   methods: {
     checkIntervalRule(v) {
-      const n = parseInt(v, 10);
+      const n = Number(v);
       return (Number.isInteger(n) && n > 0) || this.$t('runnerCheckIntervalInvalid');
     },
 

--- a/web/src/views/Runners.vue
+++ b/web/src/views/Runners.vue
@@ -56,20 +56,32 @@
             {{ $t('registrationTokenHint') }}
           </v-alert>
 
-          <v-text-field
-            v-model="checkIntervalSeconds"
-            type="number"
-            min="1"
-            class="mt-6"
-            style="max-width: 320px"
-            :label="$t('runnerCheckInterval')"
-            :hint="$t('runnerCheckIntervalHint')"
-            :rules="[checkIntervalRule]"
-            persistent-hint
-            dense
-          />
-
           <h2 class="mt-8 mb-4">{{ $t('howToRegister') }}</h2>
+
+          <v-checkbox
+              v-model="advancedOptions"
+              label="Advanced options"
+            />
+
+          <HighlightedCard
+              v-if="advancedOptions"
+              tick-left="80px"
+              style="width: 350px;"
+          >
+            <template>
+            <v-text-field
+                v-model="checkIntervalSeconds"
+                type="number"
+                min="1"
+                :label="$t('runnerCheckInterval')"
+                :hint="$t('runnerCheckIntervalHint')"
+                :rules="[checkIntervalRule]"
+                persistent-hint
+                dense
+                outlined
+            />
+            </template>
+          </HighlightedCard>
 
           <v-tabs v-model="registerTab" :show-arrows="false">
             <v-tab key="env">Env Vars</v-tab>
@@ -627,11 +639,13 @@ import RunnerForm from '@/components/RunnerForm.vue';
 import axios from 'axios';
 import CopyClipboardButton from '@/components/CopyClipboardButton.vue';
 import PageMixin from '@/components/PageMixin';
+import HighlightedCard from '@/components/HighlightedCard.vue';
 
 export default {
   mixins: [ItemListPageBase, PageMixin],
 
   components: {
+    HighlightedCard,
     CopyClipboardButton,
     RunnerForm,
     YesNoDialog,
@@ -674,10 +688,13 @@ export default {
     },
 
     runnerRegisterEnvCommand() {
+      const advancedOptions = this.advancedOptions
+        ? `SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\
+`
+        : '';
       return `SEMAPHORE_WEB_ROOT=${this.webHost} \\
 SEMAPHORE_RUNNER_REGISTRATION_TOKEN=${(this.newRunner || {}).registration_token} \\
-SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkInterval} \\
-semaphore runner register --config ./config.runner.json
+${advancedOptions}semaphore runner register --config ./config.runner.json
 
 semaphore runner start --config ./config.runner.json`;
     },
@@ -780,6 +797,7 @@ semaphore runner start --no-config`;
       unregisteredFilter: false,
       resetRegistrationDialog: false,
       resetRegistrationRunner: null,
+      advancedOptions: null,
     };
   },
 

--- a/web/src/views/Runners.vue
+++ b/web/src/views/Runners.vue
@@ -172,6 +172,18 @@
             </div>
           </div>
 
+          <v-text-field
+            v-model.number="checkIntervalSeconds"
+            type="number"
+            min="1"
+            class="mt-6"
+            style="max-width: 320px"
+            :label="$t('runnerCheckInterval')"
+            :hint="$t('runnerCheckIntervalHint')"
+            persistent-hint
+            dense
+          />
+
           <h2 class="mt-11 mb-4">Variants of usage</h2>
 
           <v-tabs v-model="usageTab" :show-arrows="false">
@@ -671,7 +683,8 @@ semaphore runner start --config ./config.runner.json`;
       return `{
   "web_host": "${this.webHost || window.location.origin}",
   "runner": {
-    "token": "${(this.newRunner || {}).token}"
+    "token": "${(this.newRunner || {}).token}",
+    "check_interval_seconds": ${this.checkIntervalSeconds}
   }
 }`;
     },
@@ -679,6 +692,7 @@ semaphore runner start --config ./config.runner.json`;
     runnerSetupCommand() {
       return `cat << EOF > /tmp/config.runner.stdin
 ${this.webHost}
+${this.checkIntervalSeconds}
 no
 yes
 ${(this.newRunner || {}).token}
@@ -691,6 +705,7 @@ semaphore runner setup --config ./config.runner.json < /tmp/config.runner.stdin`
     runnerEnvCommand() {
       return `SEMAPHORE_WEB_ROOT=${this.webHost} \\
 SEMAPHORE_RUNNER_TOKEN=${(this.newRunner || {}).token} \\
+SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkIntervalSeconds} \\
 semaphore runner start --no-config`;
     },
 
@@ -718,6 +733,7 @@ semaphore runner start --no-config`;
       return `docker run \\
 -e SEMAPHORE_WEB_ROOT=${this.webHost} \\
 -e SEMAPHORE_RUNNER_TOKEN=${(this.newRunner || {}).token} \\
+-e SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=${this.checkIntervalSeconds} \\
 -d semaphoreui/runner:${this.version}`;
     },
   },
@@ -726,6 +742,9 @@ semaphore runner start --no-config`;
     return {
       newRunnerTokenDialog: null,
       newRunner: null,
+      // Mirrors the runner-side default in util.RunnerConfig.CheckIntervalSeconds.
+      // Only shapes the snippets below; the server does not store it.
+      checkIntervalSeconds: 1,
       usageTab: null,
       registerTab: null,
       globalFilter: false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable runner polling interval in seconds, defaulting to one second.
  * Added runner setup and configuration options for the polling interval.
  * Generated setup commands, configuration files, environment variables, and Docker commands now include the selected interval.
  * Added advanced options, explanatory guidance, and validation in the runner settings interface.

* **Bug Fixes**
  * Runner polling now consistently respects the configured interval across setup methods.
  * Invalid, non-positive, or excessively large interval values safely fall back to the default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->