### PR TITLE
fix(docker): pin bcrypt below 5 so passlib can hash

### DIFF
--- a/deployment/docker/job/Dockerfile
+++ b/deployment/docker/job/Dockerfile
@@ -21,13 +21,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
     && rm -rf /var/lib/apt/lists/*
 
-
+# passlib 1.7.4 cannot load its bcrypt backend on bcrypt 5+ (#4180)
 RUN pip3 install --no-cache-dir --break-system-packages \
         "ansible-core>=2.16,<2.18" \
         "ansible==${ANSIBLE_VERSION}" \
         jmespath \
         netaddr \
-        passlib
+        passlib \
+        'bcrypt>=4,<5'
 
 RUN set -eux; \
     for bin in sh cat chmod rm ls echo ssh ssh-agent ssh-add setsid git ansible-playbook python3; do \

--- a/deployment/docker/runner/Dockerfile
+++ b/deployment/docker/runner/Dockerfile
@@ -85,11 +85,12 @@ ARG ANSIBLE_VERSION=13.5.0
 ENV ANSIBLE_VERSION=${ANSIBLE_VERSION}
 ARG ANSIBLE_VENV_PATH=/opt/semaphore/apps/ansible/${ANSIBLE_VERSION}/venv
 
+# passlib 1.7.4 cannot load its bcrypt backend on bcrypt 5+ (#4180)
 RUN apk add --no-cache -U python3-dev build-base openssl-dev libffi-dev cargo && \
      mkdir -p ${ANSIBLE_VENV_PATH} && \
      python3 -m venv ${ANSIBLE_VENV_PATH} --system-site-packages && \
      source ${ANSIBLE_VENV_PATH}/bin/activate && \
-     pip3 install --upgrade pip ansible==${ANSIBLE_VERSION} boto3 botocore requests pywinrm passlib && \
+     pip3 install --upgrade pip ansible==${ANSIBLE_VERSION} boto3 botocore requests pywinrm passlib 'bcrypt>=4,<5' && \
      apk del python3-dev build-base openssl-dev libffi-dev cargo && \
      rm -rf /var/cache/apk/* && \
      find ${ANSIBLE_VENV_PATH} -iname __pycache__ | xargs rm -rf && \

--- a/deployment/docker/server/Dockerfile
+++ b/deployment/docker/server/Dockerfile
@@ -86,11 +86,12 @@ RUN chown -R semaphore:0 /usr/local/bin/server-wrapper && \
 
 WORKDIR /home/semaphore
 
+# passlib 1.7.4 cannot load its bcrypt backend on bcrypt 5+ (#4180)
 RUN apk add --no-cache -U python3-dev build-base openssl-dev libffi-dev cargo && \
      mkdir -p ${ANSIBLE_VENV_PATH} && \
      python3 -m venv ${ANSIBLE_VENV_PATH} --system-site-packages && \
      source ${ANSIBLE_VENV_PATH}/bin/activate && \
-     pip3 install --upgrade pip ansible==${ANSIBLE_VERSION} boto3 botocore requests pywinrm passlib paramiko && \
+     pip3 install --upgrade pip ansible==${ANSIBLE_VERSION} boto3 botocore requests pywinrm passlib 'bcrypt>=4,<5' paramiko && \
      apk del python3-dev build-base openssl-dev libffi-dev cargo && \
      rm -rf /var/cache/apk/* && \
      find ${ANSIBLE_VENV_PATH} -iname __pycache__ | xargs rm -rf && \


### PR DESCRIPTION
Fixes #4180.

bcrypt 5 makes passlib 1.7.4 fail its wraparound self-test, so `password_hash('bcrypt')` errors in the Docker image even for short passwords. This pins `bcrypt>=4,<5` next to passlib in the server, runner, and job images, matching the ansible-core advice.

Confirmed locally: passlib 1.7.4 + bcrypt 5.0.0 raises the 72-byte error; bcrypt 4.x hashes fine.