### PR TITLE
fix(runner): authenticate unregister requests

### DIFF
--- a/services/runners/job_pool.go
+++ b/services/runners/job_pool.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -46,6 +47,9 @@ func newHTTPClient() *http.Client {
 	}
 	return &http.Client{
 		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return errors.New("runner API redirects are not allowed")
+		},
 	}
 }
 

--- a/services/runners/job_pool.go
+++ b/services/runners/job_pool.go
@@ -227,6 +227,7 @@ func (p *JobPool) Unregister() (err error) {
 	if err != nil {
 		return
 	}
+	p.setCommonHeaders(req)
 
 	log.WithFields(log.Fields{
 		"context": "unregistration",

--- a/services/runners/job_pool_test.go
+++ b/services/runners/job_pool_test.go
@@ -170,6 +170,37 @@ func TestJobPool_UnregisterSendsRunnerToken(t *testing.T) {
 	require.NoError(t, p.Unregister())
 }
 
+func TestJobPool_UnregisterDoesNotFollowRedirect(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		assert.Empty(t, r.Header.Get("X-Runner-Token"))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(target.Close)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", target.URL+"/api/internal/runners")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(server.Close)
+
+	previousConfig := util.Config
+	t.Cleanup(func() { util.Config = previousConfig })
+	util.Config = &util.ConfigType{
+		WebHost: server.URL,
+		Runner: &util.RunnerConfig{
+			Token:      "runner-token",
+			Connection: &util.RunnerConnectionConfig{},
+		},
+	}
+
+	p := &JobPool{client: newHTTPClient()}
+
+	assert.Error(t, p.Unregister())
+	assert.Zero(t, redirectedRequests.Load())
+}
+
 func TestJobPool_CheckNewJobsExecutorErrorUsesTaskProjectID(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		err := json.NewEncoder(w).Encode(RunnerState{

--- a/services/runners/job_pool_test.go
+++ b/services/runners/job_pool_test.go
@@ -146,6 +146,30 @@ func TestJobPool_ApplyTerminatedJobs(t *testing.T) {
 	assert.Equal(t, 0, p.runningJobsCount())
 }
 
+func TestJobPool_UnregisterSendsRunnerToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/internal/runners", r.URL.Path)
+		assert.Equal(t, "runner-token", r.Header.Get("X-Runner-Token"))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	previousConfig := util.Config
+	t.Cleanup(func() { util.Config = previousConfig })
+	util.Config = &util.ConfigType{
+		WebHost: srv.URL,
+		Runner: &util.RunnerConfig{
+			Token:      "runner-token",
+			Connection: &util.RunnerConnectionConfig{},
+		},
+	}
+
+	p := &JobPool{client: newHTTPClient()}
+
+	require.NoError(t, p.Unregister())
+}
+
 func TestJobPool_CheckNewJobsExecutorErrorUsesTaskProjectID(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		err := json.NewEncoder(w).Encode(RunnerState{


### PR DESCRIPTION
Runner `unregister` requests were rejected with 401, leaving the runner registered on the server after local unregistration and causing `./bin/semaphore runner unregister --config ../runner.local.json` to crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Runner removal requests now include the required runner authentication and startup metadata.
  - Runner-to-server API requests no longer follow redirects, preventing credentials from being forwarded to redirected destinations.

- **Tests**
  - Added coverage confirming runner removal requests include authentication details.
  - Added coverage verifying redirects are rejected without issuing a redirected request or forwarding the runner token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->