### PR TITLE
fix(web): remove trailing spaces that break the build

### DIFF
--- a/web/src/views/project/WorkflowEditor.vue
+++ b/web/src/views/project/WorkflowEditor.vue
@@ -109,7 +109,7 @@
               <v-icon small :left="!sideCollapsed">mdi-account-check</v-icon>
               <template v-if="!sideCollapsed">{{ $t('workflowPaletteApprovalNode') }}</template>
             </div>
-            
+
             <div
               class="WorkflowEditor__paletteItem WorkflowEditor__paletteItem--delay"
               draggable="true"


### PR DESCRIPTION
The line fails the eslint rule no-trailing-spaces, so `task build` stops at the frontend step. The backend build then fails too, because it embeds api/public, which the frontend step never writes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted whitespace formatting in the workflow editor without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->