### PR TITLE
Fix Dredd test server startup and port conflicts

### DIFF
--- a/.dredd/dredd.testing.yml
+++ b/.dredd/dredd.testing.yml
@@ -28,4 +28,4 @@ hooks-worker-handler-host: 0.0.0.0
 hooks-worker-handler-port: 61321
 config: ./.dredd/dredd.yml
 blueprint: api-docs.yml
-endpoint: 'http://localhost:3000'
+endpoint: 'http://localhost:58427'

--- a/.dredd/server-wrapper.sh
+++ b/.dredd/server-wrapper.sh
@@ -2,8 +2,9 @@
 
 export SEMAPHORE_MAX_TASKS_PER_TEMPLATE=300
 export SEMAPHORE_APPS='{"ansible": {}}'
+export SEMAPHORE_PORT=58427
 
 semaphore=./semaphore
 [[ -x "$semaphore" ]] || semaphore=./bin/semaphore
 
-"$semaphore" server --config .dredd/config.json
+exec "$semaphore" server --config .dredd/config.json

--- a/.dredd/server-wrapper.sh
+++ b/.dredd/server-wrapper.sh
@@ -1,5 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 export SEMAPHORE_MAX_TASKS_PER_TEMPLATE=300
 export SEMAPHORE_APPS='{"ansible": {}}'
-./semaphore server --config .dredd/config.json
+
+semaphore=./semaphore
+[[ -x "$semaphore" ]] || semaphore=./bin/semaphore
+
+"$semaphore" server --config .dredd/config.json

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -312,7 +312,7 @@ jobs:
           p455w0rd
           semaphore
           /tmp/semaphore
-          http://localhost:3000
+          http://localhost:58427
           no
           no
           no
@@ -399,7 +399,7 @@ jobs:
           p455w0rd
           semaphore
           /tmp/semaphore
-          http://localhost:3000
+          http://localhost:58427
           no
           no
           no
@@ -485,7 +485,7 @@ jobs:
           p455w0rd
           semaphore
           /tmp/semaphore
-          http://localhost:3000
+          http://localhost:58427
           no
           no
           no
@@ -553,7 +553,7 @@ jobs:
           4
           /tmp/database.sqlite
           /tmp/semaphore
-          http://localhost:3000
+          http://localhost:58427
           no
           no
           no


### PR DESCRIPTION
Improve Dredd test server startup for local development without disrupting CI.

On my development machine, Semaphore runs as a service on port `3000`. Dredd also used port `3000`, causing its requests to reach the existing service instead of the temporary test server and resulting in test failures. The ephemeral Semaphore server launched during API tests should use a dedicated high-numbered port instead.

The previous wrapper had a few issues:

- It expected the CI artifact path (`./semaphore`), which is not present during local development.
- It did not replace the wrapper process with the server process, allowing the server to remain running after Dredd exited and causing subsequent runs to fail.

This change:

- Discovers Semaphore at `./semaphore` for CI artifacts, falling back to `./bin/semaphore` for local builds.
- Runs Dredd's ephemeral server on dedicated port `58427` instead of the commonly used port `3000`.
- Updates the Dredd endpoint and CI setup URLs to use port `58427`.
- Uses `exec` when launching Semaphore so Dredd terminates the server directly without leaving an orphaned process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated API contract and integration test configurations to use a dedicated local server port.
  - Improved test server startup handling across supported database environments.
  - Added fallback behavior for locating the test server executable to make local and automated test runs more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->