### PR TITLE
feat(runners): add server-side debug diagnostics

### DIFF
--- a/api/runners/runners.go
+++ b/api/runners/runners.go
@@ -27,9 +27,7 @@ func RunnerMiddleware(next http.Handler) http.Handler {
 		token := r.Header.Get("X-Runner-Token")
 
 		if token == "" {
-			log.WithFields(log.Fields{
-				"context": "runner",
-			}).Debug("Runner authentication rejected: no token provided")
+			runnerLog.Debug("Runner authentication rejected: no token provided")
 			helpers.WriteJSON(w, http.StatusUnauthorized, map[string]string{
 				"error": "Invalid token",
 			})

--- a/api/runners/runners.go
+++ b/api/runners/runners.go
@@ -11,6 +11,7 @@ import (
 	"github.com/semaphoreui/semaphore/db"
 	"github.com/semaphoreui/semaphore/pkg/jwt"
 	"github.com/semaphoreui/semaphore/pkg/task_logger"
+	"github.com/semaphoreui/semaphore/pkg/tz"
 	"github.com/semaphoreui/semaphore/services/runners"
 	"github.com/semaphoreui/semaphore/services/server"
 	"github.com/semaphoreui/semaphore/services/tasks"
@@ -20,10 +21,15 @@ import (
 
 func RunnerMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
+		runnerLog := log.WithFields(log.Fields{
+			"context": "runner",
+		})
 		token := r.Header.Get("X-Runner-Token")
 
 		if token == "" {
+			log.WithFields(log.Fields{
+				"context": "runner",
+			}).Debug("Runner authentication rejected: no token provided")
 			helpers.WriteJSON(w, http.StatusUnauthorized, map[string]string{
 				"error": "Invalid token",
 			})
@@ -35,6 +41,11 @@ func RunnerMiddleware(next http.Handler) http.Handler {
 		runner, err := store.GetRunnerByToken(token)
 
 		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				runnerLog.Debug("Runner authentication rejected: no runner matches token")
+			} else {
+				runnerLog.WithError(err).Error("Runner authentication lookup failed")
+			}
 			helpers.WriteJSON(w, http.StatusNotFound, map[string]string{
 				"error": "Runner not found",
 			})
@@ -71,6 +82,10 @@ func NewRunnerController(runnerRepo db.RunnerManager, taskPool *tasks.TaskPool, 
 
 func (c *RunnerController) GetRunner(w http.ResponseWriter, r *http.Request) {
 	runner := helpers.GetFromContext(r, "runner").(db.Runner)
+	runnerLog := log.WithFields(log.Fields{
+		"context":   "runner",
+		"runner_id": runner.ID,
+	})
 
 	clearCache := false
 
@@ -79,22 +94,25 @@ func (c *RunnerController) GetRunner(w http.ResponseWriter, r *http.Request) {
 	// can detect runners that restarted and lost their in-memory job pool.
 	if v := r.Header.Get("X-Runner-Started-At"); v != "" {
 		if startedAt, parseErr := time.Parse(time.RFC3339, v); parseErr == nil {
+			if runner.StartedAt != nil && startedAt.After(*runner.StartedAt) {
+				runnerLog.Debug("Runner process restart detected")
+			}
 			runner.StartedAt = &startedAt
 		} else {
-			log.WithFields(log.Fields{
-				"runner_id": runner.ID,
-				"context":   "runner",
-			}).WithError(parseErr).Warn("invalid X-Runner-Started-At header")
+			runnerLog.WithError(parseErr).Warn("invalid X-Runner-Started-At header")
 		}
 	}
 
+	wasOffline := !runner.IsOnline(tz.Now(), util.Config.RunnersOfflineTimeout())
+
 	if err := c.runnerRepo.TouchRunner(runner); err != nil {
-		log.WithFields(log.Fields{
-			"runner_id": runner.ID,
-			"context":   "runner",
-		}).WithError(err).Error("runner touch failed")
+		runnerLog.WithError(err).Error("runner touch failed")
 		helpers.WriteError(w, err)
 		return
+	}
+
+	if wasOffline {
+		runnerLog.Debug("Runner became online")
 	}
 
 	if runner.CleaningRequested != nil && (runner.Touched == nil || runner.CleaningRequested.After(*runner.Touched)) {
@@ -312,10 +330,15 @@ func (c *RunnerController) collectTaskAccessKeys(tsk *tasks.TaskRunner, runnerID
 func (c *RunnerController) UpdateRunner(w http.ResponseWriter, r *http.Request) {
 
 	runner := helpers.GetFromContext(r, "runner").(db.Runner)
+	runnerLog := log.WithFields(log.Fields{
+		"context":   "runner",
+		"runner_id": runner.ID,
+	})
 
 	var body runners.RunnerProgress
 
 	if !helpers.Bind(w, r, &body) {
+		runnerLog.Debug("Rejecting runner task update: invalid request body")
 		helpers.WriteJSON(w, http.StatusBadRequest, map[string]string{
 			"error": "Invalid format",
 		})
@@ -330,21 +353,20 @@ func (c *RunnerController) UpdateRunner(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var response runners.RunnerProgressResponse
+	logRecordCount := 0
 
 	for _, job := range body.Jobs {
+		jobLog := runnerLog.WithField("task_id", job.ID)
 		tsk, err := taskPool.GetTask(job.ID)
 
 		if err != nil {
 			if errors.Is(err, db.ErrNotFound) {
 				// The task no longer exists at all — the runner's job is orphaned.
+				jobLog.Debug("Discarding runner task update: task does not exist")
 				response.TerminatedJobs = append(response.TerminatedJobs, job.ID)
 				continue
 			}
-			log.WithError(err).WithFields(log.Fields{
-				"task_id":   job.ID,
-				"runner_id": runner.ID,
-				"context":   "runner",
-			}).Warn("runner progress: task not in local pool and could not be loaded from database")
+			jobLog.WithError(err).Warn("runner progress: task not in local pool and could not be loaded from database")
 			continue
 		}
 
@@ -356,21 +378,18 @@ func (c *RunnerController) UpdateRunner(w http.ResponseWriter, r *http.Request) 
 			switch {
 			case rowErr != nil && errors.Is(rowErr, db.ErrNotFound):
 				// The task no longer exists at all — the runner's job is orphaned.
+				jobLog.Debug("Discarding runner task update: task does not exist")
 				response.TerminatedJobs = append(response.TerminatedJobs, job.ID)
 			case rowErr == nil && row.Status.IsFinished():
+				jobLog.WithFields(log.Fields{
+					"task_status":     string(row.Status),
+					"reported_status": string(job.Status),
+				}).Debug("Discarding runner task update: task is already finished")
 				response.TerminatedJobs = append(response.TerminatedJobs, job.ID)
 			case rowErr != nil:
-				log.WithError(rowErr).WithFields(log.Fields{
-					"task_id":   job.ID,
-					"runner_id": runner.ID,
-					"context":   "runner",
-				}).Warn("runner progress: task not in pool and could not be loaded from database")
+				jobLog.WithError(rowErr).Warn("runner progress: task not in pool and could not be loaded from database")
 			default:
-				log.WithFields(log.Fields{
-					"task_id":   job.ID,
-					"runner_id": runner.ID,
-					"context":   "runner",
-				}).Warn("runner progress: task not found in pool")
+				jobLog.Warn("runner progress: task not found in pool")
 			}
 			continue
 		}
@@ -381,11 +400,16 @@ func (c *RunnerController) UpdateRunner(w http.ResponseWriter, r *http.Request) 
 			// rejecting the whole progress batch with 400 — sendProgress treats
 			// >=400 as total failure and never applies terminated_jobs, so the
 			// old runner would keep executing alongside the new assignee.
+			if tsk.Task.RunnerID != nil {
+				jobLog = jobLog.WithField("assigned_runner_id", *tsk.Task.RunnerID)
+			}
+			jobLog.Debug("Discarding stale runner task update: task is no longer assigned to this runner")
 			response.TerminatedJobs = append(response.TerminatedJobs, job.ID)
 			continue
 		}
 
 		if !job.Status.IsValid() {
+			jobLog.WithField("reported_status", string(job.Status)).Debug("Rejecting runner task update: invalid status")
 			helpers.WriteErrorStatus(w, "Invalid task status", http.StatusBadRequest)
 			return
 		}
@@ -395,6 +419,10 @@ func (c *RunnerController) UpdateRunner(w http.ResponseWriter, r *http.Request) 
 		// Reject the report — logs included — and tell the runner to
 		// emergency-stop the job.
 		if tsk.Task.Status.IsFinished() {
+			jobLog.WithFields(log.Fields{
+				"task_status":     string(tsk.Task.Status),
+				"reported_status": string(job.Status),
+			}).Debug("Discarding runner task update: task is already finished")
 			response.TerminatedJobs = append(response.TerminatedJobs, job.ID)
 			continue
 		}
@@ -402,6 +430,7 @@ func (c *RunnerController) UpdateRunner(w http.ResponseWriter, r *http.Request) 
 		for _, logRecord := range job.LogRecords {
 			tsk.LogWithTime(logRecord.Time, logRecord.Message)
 		}
+		logRecordCount += len(job.LogRecords)
 
 		tsk.SetStatus(job.Status)
 
@@ -417,6 +446,14 @@ func (c *RunnerController) UpdateRunner(w http.ResponseWriter, r *http.Request) 
 			runner := runner
 			go taskPool.FinalizeRemoteTask(tsk, &runner)
 		}
+	}
+
+	if len(body.Jobs) > 0 {
+		runnerLog.WithFields(log.Fields{
+			"reported_jobs":        len(body.Jobs),
+			"accepted_log_records": logRecordCount,
+			"terminated_jobs":      len(response.TerminatedJobs),
+		}).Debug("Runner task update processed")
 	}
 
 	helpers.WriteJSON(w, http.StatusOK, response)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -296,6 +296,7 @@ func runService() {
 		defer wsBroadcaster.Stop()
 	}
 
+	taskPool.LogRunnerStateSnapshot()
 	go schedulePool.Run()
 	go taskPool.Run()
 

--- a/db/Runner.go
+++ b/db/Runner.go
@@ -92,6 +92,12 @@ func (r Runner) IsOnline(now time.Time, offlineTimeout time.Duration) bool {
 	return r.Touched != nil && now.Sub(*r.Touched) <= offlineTimeout
 }
 
+// HasFreeCapacity reports whether the runner can take one more task.
+// MaxParallelTasks == 0 means unlimited.
+func (r Runner) HasFreeCapacity(runningTasks int) bool {
+	return r.MaxParallelTasks == 0 || runningTasks < r.MaxParallelTasks
+}
+
 // FillStatus populates the transient Status field from heartbeat liveness.
 func (r *Runner) FillStatus(now time.Time, offlineTimeout time.Duration) {
 	if r.IsOnline(now, offlineTimeout) {

--- a/db/Runner_test.go
+++ b/db/Runner_test.go
@@ -36,6 +36,27 @@ func TestRunner_IsOnline(t *testing.T) {
 	}
 }
 
+func TestRunner_HasFreeCapacity(t *testing.T) {
+	tests := []struct {
+		name         string
+		runner       Runner
+		runningTasks int
+		expected     bool
+	}{
+		{"unlimited", Runner{MaxParallelTasks: 0}, 100, true},
+		{"below limit", Runner{MaxParallelTasks: 2}, 1, true},
+		{"at limit", Runner{MaxParallelTasks: 2}, 2, false},
+		{"above limit", Runner{MaxParallelTasks: 2}, 3, false},
+		{"idle with limit", Runner{MaxParallelTasks: 1}, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.runner.HasFreeCapacity(tt.runningTasks))
+		})
+	}
+}
+
 func TestRunner_FillStatus(t *testing.T) {
 	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
 	offlineTimeout := 2 * time.Minute

--- a/pkg/debuglog/formatter.go
+++ b/pkg/debuglog/formatter.go
@@ -24,11 +24,27 @@ func NewFilteringFormatter(inner log.Formatter, filter *Filter) *FilteringFormat
 	return &FilteringFormatter{Inner: inner, Filter: filter}
 }
 
+// Enabled reports whether a DEBUG entry in namespace can reach the logger's output.
+func Enabled(logger *log.Logger, namespace string) bool {
+	if !logger.IsLevelEnabled(log.DebugLevel) {
+		return false
+	}
+	formatter, ok := logger.Formatter.(*FilteringFormatter)
+	if !ok {
+		return true
+	}
+	return formatter.enabled(namespace)
+}
+
+func (f *FilteringFormatter) enabled(namespace string) bool {
+	return f.Filter != nil && f.Filter.Enabled(namespace)
+}
+
 // Format implements logrus.Formatter.
 func (f *FilteringFormatter) Format(entry *log.Entry) ([]byte, error) {
 	if entry.Level == log.DebugLevel {
 		ns, _ := entry.Data["context"].(string)
-		if f.Filter == nil || !f.Filter.Enabled(ns) {
+		if !f.enabled(ns) {
 			return nil, nil
 		}
 	}

--- a/pkg/debuglog/formatter_test.go
+++ b/pkg/debuglog/formatter_test.go
@@ -87,3 +87,29 @@ func TestFilteringFormatter_SuppressedEntryWritesNoBytes(t *testing.T) {
 	// Suppressed debug entries must produce zero output, not a bare newline.
 	require.Equal(t, 0, buf.Len())
 }
+
+func TestEnabled(t *testing.T) {
+	tests := []struct {
+		name      string
+		level     log.Level
+		formatter log.Formatter
+		namespace string
+		expected  bool
+	}{
+		{"debug without filter", log.DebugLevel, &log.TextFormatter{}, "runner", true},
+		{"info without filter", log.InfoLevel, &log.TextFormatter{}, "runner", false},
+		{"matching filter", log.DebugLevel, NewFilteringFormatter(nil, Parse("runner")), "runner", true},
+		{"non-matching filter", log.DebugLevel, NewFilteringFormatter(nil, Parse("task_pool")), "runner", false},
+		{"excluded namespace", log.DebugLevel, NewFilteringFormatter(nil, Parse("*,-runner")), "runner", false},
+		{"nil filter", log.DebugLevel, NewFilteringFormatter(nil, nil), "runner", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.New()
+			logger.SetLevel(tt.level)
+			logger.SetFormatter(tt.formatter)
+			assert.Equal(t, tt.expected, Enabled(logger, tt.namespace))
+		})
+	}
+}

--- a/services/tasks/RemoteJob.go
+++ b/services/tasks/RemoteJob.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/semaphoreui/semaphore/db"
+	"github.com/semaphoreui/semaphore/pkg/debuglog"
 	"github.com/semaphoreui/semaphore/pkg/task_logger"
 	"github.com/semaphoreui/semaphore/pkg/tz"
 	"github.com/semaphoreui/semaphore/util"
@@ -71,12 +73,10 @@ func callRunnerWebhook(runner *db.Runner, tsk *TaskRunner, action string) (err e
 		return
 	}
 
-	if resp != nil {
-		defer resp.Body.Close() //nolint:errcheck
-	}
+	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != 200 && resp.StatusCode != 204 {
-		err = fmt.Errorf("webhook returned incorrect status")
+		err = fmt.Errorf("webhook returned status %d", resp.StatusCode)
 		return
 	}
 
@@ -124,11 +124,80 @@ func selectRunner(
 		if !r.IsOnline(now, offlineTimeout) {
 			continue
 		}
-		if n := busyTasks(r.ID); n < r.MaxParallelTasks || r.MaxParallelTasks == 0 {
+		if r.HasFreeCapacity(busyTasks(r.ID)) {
 			return r
 		}
 	}
 	return nil
+}
+
+func runnerExclusionReason(
+	r db.Runner,
+	runnerTag *string,
+	now time.Time,
+	offlineTimeout time.Duration,
+	runningTasks int,
+) string {
+	switch {
+	case !r.Active:
+		return "inactive"
+	case !r.IsRegistered():
+		return "not_registered"
+	case runnerTag == nil && !r.IsDefault:
+		return "not_default"
+	case runnerTag != nil && !r.HasTag(*runnerTag):
+		return "tag_mismatch"
+	case !r.IsOnline(now, offlineTimeout):
+		return "offline"
+	case !r.HasFreeCapacity(runningTasks):
+		return "at_capacity"
+	default:
+		return ""
+	}
+}
+
+func (t *RemoteJob) logDispatchFailure(message string) {
+	if !debuglog.Enabled(log.StandardLogger(), "runner") {
+		return
+	}
+
+	fields := log.Fields{
+		"context":        "runner",
+		"task_id":        t.Task.ID,
+		"selection_mode": "default",
+	}
+	if t.RunnerTag != nil {
+		fields["selection_mode"] = "tag"
+		fields["runner_tag"] = *t.RunnerTag
+	}
+	dispatchLog := log.WithFields(fields)
+
+	projectRunners, err := t.taskPool.store.GetRunners(t.Task.ProjectID, false, db.RunnerFilterIgnoreTags, nil)
+	if err != nil {
+		dispatchLog.WithError(err).Debug("Runner dispatch diagnostics unavailable: failed to load project runners")
+		return
+	}
+	globalRunners, err := t.taskPool.store.GetAllRunners(false, true, db.RunnerFilterIgnoreTags, nil)
+	if err != nil {
+		dispatchLog.WithError(err).Debug("Runner dispatch diagnostics unavailable: failed to load global runners")
+		return
+	}
+
+	runners := slices.Concat(projectRunners, globalRunners)
+	dispatchLog.WithField("configured_runner_count", len(runners)).Debug(message)
+
+	now := tz.Now()
+	offlineTimeout := util.Config.RunnersOfflineTimeout()
+	runningTasks := countRunningTasksByRunner(t.taskPool.state.RunningRange())
+	for _, r := range runners {
+		reason := runnerExclusionReason(r, t.RunnerTag, now, offlineTimeout, runningTasks[r.ID])
+		runnerLog := dispatchLog.WithField("runner_id", r.ID)
+		if reason == "" {
+			runnerLog.Debug("Runner passes dispatch filters")
+		} else {
+			runnerLog.WithField("exclusion_reason", reason).Debug("Runner excluded from task dispatch")
+		}
+	}
 }
 
 func (t *RemoteJob) Run(username string, incomingVersion *string, alias string) (err error) {
@@ -168,11 +237,8 @@ func (t *RemoteJob) Run(username string, incomingVersion *string, alias string) 
 	runners = append(runners, shuffleRunners(projectRunners)...)
 	runners = append(runners, shuffleRunners(globalRunners)...)
 
-	if err != nil {
-		return
-	}
-
 	if len(runners) == 0 {
+		t.logDispatchFailure("No runners matched dispatch filters")
 		err = fmt.Errorf("no runners available")
 		return
 	}
@@ -184,6 +250,7 @@ func (t *RemoteJob) Run(username string, incomingVersion *string, alias string) 
 		t.taskPool.GetNumberOfRunningTasksOfRunner)
 
 	if runner == nil {
+		t.logDispatchFailure("All matching runners are offline or busy")
 		err = ErrAllRunnersBusy
 		return
 	}
@@ -191,6 +258,11 @@ func (t *RemoteJob) Run(username string, incomingVersion *string, alias string) 
 	err = callRunnerWebhook(runner, tsk, "start")
 
 	if err != nil {
+		log.WithFields(log.Fields{
+			"context":   "runner",
+			"task_id":   tsk.Task.ID,
+			"runner_id": runner.ID,
+		}).WithError(err).Error("Cannot assign task: runner start webhook request failed")
 		return
 	}
 

--- a/services/tasks/RemoteJob.go
+++ b/services/tasks/RemoteJob.go
@@ -258,11 +258,6 @@ func (t *RemoteJob) Run(username string, incomingVersion *string, alias string) 
 	err = callRunnerWebhook(runner, tsk, "start")
 
 	if err != nil {
-		log.WithFields(log.Fields{
-			"context":   "runner",
-			"task_id":   tsk.Task.ID,
-			"runner_id": runner.ID,
-		}).WithError(err).Error("Cannot assign task: runner start webhook request failed")
 		return
 	}
 

--- a/services/tasks/RemoteJob_test.go
+++ b/services/tasks/RemoteJob_test.go
@@ -1,0 +1,38 @@
+package tasks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/semaphoreui/semaphore/db"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunnerExclusionReason(t *testing.T) {
+	tag := "production"
+	now := time.Date(2026, time.September, 10, 12, 0, 0, 0, time.UTC)
+	recent := now.Add(-time.Minute)
+	tests := []struct {
+		name         string
+		runner       db.Runner
+		runnerTag    *string
+		runningTasks int
+		expected     string
+	}{
+		{"inactive", db.Runner{}, nil, 0, "inactive"},
+		{"not registered", db.Runner{Active: true, IsDefault: true}, nil, 0, "not_registered"},
+		{"not default", db.Runner{Active: true, Token: "token", Touched: &recent}, nil, 0, "not_default"},
+		{"tag mismatch", db.Runner{Active: true, Token: "token", Tags: []string{"staging"}, Touched: &recent}, &tag, 0, "tag_mismatch"},
+		{"offline", db.Runner{Active: true, Token: "token", IsDefault: true}, nil, 0, "offline"},
+		{"at capacity", db.Runner{Active: true, Token: "token", IsDefault: true, Touched: &recent, MaxParallelTasks: 2}, nil, 2, "at_capacity"},
+		{"available", db.Runner{Active: true, Token: "token", IsDefault: true, Touched: &recent}, nil, 10, ""},
+		{"webhook runner", db.Runner{Active: true, Token: "token", IsDefault: true, Webhook: "https://runner.example.test"}, nil, 0, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason := runnerExclusionReason(tt.runner, tt.runnerTag, now, 2*time.Minute, tt.runningTasks)
+			assert.Equal(t, tt.expected, reason)
+		})
+	}
+}

--- a/services/tasks/TaskPool.go
+++ b/services/tasks/TaskPool.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/semaphoreui/semaphore/pkg/debuglog"
 	"github.com/semaphoreui/semaphore/pkg/jwt"
 	"github.com/semaphoreui/semaphore/pkg/metrics"
 	"github.com/semaphoreui/semaphore/pkg/random"
@@ -169,6 +170,56 @@ func (p *TaskPool) GetNumberOfRunningTasksOfRunner(runnerID int) (res int) {
 		}
 	}
 	return
+}
+
+func countRunningTasksByRunner(tasks []*TaskRunner) map[int]int {
+	counts := make(map[int]int)
+	for _, task := range tasks {
+		if task.Task.RunnerID != nil {
+			counts[*task.Task.RunnerID]++
+		}
+	}
+	return counts
+}
+
+func (p *TaskPool) LogRunnerStateSnapshot() {
+	if !debuglog.Enabled(log.StandardLogger(), "runner") {
+		return
+	}
+	l := log.WithFields(log.Fields{
+		"context": "runner",
+	})
+
+	runners, err := p.store.GetAllRunners(false, false, db.RunnerFilterIgnoreTags, nil)
+	if err != nil {
+		l.WithError(err).Debug("Runner startup diagnostics unavailable")
+		return
+	}
+
+	if len(runners) == 0 {
+		l.Debug("No runners configured at server startup")
+		return
+	}
+
+	now := tz.Now()
+	runningTasks := countRunningTasksByRunner(p.state.RunningRange())
+	for _, runner := range runners {
+		l := l.WithFields(log.Fields{
+			"runner_id":          runner.ID,
+			"runner_name":        runner.Name,
+			"active":             runner.Active,
+			"registered":         runner.IsRegistered(),
+			"online":             runner.IsOnline(now, util.Config.RunnersOfflineTimeout()),
+			"is_default":         runner.IsDefault,
+			"tags":               runner.Tags,
+			"max_parallel_tasks": runner.MaxParallelTasks,
+			"running_tasks":      runningTasks[runner.ID],
+		})
+		if runner.ProjectID != nil {
+			l = l.WithField("project_id", *runner.ProjectID)
+		}
+		l.Debug("Runner state at server startup")
+	}
 }
 
 func (p *TaskPool) GetRunningTasks() (res []*TaskRunner) {
@@ -488,7 +539,11 @@ func (p *TaskPool) finalizeRemoteTaskLocked(tsk *TaskRunner, runner *db.Runner) 
 
 	if runner != nil {
 		if err := callRunnerWebhook(runner, tsk, "finish"); err != nil {
-			log.WithError(err).WithField("task_id", tsk.Task.ID).Warn("remote task finish webhook failed")
+			log.WithError(err).WithFields(log.Fields{
+				"context":   "runner",
+				"task_id":   tsk.Task.ID,
+				"runner_id": runner.ID,
+			}).Warn("Runner finish webhook request failed; task finalization continues")
 		}
 	}
 

--- a/services/tasks/TaskRunner.go
+++ b/services/tasks/TaskRunner.go
@@ -201,7 +201,7 @@ func (t *TaskRunner) run() {
 			l := log.WithField("task_id", t.Task.ID).WithField("status", t.Task.Status)
 
 			if t.Task.RunnerID != nil {
-				l = log.WithField("runner_id", *t.Task.RunnerID)
+				l = l.WithField("runner_id", *t.Task.RunnerID)
 			}
 
 			l.Info("Task dispatched to runner; awaiting remote completion")

--- a/services/tasks/runner_reconciler.go
+++ b/services/tasks/runner_reconciler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/semaphoreui/semaphore/db"
+	"github.com/semaphoreui/semaphore/pkg/debuglog"
 	"github.com/semaphoreui/semaphore/pkg/task_logger"
 	"github.com/semaphoreui/semaphore/pkg/tz"
 	"github.com/semaphoreui/semaphore/util"
@@ -128,6 +129,9 @@ func (p *TaskPool) runnerTasksReconcileLoop() {
 func (p *TaskPool) reconcileRunnerTasks(now time.Time) {
 	offlineTimeout := util.Config.RunnersOfflineTimeout()
 	taskFailTimeout := util.Config.RunnersTaskFailTimeout()
+	if debuglog.Enabled(log.StandardLogger(), "runner") {
+		p.logOfflineRunners(now, offlineTimeout)
+	}
 
 	for _, tsk := range p.state.OwnedRunningRange() {
 		if tsk == nil || tsk.Task.Status.IsFinished() {
@@ -181,6 +185,30 @@ func (p *TaskPool) reconcileRunnerTasks(now time.Time) {
 		case RunnerTaskKeep:
 			// Do nothing
 		}
+	}
+}
+
+func (p *TaskPool) logOfflineRunners(now time.Time, offlineTimeout time.Duration) {
+	runners, err := p.store.GetAllRunners(true, false, db.RunnerFilterIgnoreTags, nil)
+	l := log.WithFields(log.Fields{"context": "runner"})
+	if err != nil {
+		l.WithError(err).Debug("Runner offline diagnostics unavailable")
+		return
+	}
+
+	for _, runner := range runners {
+		if runner.IsOnline(now, offlineTimeout) {
+			continue
+		}
+
+		l := l.WithFields(log.Fields{
+			"runner_id":               runner.ID,
+			"offline_timeout_seconds": int(offlineTimeout.Seconds()),
+		})
+		if runner.Touched != nil {
+			l = l.WithField("last_seen_seconds", int(now.Sub(*runner.Touched).Seconds()))
+		}
+		l.Debug("Runner is offline")
 	}
 }
 


### PR DESCRIPTION
A task can fail to reach a runner without a server-side explanation of whether no runner matched, all matching runners were offline or full, or the runner later sent an invalid or stale update.

So these are opt-in `runner` DEBUG diagnostics that expose this context while keeping normal logs unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Runner scheduling now supports unlimited capacity and more accurately avoids assigning tasks to unavailable or fully occupied runners.
  - Debug logging provides clearer visibility into runner availability, capacity, offline status, and dispatch decisions.

- **Bug Fixes**
  - Webhook errors now report the actual HTTP status and include improved runner context.
  - Task and runner logs retain relevant identifiers for easier troubleshooting.
  - Runner state transitions, restarts, and task processing now produce clearer diagnostic messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->