### PR TITLE
fix(tasks): isolate checkouts by effective branch

### DIFF
--- a/db/Repository.go
+++ b/db/Repository.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"path"
 	"regexp"
@@ -46,6 +47,39 @@ func (r Repository) GetDirName(templateID int) string {
 	return r.getDirNamePrefix() + "template_" + strconv.Itoa(templateID)
 }
 
+const branchDirNameMaxLen = 48
+const branchDirNameHashBytes = 16
+
+// branchDirName turns a branch name into a path-safe directory suffix. The
+// hash distinguishes branches whose readable names would otherwise collide.
+func branchDirName(branch string) string {
+	sum := sha1.Sum([]byte(branch))
+
+	readable := strings.Map(func(c rune) rune {
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' ||
+			c == '.' || c == '_' || c == '-' {
+			return c
+		}
+		return '-'
+	}, branch)
+
+	if len(readable) > branchDirNameMaxLen {
+		readable = readable[:branchDirNameMaxLen]
+	}
+
+	if readable == "" {
+		return fmt.Sprintf("%x", sum[:branchDirNameHashBytes])
+	}
+
+	return readable + "_" + fmt.Sprintf("%x", sum[:branchDirNameHashBytes])
+}
+
+// GetCheckoutDirName returns the checkout directory name for this template and
+// branch. Different branches must not share a working tree while tasks run.
+func (r Repository) GetCheckoutDirName(templateID int) string {
+	return r.GetDirName(templateID) + "_" + branchDirName(r.GitBranch)
+}
+
 // GetHomePath returns the per-template "home" directory with a "_home" suffix.
 // Currently this path is used for home-like directories such as ANSIBLE_HOME so
 // that parallel tasks from different templates get isolated home directories
@@ -62,13 +96,13 @@ func (r Repository) GetInternalPath(templateID int) string {
 }
 
 // GetFullPath returns the path where the repository source code lives.
-// The repository is cloned directly into the template directory
-// (e.g. repository_15_template_114) without any subdirectory.
+// The repository is cloned directly into its branch-specific checkout
+// directory (e.g. repository_15_template_114_main_1a2b3c4d).
 func (r Repository) GetFullPath(templateID int) string {
 	if r.GetType() == RepositoryLocal {
 		return r.GetGitURL(true)
 	}
-	return path.Join(util.Config.GetProjectTmpDir(r.ProjectID), r.GetDirName(templateID))
+	return path.Join(util.Config.GetProjectTmpDir(r.ProjectID), r.GetCheckoutDirName(templateID))
 }
 
 func (r Repository) GetGitURL(secure bool) string {

--- a/db/Repository_test.go
+++ b/db/Repository_test.go
@@ -72,3 +72,26 @@ func TestRepository_GetGitURL(t *testing.T) {
 		assert.Equal(t, v.ExpectedGitUrl, gitUrl, "wrong gitUrl")
 	}
 }
+
+func TestRepository_GetCheckoutDirName(t *testing.T) {
+	repo := Repository{ID: 1, GitURL: "https://example.com/hello/world"}
+
+	repo.GitBranch = "main"
+	main := repo.GetCheckoutDirName(2)
+	assert.Equal(t, "repository_1_template_2_main_b28b7af69320201d1cf206ebf2837398", main)
+
+	repo.GitBranch = "prod"
+	prod := repo.GetCheckoutDirName(2)
+
+	assert.NotEqual(t, main, prod)
+
+	repo.GitBranch = "main"
+	assert.Equal(t, main, repo.GetCheckoutDirName(2))
+
+	repo.GitBranch = "feature/login"
+	assert.NotContains(t, repo.GetCheckoutDirName(2), "/")
+
+	slashed := repo.GetCheckoutDirName(2)
+	repo.GitBranch = "feature-login"
+	assert.NotEqual(t, slashed, repo.GetCheckoutDirName(2))
+}

