### PR TITLE
feat(TaskDetails, TaskLogView): link to schedule or integration details and handle deleted origins

### DIFF
--- a/web/src/components/TaskDetails.vue
+++ b/web/src/components/TaskDetails.vue
@@ -83,10 +83,10 @@
                   <td><b>{{ $t('integration') }}</b></td>
                   <td>
                     <router-link
-                      v-if="integration"
+                      v-if="isReady(integration)"
                       :to="`/project/${projectId}/integrations/${item.integration_id}`"
-                    >{{ integration.name }}</router-link>
-                    <span v-else>{{ $t('deletedOrigin', { id: item.integration_id }) }}</span>
+                    >{{ integration.data.name }}</router-link>
+                    <span v-else>{{ originLabel(integration, item.integration_id) }}</span>
                   </td>
                 </tr>
                 <tr v-else-if="item.schedule_id != null">
@@ -94,10 +94,10 @@
                   <td>
                     <!-- Schedules have no detail page, so link to the list. -->
                     <router-link
-                      v-if="schedule"
+                      v-if="isReady(schedule)"
                       :to="`/project/${projectId}/schedule`"
-                    >{{ schedule.name || $t('unnamedSchedule') }}</router-link>
-                    <span v-else>{{ $t('deletedOrigin', { id: item.schedule_id }) }}</span>
+                    >{{ schedule.data.name || $t('unnamedSchedule') }}</router-link>
+                    <span v-else>{{ originLabel(schedule, item.schedule_id) }}</span>
                   </td>
                 </tr>
                 <tr>
