### PR TITLE
Potential fix for code scanning alert no. 154: Uncontrolled data used in path expression

### DIFF
--- a/util/config_sysproc.go
+++ b/util/config_sysproc.go
@@ -3,10 +3,13 @@
 package util
 
 import (
+	"fmt"
 	"math"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 )
 
@@ -82,5 +85,20 @@ func ChownDir(path string) error {
 		return nil
 	}
 
-	return os.Chown(path, int(uid), int(gid))
+	baseAbs, err := filepath.Abs(filepath.Clean(Config.TmpPath))
+	if err != nil {
+		return err
+	}
+
+	targetAbs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return err
+	}
+
+	baseWithSep := baseAbs + string(os.PathSeparator)
+	if targetAbs != baseAbs && !strings.HasPrefix(targetAbs, baseWithSep) {
+		return fmt.Errorf("refusing to chown path outside tmp dir: %s", targetAbs)
+	}
+
+	return os.Chown(targetAbs, int(uid), int(gid))
 }


### PR DESCRIPTION
Potential fix for [https://github.com/semaphoreui/semaphore/security/code-scanning/154](https://github.com/semaphoreui/semaphore/security/code-scanning/154)

General fix: before performing `os.Chown`, canonicalize and validate the provided path against an expected safe base directory, and reject paths outside that base. This prevents traversal/absolute-path abuse even if upstream validation regresses.

Best targeted fix here (without changing functionality): in `util/config_sysproc.go`, harden `ChownDir(path string)` by:
- Resolving both the configured project tmp base (`Config.TmpPath`) and the input `path` to absolute cleaned paths.
- Ensuring the target is either exactly the base or a child of the base using a prefix check with path separator boundary.
- Returning an error when outside the allowed base.
- Proceeding to `os.Chown` only after validation.

This keeps existing behavior for legitimate repository temp dirs while blocking uncontrolled filesystem targets.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved protection for temporary-directory ownership changes by rejecting paths outside the configured temporary directory.
  - Paths are now normalized before validation to ensure consistent safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->