--- a/db_lib/CmdGitClient.go
+++ b/db_lib/CmdGitClient.go
@@ -99,7 +99,7 @@ func (c CmdGitClient) Clone(r GitRepository) error {
 
 	var dirName string
 	if r.TmpDirName == "" {
-		dirName = r.Repository.GetDirName(r.TemplateID)
+		dirName = r.Repository.GetCheckoutDirName(r.TemplateID)
 	} else {
 		dirName = r.TmpDirName
 	}

--- a/db_lib/GoGitClient.go
+++ b/db_lib/GoGitClient.go
@@ -138,6 +138,7 @@ func (c GoGitClient) Pull(r GitRepository) error {
 
 	// Pull the latest changes from the origin remote and merge into the current branch
 	err = wt.Pull(&git.PullOptions{RemoteName: "origin",
+		ReferenceName:     plumbing.NewBranchReferenceName(r.Repository.GitBranch),
 		Auth:              authMethod,
 		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth})
 	if err != nil && err != git.NoErrAlreadyUpToDate {

--- a/services/tasks/TaskRunner.go
+++ b/services/tasks/TaskRunner.go
@@ -549,6 +549,8 @@ func (t *TaskRunner) populateDetails() error {
 		return err
 	}
 
+	t.Repository = withEffectiveBranch(t.Repository, t.Template, t.Task)
+
 	// load and merge all configured environments
 	err = t.loadEnvironments()
 	if err != nil {

--- a/services/tasks/TaskRunner_test.go
+++ b/services/tasks/TaskRunner_test.go
@@ -227,7 +227,7 @@ func TestGetRepoPath(t *testing.T) {
 	}
 
 	dir := tsk.job.(*LocalExecutor).App.(*db_lib.AnsibleApp).GetPlaybookDir()
-	if dir != "/tmp/project_0/repository_0_template_0/deploy" {
+	if dir != "/tmp/project_0/repository_0_template_0_da39a3ee5e6b4b0d3255bfef95601890/deploy" {
 		t.Fatal("Invalid playbook dir: " + dir)
 	}
 }
@@ -273,7 +273,7 @@ func TestGetRepoPath_whenStartsWithSlash(t *testing.T) {
 	}
 
 	dir := tsk.job.(*LocalExecutor).App.(*db_lib.AnsibleApp).GetPlaybookDir()
-	if dir != "/tmp/project_0/repository_0_template_0/deploy" {
+	if dir != "/tmp/project_0/repository_0_template_0_da39a3ee5e6b4b0d3255bfef95601890/deploy" {
 		t.Fatal("Invalid playbook dir: " + dir)
 	}
 }

--- a/services/tasks/executor_test.go
+++ b/services/tasks/executor_test.go
@@ -66,6 +66,17 @@ func TestResolveGitBranch(t *testing.T) {
 	}
 }
 
+func TestWithEffectiveBranch(t *testing.T) {
+	repository := db.Repository{GitBranch: "main"}
+	template := db.Template{AllowOverrideBranchInTask: true}
+	task := db.Task{GitBranch: new("release")}
+
+	effective := withEffectiveBranch(repository, template, task)
+
+	assert.Equal(t, "release", effective.GitBranch)
+	assert.Equal(t, "main", repository.GitBranch)
+}
+
 // TestLocalExecutorImplementsExecutor is a compile-time guard: if LocalExecutor stops
 // satisfying the Executor interface, this file fails to build. It documents the
 // contract introduced in Phase 1 of the Kubernetes runner refactor.

--- a/services/tasks/local_executor.go
+++ b/services/tasks/local_executor.go
@@ -962,6 +962,13 @@ func resolveGitBranch(repoBranch string, template db.Template, task db.Task) str
 	return branch
 }
 
+// withEffectiveBranch settles the branch before the App is built, so the App
+// and Git operations use the same branch-specific checkout directory.
+func withEffectiveBranch(repository db.Repository, template db.Template, task db.Task) db.Repository {
+	repository.GitBranch = resolveGitBranch(repository.GitBranch, template, task)
+	return repository
+}
+
 func (t *LocalExecutor) prepareRun(installingArgs db_lib.LocalAppInstallingArgs) error {
 
 	t.Log("Preparing: " + strconv.Itoa(t.Task.ID))
@@ -981,8 +988,6 @@ func (t *LocalExecutor) prepareRun(installingArgs db_lib.LocalAppInstallingArgs)
 			return err
 		}
 	}
-
-	t.Repository.GitBranch = resolveGitBranch(t.Repository.GitBranch, t.Template, t.Task)
 
 	if t.Repository.GetType() == db.RepositoryLocal {
 		localPath := t.Repository.GetGitURL(true)
@@ -1038,8 +1043,6 @@ func (t *LocalExecutor) prepareRunTerraform(tfApp *db_lib.TerraformApp, installi
 		}
 	}
 
-	t.Repository.GitBranch = resolveGitBranch(t.Repository.GitBranch, t.Template, t.Task)
-
 	if t.Repository.GetType() == db.RepositoryLocal {
 		localPath := t.Repository.GetGitURL(true)
 		if _, err := os.Stat(localPath); err != nil {
@@ -1076,8 +1079,8 @@ func (t *LocalExecutor) prepareRunTerraform(tfApp *db_lib.TerraformApp, installi
 }
 
 // updateAndCheckoutRepository runs the pull/clone + checkout sequence as one
-// critical section per repository directory, so parallel tasks of the same
-// template cannot run concurrent git operations on the shared working copy.
+// critical section per repository directory, so parallel tasks using the same
+// branch checkout cannot run concurrent git operations.
 //
 // ponytail: the lock covers git operations only; parallel tasks pinned to
 // different commits still share the working tree afterwards — per-task
@@ -1211,4 +1214,3 @@ func (t *LocalExecutor) getSSHAgentEnv() string {
 	}
 	return ""
 }
-

--- a/services/tasks/local_executor_provider.go
+++ b/services/tasks/local_executor_provider.go
@@ -35,6 +35,8 @@ func NewLocalExecutorProvider(keyInstaller db_lib.AccessKeyInstaller) *LocalExec
 // here rather than inside LocalExecutor.Prepare so the executor arrives with a
 // non-nil App — Prepare's contract is "do the I/O", not "build the structure".
 func (p *LocalExecutorProvider) NewExecutor(task db.Task, template db.Template, inventory db.Inventory, repository db.Repository, environment db.Environment, jwt string) (Executor, error) {
+	repository = withEffectiveBranch(repository, template, task)
+
 	return &LocalExecutor{
 		Task:        task,
 		Template:    template,


### PR DESCRIPTION
Parallel tasks with different branch overrides previously shared one template checkout. Updating the second task switched repository files while the first task was still running, causing Ansible to fail with missing-file errors.

Key checkout paths by the effective branch so each branch keeps its own clone and parallel runs on different branches cannot modify each other's source tree.

Fixes #3749 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Separate working directories are now used for different repository branches, preventing branch checkouts from interfering with one another.
  - Branch names are converted into safe, distinct directory names for more reliable repository operations.
  - Pull operations now consistently target the configured branch instead of relying on the remote’s default branch.
  - Task- and template-level branch settings are applied consistently before repository operations begin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->