@@ -239,8 +239,8 @@ export default {
   props: {
     item: Object,
     user: Object,
-    // The schedule or integration that started the task. Null when a person
-    // started it, or when the origin has been deleted since.
+    // { status: 'loading' | 'ready' | 'missing' | 'error', data } for the
+    // schedule or integration that started the task; null when a person did.
     schedule: Object,
     integration: Object,
     projectId: Number,
@@ -290,6 +290,19 @@ export default {
   },
 
   methods: {
+    isReady(origin) {
+      return origin != null && origin.status === 'ready';
+    },
+
+    // Only a confirmed 404 says "deleted"; while loading or after an unrelated
+    // failure the id alone is all we can honestly show.
+    originLabel(origin, id) {
+      if (origin != null && origin.status === 'missing') {
+        return this.$t('deletedOrigin', { id });
+      }
+      return `#${id}`;
+    },
+
     async loadData() {
       this.template = await this.loadProjectResource('templates', this.item.template_id);
     },

--- a/web/src/components/TaskDetails.vue
+++ b/web/src/components/TaskDetails.vue
@@ -81,11 +81,24 @@
                 </tr>
                 <tr v-else-if="item.integration_id != null">
                   <td><b>{{ $t('integration') }}</b></td>
-                  <td>{{ item.integration_id }}</td>
+                  <td>
+                    <router-link
+                      v-if="integration"
+                      :to="`/project/${projectId}/integrations/${item.integration_id}`"
+                    >{{ integration.name }}</router-link>
+                    <span v-else>{{ $t('deletedOrigin', { id: item.integration_id }) }}</span>
+                  </td>
                 </tr>
                 <tr v-else-if="item.schedule_id != null">
                   <td><b>{{ $t('schedule') }}</b></td>
-                  <td>{{ item.schedule_id }}</td>
+                  <td>
+                    <!-- Schedules have no detail page, so link to the list. -->
+                    <router-link
+                      v-if="schedule"
+                      :to="`/project/${projectId}/schedule`"
+                    >{{ schedule.name || $t('unnamedSchedule') }}</router-link>
+                    <span v-else>{{ $t('deletedOrigin', { id: item.schedule_id }) }}</span>
+                  </td>
                 </tr>
                 <tr>
                   <td><b>{{ $t('created') }}</b></td>
@@ -226,6 +239,10 @@ export default {
   props: {
     item: Object,
     user: Object,
+    // The schedule or integration that started the task. Null when a person
+    // started it, or when the origin has been deleted since.
+    schedule: Object,
+    integration: Object,
     projectId: Number,
   },
 

--- a/web/src/components/TaskLogView.vue
+++ b/web/src/components/TaskLogView.vue
@@ -116,7 +116,13 @@
       <v-divider style="margin-top: -1px;" />
 
       <v-container fluid class="py-0 px-5 overflow-auto pt-4">
-        <TaskDetails :item="item" :user="user" :project-id="projectId" />
+        <TaskDetails
+          :item="item"
+          :user="user"
+          :schedule="schedule"
+          :integration="integration"
+          :project-id="projectId"
+        />
       </v-container>
     </div>
 
@@ -260,6 +266,11 @@ export default {
       output: [],
       outputBuffer: [],
       user: {},
+      // The schedule or integration that started this task, resolved by id so
+      // the details panel can name and link it. Null when the task was started
+      // by a person, or when the origin has since been deleted.
+      schedule: null,
+      integration: null,
       autoScroll: true,
       // stages: null,
     };
@@ -421,10 +432,22 @@ export default {
       }
     },
 
+    // Fetches an object that may have been deleted since the task ran; a
+    // missing origin must leave the task view working, not break it.
+    async loadOptional(url) {
+      try {
+        return (await axios({ method: 'get', url, responseType: 'json' })).data;
+      } catch (e) {
+        return null;
+      }
+    },
+
     async loadData() {
       [
         this.output,
         this.user,
+        this.schedule,
+        this.integration,
       ] = await Promise.all([
 
         (await axios({
@@ -441,6 +464,14 @@ export default {
           url: `/api/users/${this.item.user_id}`,
           responseType: 'json',
         })).data : null,
+
+        this.item.schedule_id
+          ? this.loadOptional(`/api/project/${this.projectId}/schedules/${this.item.schedule_id}`)
+          : null,
+
+        this.item.integration_id
+          ? this.loadOptional(`/api/project/${this.projectId}/integrations/${this.item.integration_id}`)
+          : null,
       ]);
     },
   },

--- a/web/src/components/TaskLogView.vue
+++ b/web/src/components/TaskLogView.vue
@@ -407,6 +407,8 @@ export default {
       this.outputBuffer = [];
       this.outputInterval = null;
       this.user = {};
+      this.schedule = null;
+      this.integration = null;
     },
 
     onWebsocketDataReceived(data) {
@@ -432,23 +434,31 @@ export default {
       }
     },
 
-    // Fetches an object that may have been deleted since the task ran; a
-    // missing origin must leave the task view working, not break it.
-    async loadOptional(url) {
+    // Only a 404 proves the origin is gone. A timeout or a 500 means we simply
+    // do not know, and must not be reported to the user as "deleted".
+    async loadOrigin(url) {
       try {
-        return (await axios({ method: 'get', url, responseType: 'json' })).data;
+        return { status: 'ready', data: (await axios({ method: 'get', url, responseType: 'json' })).data };
       } catch (e) {
-        return null;
+        return { status: e.response && e.response.status === 404 ? 'missing' : 'error', data: null };
       }
     },
 
     async loadData() {
-      [
-        this.output,
-        this.user,
-        this.schedule,
-        this.integration,
-      ] = await Promise.all([
+      // Distinguishes "still loading" from "not there", so a valid origin is
+      // never briefly labelled as deleted.
+      if (this.item.schedule_id) {
+        this.schedule = { status: 'loading', data: null };
+      }
+      if (this.item.integration_id) {
+        this.integration = { status: 'loading', data: null };
+      }
+
+      // These requests are fired again on every task change; without this the
+      // slower response of an earlier task can land after a later one.
+      const requested = { project: this.projectId, task: this.itemId };
+
+      const [output, user, schedule, integration] = await Promise.all([
 
         (await axios({
           method: 'get',
@@ -466,13 +476,22 @@ export default {
         })).data : null,
 
         this.item.schedule_id
-          ? this.loadOptional(`/api/project/${this.projectId}/schedules/${this.item.schedule_id}`)
+          ? this.loadOrigin(`/api/project/${this.projectId}/schedules/${this.item.schedule_id}`)
           : null,
 
         this.item.integration_id
-          ? this.loadOptional(`/api/project/${this.projectId}/integrations/${this.item.integration_id}`)
+          ? this.loadOrigin(`/api/project/${this.projectId}/integrations/${this.item.integration_id}`)
           : null,
       ]);
+
+      if (requested.project !== this.projectId || requested.task !== this.itemId) {
+        return;
+      }
+
+      this.output = output;
+      this.user = user;
+      this.schedule = schedule;
+      this.integration = integration;
     },
   },
 };

--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -405,6 +405,8 @@ export default {
   empty: 'Empty',
   noValues: 'No values',
   addArg: 'Add arg',
+  deletedOrigin: '#{id} (deleted)',
+  unnamedSchedule: 'Schedule',
 
   status_success: 'Success',
   status_failed: 'Failed',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Task details now display ready schedule and integration origins as links.
  * Origin information shows clear loading and error states, including the origin ID when details are unavailable.
  * Deleted origins use localized fallback messaging.
  * Schedule and integration origin data is refreshed with task details and protected against stale results.
  * Added localized text for deleted origins and unnamed schedules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->