### PR TITLE
feat(telegram): add optional topic thread ID for alerts

### DIFF
--- a/api-docs.yml
+++ b/api-docs.yml
@@ -255,6 +255,8 @@ definitions:
             type: boolean
           alert_chat:
             type: string
+          alert_thread:
+            type: string
           max_parallel_tasks:
             type: integer
             minimum: 0
@@ -403,6 +405,10 @@ definitions:
         type: string
         x-nullable: true
         example: Test
+      alert_thread:
+        type: string
+        x-nullable: true
+        example: "123"
       max_parallel_tasks:
         type: integer
         minimum: 0
@@ -430,6 +436,10 @@ definitions:
         type: string
         x-nullable: true
         example: Test
+      alert_thread:
+        type: string
+        x-nullable: true
+        example: "123"
       max_parallel_tasks:
         type: integer
         minimum: 0

--- a/api-docs.yml
+++ b/api-docs.yml
@@ -257,6 +257,7 @@ definitions:
             type: string
           alert_thread:
             type: string
+            description: Optional Telegram forum topic ID (message_thread_id).
           max_parallel_tasks:
             type: integer
             minimum: 0
@@ -409,6 +410,7 @@ definitions:
         type: string
         x-nullable: true
         example: "123"
+        description: Optional Telegram forum topic ID (message_thread_id).
       max_parallel_tasks:
         type: integer
         minimum: 0
@@ -440,6 +442,7 @@ definitions:
         type: string
         x-nullable: true
         example: "123"
+        description: Optional Telegram forum topic ID (message_thread_id).
       max_parallel_tasks:
         type: integer
         minimum: 0

--- a/cli/setup/setup.go
+++ b/cli/setup/setup.go
@@ -122,6 +122,7 @@ func InteractiveSetup(conf *util.ConfigType) {
 	if conf.TelegramAlert {
 		askValue("Telegram bot token (you can get it from @BotFather)", "", &conf.TelegramToken)
 		askValue("Telegram chat ID", "", &conf.TelegramChat)
+		askValue("Telegram thread / topic ID (optional)", "", &conf.TelegramThread)
 	}
 
 	askConfirmation("Enable slack alerts?", false, &conf.SlackAlert)

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -146,6 +146,7 @@ properties:
   # ==========================================================================
   telegram_alert:        { type: boolean }
   telegram_chat:         { type: string }
+  telegram_thread:       { type: string }
   telegram_token:
     type: string
     description: Telegram bot token (sensitive).

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -146,7 +146,9 @@ properties:
   # ==========================================================================
   telegram_alert:        { type: boolean }
   telegram_chat:         { type: string }
-  telegram_thread:       { type: string }
+  telegram_thread:
+    type: string
+    description: Optional Telegram forum topic ID (message_thread_id).
   telegram_token:
     type: string
     description: Telegram bot token (sensitive).

--- a/db/Migration.go
+++ b/db/Migration.go
@@ -139,6 +139,7 @@ func GetMigrations(dialect string) []Migration {
 		{Version: "2.20.3"},
 		{Version: "2.20.4"},
 		{Version: "2.20.5"},
+		{Version: "2.20.6"},
 	}
 
 	return append(initScripts, commonScripts...)

--- a/db/Project.go
+++ b/db/Project.go
@@ -11,6 +11,7 @@ type Project struct {
 	Created                time.Time `db:"created" json:"created" backup:"-"`
 	Alert                  bool      `db:"alert" json:"alert,omitempty"`
 	AlertChat              *string   `db:"alert_chat" json:"alert_chat,omitempty"`
+	AlertThread            *string   `db:"alert_thread" json:"alert_thread,omitempty"`
 	MaxParallelTasks       int       `db:"max_parallel_tasks" json:"max_parallel_tasks,omitempty"`
 	Type                   string    `db:"type" json:"type"`
 	DefaultSecretStorageID *int      `db:"default_secret_storage_id" json:"default_secret_storage_id,omitempty" backup:"-"`

--- a/db/sql/migration_2_19_11_test.go
+++ b/db/sql/migration_2_19_11_test.go
@@ -30,11 +30,14 @@ func TestMigration_2_19_11(t *testing.T) {
 	target := "2.19.2"
 	require.NoError(t, db.Migrate(store, &target))
 
-	proj, err := store.CreateProject(db.Project{Name: "p"})
+	// SqlDb.CreateProject writes alert_thread, which appears only in 2.20.6,
+	// so seed the project with SQL matching the 2.19.2 schema.
+	projectID, err := store.insert("id",
+		"insert into project (name, created) values (?, datetime('now'))", "p")
 	require.NoError(t, err)
 
 	_, err = store.Sql().Exec(
-		"insert into project__workflow_template (project_id, name) values (?, ?)", proj.ID, "wf")
+		"insert into project__workflow_template (project_id, name) values (?, ?)", projectID, "wf")
 	require.NoError(t, err)
 	workflowID, err := store.Sql().SelectInt("select id from project__workflow_template where name = 'wf'")
 	require.NoError(t, err)
@@ -55,6 +58,6 @@ func TestMigration_2_19_11(t *testing.T) {
 	err = store.Sql().SelectOne(&taskParams,
 		"select * from project__task_params where id = ?", paramsID.Int64)
 	require.NoError(t, err)
-	assert.Equal(t, proj.ID, taskParams.ProjectID)
+	assert.Equal(t, projectID, taskParams.ProjectID)
 	assert.Equal(t, []any{"web*", "db"}, taskParams.Params["limit"])
 }

--- a/db/sql/migration_2_19_14_test.go
+++ b/db/sql/migration_2_19_14_test.go
@@ -34,9 +34,10 @@ func TestMigration_2_19_14_DataSurvivesRebuild(t *testing.T) {
 	// newTemplateTestProject is unusable here: its CreateAccessKey call
 	// writes the task_id/expire_at columns which appear only in 2.20.1,
 	// so seed the access key with SQL matching the 2.19.12 schema.
-	project, err := store.CreateProject(db.Project{Name: "proj"})
+	// SqlDb.CreateProject writes alert_thread, which appears only in 2.20.6.
+	projectID, err := store.insert("id",
+		"insert into project (name, created) values (?, datetime('now'))", "proj")
 	require.NoError(t, err)
-	projectID := project.ID
 
 	keyID, err := store.insert("id",
 		"insert into access_key (name, type, project_id) values ('key', 'none', ?)", projectID)

--- a/db/sql/migrations/v2.20.6.err.sql
+++ b/db/sql/migrations/v2.20.6.err.sql
@@ -1,0 +1,1 @@
+alter table `project` drop column `alert_thread`;

--- a/db/sql/migrations/v2.20.6.sql
+++ b/db/sql/migrations/v2.20.6.sql
@@ -1,0 +1,1 @@
+alter table `project` add column `alert_thread` varchar(30) default null;

--- a/db/sql/project.go
+++ b/db/sql/project.go
@@ -11,8 +11,8 @@ func (d *SqlDb) CreateProject(project db.Project) (newProject db.Project, err er
 
 	insertId, err := d.insert(
 		"id",
-		"insert into project(name, created, type, alert, alert_chat, max_parallel_tasks) values (?, ?, ?, ?, ?, ?)",
-		project.Name, project.Created, project.Type, project.Alert, project.AlertChat, project.MaxParallelTasks)
+		"insert into project(name, created, type, alert, alert_chat, alert_thread, max_parallel_tasks) values (?, ?, ?, ?, ?, ?, ?)",
+		project.Name, project.Created, project.Type, project.Alert, project.AlertChat, project.AlertThread, project.MaxParallelTasks)
 
 	if err != nil {
 		return
@@ -111,10 +111,11 @@ func (d *SqlDb) DeleteProject(projectID int) error {
 
 func (d *SqlDb) UpdateProject(project db.Project) error {
 	_, err := d.exec(
-		"update project set name=?, alert=?, alert_chat=?, max_parallel_tasks=? where id=?",
+		"update project set name=?, alert=?, alert_chat=?, alert_thread=?, max_parallel_tasks=? where id=?",
 		project.Name,
 		project.Alert,
 		project.AlertChat,
+		project.AlertThread,
 		project.MaxParallelTasks,
 		project.ID)
 	return err

--- a/db/sql/project.go
+++ b/db/sql/project.go
@@ -1,13 +1,27 @@
 package sql
 
 import (
+	"strings"
+
 	"github.com/Masterminds/squirrel"
 	"github.com/semaphoreui/semaphore/db"
 	"github.com/semaphoreui/semaphore/pkg/tz"
 )
 
+func optionalString(s *string) *string {
+	if s == nil {
+		return nil
+	}
+	v := strings.TrimSpace(*s)
+	if v == "" {
+		return nil
+	}
+	return &v
+}
+
 func (d *SqlDb) CreateProject(project db.Project) (newProject db.Project, err error) {
 	project.Created = tz.Now()
+	project.AlertThread = optionalString(project.AlertThread)
 
 	insertId, err := d.insert(
 		"id",
@@ -110,6 +124,7 @@ func (d *SqlDb) DeleteProject(projectID int) error {
 }
 
 func (d *SqlDb) UpdateProject(project db.Project) error {
+	project.AlertThread = optionalString(project.AlertThread)
 	_, err := d.exec(
 		"update project set name=?, alert=?, alert_chat=?, alert_thread=?, max_parallel_tasks=? where id=?",
 		project.Name,

--- a/db/sql/project_test.go
+++ b/db/sql/project_test.go
@@ -38,4 +38,28 @@ func TestProjectAlertThreadRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got.AlertThread)
 	assert.Equal(t, updatedThread, *got.AlertThread)
+
+	blank := "  "
+	got.AlertThread = &blank
+	require.NoError(t, store.UpdateProject(got))
+
+	got, err = store.GetProject(created.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got.AlertThread)
+}
+
+func TestProjectAlertThreadEmptyBecomesNil(t *testing.T) {
+	store := InitConfigCreateTestStore()
+
+	blank := "   "
+	created, err := store.CreateProject(db.Project{
+		Name:        "empty-thread",
+		AlertThread: &blank,
+	})
+	require.NoError(t, err)
+	assert.Nil(t, created.AlertThread)
+
+	got, err := store.GetProject(created.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got.AlertThread)
 }

--- a/db/sql/project_test.go
+++ b/db/sql/project_test.go
@@ -1,0 +1,41 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/semaphoreui/semaphore/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectAlertThreadRoundTrip(t *testing.T) {
+	store := InitConfigCreateTestStore()
+
+	thread := "42"
+	chat := "-1001"
+	created, err := store.CreateProject(db.Project{
+		Name:        "alerts",
+		Alert:       true,
+		AlertChat:   &chat,
+		AlertThread: &thread,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created.AlertThread)
+	assert.Equal(t, thread, *created.AlertThread)
+
+	got, err := store.GetProject(created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.AlertChat)
+	require.NotNil(t, got.AlertThread)
+	assert.Equal(t, chat, *got.AlertChat)
+	assert.Equal(t, thread, *got.AlertThread)
+
+	updatedThread := "99"
+	got.AlertThread = &updatedThread
+	require.NoError(t, store.UpdateProject(got))
+
+	got, err = store.GetProject(created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.AlertThread)
+	assert.Equal(t, updatedThread, *got.AlertThread)
+}

--- a/services/tasks/TaskRunner.go
+++ b/services/tasks/TaskRunner.go
@@ -48,6 +48,7 @@ type TaskRunner struct {
 	users        []int
 	alert        bool
 	alertChat    *string
+	alertThread  *string
 	pool         *TaskPool
 	keyInstaller db_lib.AccessKeyInstaller
 
@@ -486,6 +487,7 @@ func (t *TaskRunner) populateDetails() error {
 
 	t.alert = project.Alert
 	t.alertChat = project.AlertChat
+	t.alertThread = project.AlertThread
 
 	// get project users
 	projectUsers, err := t.pool.store.GetProjectUsers(t.Template.ProjectID, db.RetrieveQueryParams{})

--- a/services/tasks/alert.go
+++ b/services/tasks/alert.go
@@ -29,7 +29,6 @@ type Alert struct {
 	Author string
 	Color  string
 	Task   alertTask
-	Chat   alertChat
 }
 
 type alertTask struct {
@@ -38,11 +37,6 @@ type alertTask struct {
 	Result  string
 	Desc    string
 	Version string
-}
-
-type alertChat struct {
-	ID       string
-	ThreadID int64
 }
 
 func stringValue(s *string) string {
@@ -98,9 +92,9 @@ type telegramSendMessage struct {
 	MessageThreadID int64  `json:"message_thread_id,omitempty"`
 }
 
-func renderTelegramAlert(alert Alert) ([]byte, error) {
+func renderTelegramAlert(alert Alert, dest telegramDestination) ([]byte, error) {
 	return json.Marshal(telegramSendMessage{
-		ChatID:    alert.Chat.ID,
+		ChatID:    dest.chatID,
 		ParseMode: "HTML",
 		Text: fmt.Sprintf(
 			"<code>%s</code>\n#%s <b>%s</b> <code>%s</code> - %s\nby %s\n%s",
@@ -112,7 +106,7 @@ func renderTelegramAlert(alert Alert) ([]byte, error) {
 			html.EscapeString(alert.Author),
 			html.EscapeString(alert.Task.URL),
 		),
-		MessageThreadID: alert.Chat.ThreadID,
+		MessageThreadID: dest.threadID,
 	})
 }
 
@@ -238,11 +232,7 @@ func (t *TaskRunner) sendTelegramAlert() {
 			Version: version,
 			Desc:    t.Task.Message,
 		},
-		Chat: alertChat{
-			ID:       dest.chatID,
-			ThreadID: dest.threadID,
-		},
-	})
+	}, dest)
 	if err != nil {
 		t.Log("Can't generate telegram alert: " + err.Error())
 		return
@@ -278,6 +268,7 @@ func (t *TaskRunner) sendTelegramAlert() {
 		return
 	}
 
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
 	t.Log("Sent successfully telegram alert")
 }
 

--- a/services/tasks/alert.go
+++ b/services/tasks/alert.go
@@ -3,8 +3,10 @@ package tasks
 import (
 	"bytes"
 	"embed"
+	"encoding/json"
 	"fmt"
 	htmltemplate "html/template"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -53,12 +55,11 @@ func normalizeTelegramThreadID(threadID string) string {
 	if threadID == "" {
 		return ""
 	}
-	for _, r := range threadID {
-		if r < '0' || r > '9' {
-			return ""
-		}
+	n, err := strconv.ParseInt(threadID, 10, 64)
+	if err != nil || n <= 0 {
+		return ""
 	}
-	return threadID
+	return strconv.FormatInt(n, 10)
 }
 
 func telegramChatAndThread(globalChat, globalThread string, projectChat, projectThread *string) (chatID, rawThread string) {
@@ -76,23 +77,48 @@ func telegramChatAndThread(globalChat, globalThread string, projectChat, project
 	return globalChat, globalThread
 }
 
-func resolveTelegramDestination(globalChat, globalThread string, projectChat, projectThread *string) (chatID, threadID string) {
+type telegramDestination struct {
+	chatID        string
+	threadID      string
+	invalidThread bool
+}
+
+func resolveTelegramDestination(globalChat, globalThread string, projectChat, projectThread *string) telegramDestination {
 	chatID, rawThread := telegramChatAndThread(globalChat, globalThread, projectChat, projectThread)
-	return chatID, normalizeTelegramThreadID(rawThread)
+	threadID := normalizeTelegramThreadID(rawThread)
+	return telegramDestination{
+		chatID:        chatID,
+		threadID:      threadID,
+		invalidThread: rawThread != "" && threadID == "",
+	}
+}
+
+type telegramSendMessage struct {
+	ChatID          string `json:"chat_id"`
+	ParseMode       string `json:"parse_mode"`
+	Text            string `json:"text"`
+	MessageThreadID int64  `json:"message_thread_id,omitempty"`
 }
 
 func renderTelegramAlert(alert Alert) ([]byte, error) {
-	tpl, err := template.ParseFS(templates, "templates/telegram.tmpl")
-	if err != nil {
-		return nil, err
+	msg := telegramSendMessage{
+		ChatID:    alert.Chat.ID,
+		ParseMode: "HTML",
+		Text: fmt.Sprintf(
+			"<code>%s</code>\n#%s <b>%s</b> <code>%s</code> - %s\nby %s\n%s",
+			alert.Name,
+			alert.Task.ID,
+			alert.Task.Result,
+			alert.Task.Version,
+			alert.Task.Desc,
+			alert.Author,
+			alert.Task.URL,
+		),
 	}
-
-	body := bytes.NewBuffer(nil)
-	if err := tpl.Execute(body, alert); err != nil {
-		return nil, err
+	if n, err := strconv.ParseInt(alert.Chat.ThreadID, 10, 64); err == nil && n > 0 {
+		msg.MessageThreadID = n
 	}
-
-	return body.Bytes(), nil
+	return json.Marshal(msg)
 }
 
 func (t *TaskRunner) shouldSkipStatusAlert() bool {
@@ -191,18 +217,17 @@ func (t *TaskRunner) sendTelegramAlert() {
 		return
 	}
 
-	chatID, rawThread := telegramChatAndThread(
+	dest := resolveTelegramDestination(
 		util.Config.TelegramChat,
 		util.Config.TelegramThread,
 		t.alertChat,
 		t.alertThread,
 	)
-	threadID := normalizeTelegramThreadID(rawThread)
-	if rawThread != "" && threadID == "" {
+	if dest.invalidThread {
 		t.Log("Invalid Telegram thread ID, sending without message_thread_id")
 	}
 
-	if chatID == "" {
+	if dest.chatID == "" {
 		return
 	}
 
@@ -220,8 +245,8 @@ func (t *TaskRunner) sendTelegramAlert() {
 			Desc:    t.Task.Message,
 		},
 		Chat: alertChat{
-			ID:       chatID,
-			ThreadID: threadID,
+			ID:       dest.chatID,
+			ThreadID: dest.threadID,
 		},
 	}
 
@@ -236,8 +261,6 @@ func (t *TaskRunner) sendTelegramAlert() {
 		return
 	}
 
-	body := bytes.NewReader(payload)
-
 	t.Log("Attempting to send telegram alert")
 
 	resp, err := http.Post(
@@ -246,20 +269,28 @@ func (t *TaskRunner) sendTelegramAlert() {
 			util.Config.TelegramToken,
 		),
 		"application/json",
-		body,
+		bytes.NewReader(payload),
 	)
-
-	if err != nil {
-		t.Log("Can't send telegram alert! Error: " + err.Error())
-	} else if resp.StatusCode != 200 {
-		t.Log("Can't send telegram alert! Response code: " + strconv.Itoa(resp.StatusCode))
-	} else {
-		t.Log("Sent successfully telegram alert")
-	}
-
 	if resp != nil {
 		defer resp.Body.Close() //nolint:errcheck
 	}
+
+	if err != nil {
+		t.Log("Can't send telegram alert! Error: " + err.Error())
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		if readErr != nil {
+			t.Log("Can't send telegram alert! Response code: " + strconv.Itoa(resp.StatusCode))
+			return
+		}
+		t.Log("Can't send telegram alert! Response code: " + strconv.Itoa(resp.StatusCode) + " " + strings.TrimSpace(string(respBody)))
+		return
+	}
+
+	t.Log("Sent successfully telegram alert")
 }
 
 func (t *TaskRunner) sendSlackAlert() {

--- a/services/tasks/alert.go
+++ b/services/tasks/alert.go
@@ -5,12 +5,14 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"html"
 	htmltemplate "html/template"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/semaphoreui/semaphore/db"
 	"github.com/semaphoreui/semaphore/pkg/task_logger"
@@ -40,7 +42,7 @@ type alertTask struct {
 
 type alertChat struct {
 	ID       string
-	ThreadID string
+	ThreadID int64
 }
 
 func stringValue(s *string) string {
@@ -50,46 +52,42 @@ func stringValue(s *string) string {
 	return strings.TrimSpace(*s)
 }
 
-func normalizeTelegramThreadID(threadID string) string {
+func parseTelegramThreadID(threadID string) (id int64, ok bool) {
 	threadID = strings.TrimSpace(threadID)
 	if threadID == "" {
-		return ""
+		return 0, true
 	}
 	n, err := strconv.ParseInt(threadID, 10, 64)
 	if err != nil || n <= 0 {
-		return ""
+		return 0, false
 	}
-	return strconv.FormatInt(n, 10)
-}
-
-func telegramChatAndThread(globalChat, globalThread string, projectChat, projectThread *string) (chatID, rawThread string) {
-	projChat := stringValue(projectChat)
-	projThread := stringValue(projectThread)
-	globalChat = strings.TrimSpace(globalChat)
-	globalThread = strings.TrimSpace(globalThread)
-
-	if projChat != "" {
-		return projChat, projThread
-	}
-	if projThread != "" {
-		return globalChat, projThread
-	}
-	return globalChat, globalThread
+	return n, true
 }
 
 type telegramDestination struct {
 	chatID        string
-	threadID      string
+	threadID      int64
 	invalidThread bool
 }
 
 func resolveTelegramDestination(globalChat, globalThread string, projectChat, projectThread *string) telegramDestination {
-	chatID, rawThread := telegramChatAndThread(globalChat, globalThread, projectChat, projectThread)
-	threadID := normalizeTelegramThreadID(rawThread)
+	projChat := stringValue(projectChat)
+	projThread := stringValue(projectThread)
+
+	chatID := strings.TrimSpace(globalChat)
+	rawThread := strings.TrimSpace(globalThread)
+	if projChat != "" {
+		chatID = projChat
+		rawThread = projThread
+	} else if projThread != "" {
+		rawThread = projThread
+	}
+
+	threadID, ok := parseTelegramThreadID(rawThread)
 	return telegramDestination{
 		chatID:        chatID,
 		threadID:      threadID,
-		invalidThread: rawThread != "" && threadID == "",
+		invalidThread: !ok,
 	}
 }
 
@@ -101,24 +99,21 @@ type telegramSendMessage struct {
 }
 
 func renderTelegramAlert(alert Alert) ([]byte, error) {
-	msg := telegramSendMessage{
+	return json.Marshal(telegramSendMessage{
 		ChatID:    alert.Chat.ID,
 		ParseMode: "HTML",
 		Text: fmt.Sprintf(
 			"<code>%s</code>\n#%s <b>%s</b> <code>%s</code> - %s\nby %s\n%s",
-			alert.Name,
-			alert.Task.ID,
-			alert.Task.Result,
-			alert.Task.Version,
-			alert.Task.Desc,
-			alert.Author,
-			alert.Task.URL,
+			html.EscapeString(alert.Name),
+			html.EscapeString(alert.Task.ID),
+			html.EscapeString(alert.Task.Result),
+			html.EscapeString(alert.Task.Version),
+			html.EscapeString(alert.Task.Desc),
+			html.EscapeString(alert.Author),
+			html.EscapeString(alert.Task.URL),
 		),
-	}
-	if n, err := strconv.ParseInt(alert.Chat.ThreadID, 10, 64); err == nil && n > 0 {
-		msg.MessageThreadID = n
-	}
-	return json.Marshal(msg)
+		MessageThreadID: alert.Chat.ThreadID,
+	})
 }
 
 func (t *TaskRunner) shouldSkipStatusAlert() bool {
@@ -223,17 +218,16 @@ func (t *TaskRunner) sendTelegramAlert() {
 		t.alertChat,
 		t.alertThread,
 	)
+	if dest.chatID == "" {
+		return
+	}
 	if dest.invalidThread {
 		t.Log("Invalid Telegram thread ID, sending without message_thread_id")
 	}
 
-	if dest.chatID == "" {
-		return
-	}
-
 	author, version := t.alertInfos()
 
-	alert := Alert{
+	payload, err := renderTelegramAlert(Alert{
 		Name:   t.Template.Name,
 		Author: author,
 		Color:  t.alertColor("telegram"),
@@ -248,22 +242,16 @@ func (t *TaskRunner) sendTelegramAlert() {
 			ID:       dest.chatID,
 			ThreadID: dest.threadID,
 		},
-	}
-
-	payload, err := renderTelegramAlert(alert)
+	})
 	if err != nil {
-		t.Log("Can't generate telegram alert template!")
-		panic(err)
-	}
-
-	if len(payload) == 0 {
-		t.Log("Buffer for telegram alert is empty")
+		t.Log("Can't generate telegram alert: " + err.Error())
 		return
 	}
 
 	t.Log("Attempting to send telegram alert")
 
-	resp, err := http.Post(
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Post(
 		fmt.Sprintf(
 			"https://api.telegram.org/bot%s/sendMessage",
 			util.Config.TelegramToken,

--- a/services/tasks/alert.go
+++ b/services/tasks/alert.go
@@ -7,6 +7,7 @@ import (
 	htmltemplate "html/template"
 	"net/http"
 	"strconv"
+	"strings"
 	"text/template"
 
 	"github.com/semaphoreui/semaphore/db"
@@ -36,7 +37,62 @@ type alertTask struct {
 }
 
 type alertChat struct {
-	ID string
+	ID       string
+	ThreadID string
+}
+
+func stringValue(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return strings.TrimSpace(*s)
+}
+
+func normalizeTelegramThreadID(threadID string) string {
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" {
+		return ""
+	}
+	for _, r := range threadID {
+		if r < '0' || r > '9' {
+			return ""
+		}
+	}
+	return threadID
+}
+
+func telegramChatAndThread(globalChat, globalThread string, projectChat, projectThread *string) (chatID, rawThread string) {
+	projChat := stringValue(projectChat)
+	projThread := stringValue(projectThread)
+	globalChat = strings.TrimSpace(globalChat)
+	globalThread = strings.TrimSpace(globalThread)
+
+	if projChat != "" {
+		return projChat, projThread
+	}
+	if projThread != "" {
+		return globalChat, projThread
+	}
+	return globalChat, globalThread
+}
+
+func resolveTelegramDestination(globalChat, globalThread string, projectChat, projectThread *string) (chatID, threadID string) {
+	chatID, rawThread := telegramChatAndThread(globalChat, globalThread, projectChat, projectThread)
+	return chatID, normalizeTelegramThreadID(rawThread)
+}
+
+func renderTelegramAlert(alert Alert) ([]byte, error) {
+	tpl, err := template.ParseFS(templates, "templates/telegram.tmpl")
+	if err != nil {
+		return nil, err
+	}
+
+	body := bytes.NewBuffer(nil)
+	if err := tpl.Execute(body, alert); err != nil {
+		return nil, err
+	}
+
+	return body.Bytes(), nil
 }
 
 func (t *TaskRunner) shouldSkipStatusAlert() bool {
@@ -135,16 +191,21 @@ func (t *TaskRunner) sendTelegramAlert() {
 		return
 	}
 
-	chatID := util.Config.TelegramChat
-	if t.alertChat != nil && *t.alertChat != "" {
-		chatID = *t.alertChat
+	chatID, rawThread := telegramChatAndThread(
+		util.Config.TelegramChat,
+		util.Config.TelegramThread,
+		t.alertChat,
+		t.alertThread,
+	)
+	threadID := normalizeTelegramThreadID(rawThread)
+	if rawThread != "" && threadID == "" {
+		t.Log("Invalid Telegram thread ID, sending without message_thread_id")
 	}
 
 	if chatID == "" {
 		return
 	}
 
-	body := bytes.NewBufferString("")
 	author, version := t.alertInfos()
 
 	alert := Alert{
@@ -159,26 +220,23 @@ func (t *TaskRunner) sendTelegramAlert() {
 			Desc:    t.Task.Message,
 		},
 		Chat: alertChat{
-			ID: chatID,
+			ID:       chatID,
+			ThreadID: threadID,
 		},
 	}
 
-	tpl, err := template.ParseFS(templates, "templates/telegram.tmpl")
-
+	payload, err := renderTelegramAlert(alert)
 	if err != nil {
-		t.Log("Can't parse telegram alert template!")
-		panic(err)
-	}
-
-	if err := tpl.Execute(body, alert); err != nil {
 		t.Log("Can't generate telegram alert template!")
 		panic(err)
 	}
 
-	if body.Len() == 0 {
+	if len(payload) == 0 {
 		t.Log("Buffer for telegram alert is empty")
 		return
 	}
+
+	body := bytes.NewReader(payload)
 
 	t.Log("Attempting to send telegram alert")
 

--- a/services/tasks/alert_test.go
+++ b/services/tasks/alert_test.go
@@ -105,6 +105,7 @@ func TestResolveTelegramDestination(t *testing.T) {
 		projectThread *string
 		wantChat      string
 		wantThread    string
+		wantInvalid   bool
 	}{
 		{
 			name:       "only global chat",
@@ -158,6 +159,7 @@ func TestResolveTelegramDestination(t *testing.T) {
 			globalThread: "not-a-number",
 			wantChat:     "-1001",
 			wantThread:   "",
+			wantInvalid:  true,
 		},
 		{
 			name:          "invalid project thread is omitted",
@@ -166,6 +168,7 @@ func TestResolveTelegramDestination(t *testing.T) {
 			projectThread: strPtr("abc"),
 			wantChat:      "-1001",
 			wantThread:    "",
+			wantInvalid:   true,
 		},
 		{
 			name:          "whitespace-only project chat is treated as unset",
@@ -176,18 +179,42 @@ func TestResolveTelegramDestination(t *testing.T) {
 			wantChat:      "-1001",
 			wantThread:    "99",
 		},
+		{
+			name:         "leading zeros are canonicalized",
+			globalChat:   "-1001",
+			globalThread: "042",
+			wantChat:     "-1001",
+			wantThread:   "42",
+		},
+		{
+			name:         "zero thread is omitted",
+			globalChat:   "-1001",
+			globalThread: "0",
+			wantChat:     "-1001",
+			wantThread:   "",
+			wantInvalid:  true,
+		},
+		{
+			name:         "negative thread is omitted",
+			globalChat:   "-1001",
+			globalThread: "-5",
+			wantChat:     "-1001",
+			wantThread:   "",
+			wantInvalid:  true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			chatID, threadID := resolveTelegramDestination(
+			dest := resolveTelegramDestination(
 				tt.globalChat,
 				tt.globalThread,
 				tt.projectChat,
 				tt.projectThread,
 			)
-			assert.Equal(t, tt.wantChat, chatID)
-			assert.Equal(t, tt.wantThread, threadID)
+			assert.Equal(t, tt.wantChat, dest.chatID)
+			assert.Equal(t, tt.wantThread, dest.threadID)
+			assert.Equal(t, tt.wantInvalid, dest.invalidThread)
 		})
 	}
 }
@@ -222,16 +249,26 @@ func TestRenderTelegramAlert_Payload(t *testing.T) {
 
 	t.Run("with thread id as json number", func(t *testing.T) {
 		alert := base
-		alert.Chat.ThreadID = "42"
+		alert.Chat.ThreadID = "042"
 
 		body, err := renderTelegramAlert(alert)
 		require.NoError(t, err)
-
-		assert.Contains(t, string(body), `"message_thread_id": 42`)
 
 		var payload map[string]any
 		require.NoError(t, json.Unmarshal(body, &payload))
 		assert.Equal(t, "-1001", payload["chat_id"])
 		assert.Equal(t, float64(42), payload["message_thread_id"])
+	})
+
+	t.Run("escapes quotes in text", func(t *testing.T) {
+		alert := base
+		alert.Name = `Deploy "prod"`
+
+		body, err := renderTelegramAlert(alert)
+		require.NoError(t, err)
+
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(body, &payload))
+		assert.Contains(t, payload["text"], `Deploy "prod"`)
 	})
 }

--- a/services/tasks/alert_test.go
+++ b/services/tasks/alert_test.go
@@ -230,13 +230,10 @@ func TestRenderTelegramAlert_Payload(t *testing.T) {
 			Desc:    "ok",
 			Version: "1.0",
 		},
-		Chat: alertChat{
-			ID: "-1001",
-		},
 	}
 
 	t.Run("without thread id", func(t *testing.T) {
-		body, err := renderTelegramAlert(base)
+		body, err := renderTelegramAlert(base, telegramDestination{chatID: "-1001"})
 		require.NoError(t, err)
 
 		var payload map[string]any
@@ -254,10 +251,7 @@ func TestRenderTelegramAlert_Payload(t *testing.T) {
 	})
 
 	t.Run("with thread id as json number", func(t *testing.T) {
-		alert := base
-		alert.Chat.ThreadID = 42
-
-		body, err := renderTelegramAlert(alert)
+		body, err := renderTelegramAlert(base, telegramDestination{chatID: "-1001", threadID: 42})
 		require.NoError(t, err)
 
 		var payload map[string]any
@@ -270,7 +264,7 @@ func TestRenderTelegramAlert_Payload(t *testing.T) {
 		alert := base
 		alert.Name = `Deploy <prod> & "qa"`
 
-		body, err := renderTelegramAlert(alert)
+		body, err := renderTelegramAlert(alert, telegramDestination{chatID: "-1001"})
 		require.NoError(t, err)
 
 		var payload map[string]any

--- a/services/tasks/alert_test.go
+++ b/services/tasks/alert_test.go
@@ -104,7 +104,7 @@ func TestResolveTelegramDestination(t *testing.T) {
 		projectChat   *string
 		projectThread *string
 		wantChat      string
-		wantThread    string
+		wantThread    int64
 		wantInvalid   bool
 	}{
 		{
@@ -113,11 +113,16 @@ func TestResolveTelegramDestination(t *testing.T) {
 			wantChat:   "-1001",
 		},
 		{
+			name:          "thread without chat still resolves",
+			projectThread: strPtr("7"),
+			wantThread:    7,
+		},
+		{
 			name:         "global chat and global thread",
 			globalChat:   "-1001",
 			globalThread: "42",
 			wantChat:     "-1001",
-			wantThread:   "42",
+			wantThread:   42,
 		},
 		{
 			name:         "project chat without thread does not use global thread",
@@ -125,7 +130,6 @@ func TestResolveTelegramDestination(t *testing.T) {
 			globalThread: "42",
 			projectChat:  strPtr("-2002"),
 			wantChat:     "-2002",
-			wantThread:   "",
 		},
 		{
 			name:          "empty project chat with project thread uses global chat",
@@ -134,7 +138,7 @@ func TestResolveTelegramDestination(t *testing.T) {
 			projectChat:   strPtr(""),
 			projectThread: strPtr("99"),
 			wantChat:      "-1001",
-			wantThread:    "99",
+			wantThread:    99,
 		},
 		{
 			name:          "nil project chat with project thread uses global chat",
@@ -142,7 +146,7 @@ func TestResolveTelegramDestination(t *testing.T) {
 			globalThread:  "42",
 			projectThread: strPtr("99"),
 			wantChat:      "-1001",
-			wantThread:    "99",
+			wantThread:    99,
 		},
 		{
 			name:          "project chat and project thread",
@@ -151,14 +155,13 @@ func TestResolveTelegramDestination(t *testing.T) {
 			projectChat:   strPtr("-2002"),
 			projectThread: strPtr("7"),
 			wantChat:      "-2002",
-			wantThread:    "7",
+			wantThread:    7,
 		},
 		{
 			name:         "invalid global thread is omitted",
 			globalChat:   "-1001",
 			globalThread: "not-a-number",
 			wantChat:     "-1001",
-			wantThread:   "",
 			wantInvalid:  true,
 		},
 		{
@@ -167,7 +170,6 @@ func TestResolveTelegramDestination(t *testing.T) {
 			globalThread:  "42",
 			projectThread: strPtr("abc"),
 			wantChat:      "-1001",
-			wantThread:    "",
 			wantInvalid:   true,
 		},
 		{
@@ -177,21 +179,20 @@ func TestResolveTelegramDestination(t *testing.T) {
 			projectChat:   strPtr("   "),
 			projectThread: strPtr(" 99 "),
 			wantChat:      "-1001",
-			wantThread:    "99",
+			wantThread:    99,
 		},
 		{
 			name:         "leading zeros are canonicalized",
 			globalChat:   "-1001",
 			globalThread: "042",
 			wantChat:     "-1001",
-			wantThread:   "42",
+			wantThread:   42,
 		},
 		{
 			name:         "zero thread is omitted",
 			globalChat:   "-1001",
 			globalThread: "0",
 			wantChat:     "-1001",
-			wantThread:   "",
 			wantInvalid:  true,
 		},
 		{
@@ -199,7 +200,6 @@ func TestResolveTelegramDestination(t *testing.T) {
 			globalChat:   "-1001",
 			globalThread: "-5",
 			wantChat:     "-1001",
-			wantThread:   "",
 			wantInvalid:  true,
 		},
 	}
@@ -242,6 +242,12 @@ func TestRenderTelegramAlert_Payload(t *testing.T) {
 		var payload map[string]any
 		require.NoError(t, json.Unmarshal(body, &payload))
 		assert.Equal(t, "-1001", payload["chat_id"])
+		assert.Equal(t, "HTML", payload["parse_mode"])
+		assert.Equal(
+			t,
+			"<code>Deploy</code>\n#12 <b>success</b> <code>1.0</code> - ok\nby Ann\nhttps://example.test/task/12",
+			payload["text"],
+		)
 		_, hasThread := payload["message_thread_id"]
 		assert.False(t, hasThread)
 		assert.NotContains(t, string(body), "message_thread_id")
@@ -249,7 +255,7 @@ func TestRenderTelegramAlert_Payload(t *testing.T) {
 
 	t.Run("with thread id as json number", func(t *testing.T) {
 		alert := base
-		alert.Chat.ThreadID = "042"
+		alert.Chat.ThreadID = 42
 
 		body, err := renderTelegramAlert(alert)
 		require.NoError(t, err)
@@ -260,15 +266,18 @@ func TestRenderTelegramAlert_Payload(t *testing.T) {
 		assert.Equal(t, float64(42), payload["message_thread_id"])
 	})
 
-	t.Run("escapes quotes in text", func(t *testing.T) {
+	t.Run("escapes html in text", func(t *testing.T) {
 		alert := base
-		alert.Name = `Deploy "prod"`
+		alert.Name = `Deploy <prod> & "qa"`
 
 		body, err := renderTelegramAlert(alert)
 		require.NoError(t, err)
 
 		var payload map[string]any
 		require.NoError(t, json.Unmarshal(body, &payload))
-		assert.Contains(t, payload["text"], `Deploy "prod"`)
+		text, ok := payload["text"].(string)
+		require.True(t, ok)
+		assert.Contains(t, text, `Deploy &lt;prod&gt; &amp; &#34;qa&#34;`)
+		assert.NotContains(t, text, `<prod>`)
 	})
 }

--- a/services/tasks/alert_test.go
+++ b/services/tasks/alert_test.go
@@ -1,12 +1,18 @@
 package tasks
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/semaphoreui/semaphore/db"
 	"github.com/semaphoreui/semaphore/pkg/task_logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func strPtr(s string) *string {
+	return &s
+}
 
 func TestShouldSkipStatusAlert(t *testing.T) {
 	tests := []struct {
@@ -88,4 +94,144 @@ func TestShouldSkipStatusAlert(t *testing.T) {
 			assert.Equal(t, tt.expected, runner.shouldSkipStatusAlert())
 		})
 	}
+}
+
+func TestResolveTelegramDestination(t *testing.T) {
+	tests := []struct {
+		name          string
+		globalChat    string
+		globalThread  string
+		projectChat   *string
+		projectThread *string
+		wantChat      string
+		wantThread    string
+	}{
+		{
+			name:       "only global chat",
+			globalChat: "-1001",
+			wantChat:   "-1001",
+		},
+		{
+			name:         "global chat and global thread",
+			globalChat:   "-1001",
+			globalThread: "42",
+			wantChat:     "-1001",
+			wantThread:   "42",
+		},
+		{
+			name:         "project chat without thread does not use global thread",
+			globalChat:   "-1001",
+			globalThread: "42",
+			projectChat:  strPtr("-2002"),
+			wantChat:     "-2002",
+			wantThread:   "",
+		},
+		{
+			name:          "empty project chat with project thread uses global chat",
+			globalChat:    "-1001",
+			globalThread:  "42",
+			projectChat:   strPtr(""),
+			projectThread: strPtr("99"),
+			wantChat:      "-1001",
+			wantThread:    "99",
+		},
+		{
+			name:          "nil project chat with project thread uses global chat",
+			globalChat:    "-1001",
+			globalThread:  "42",
+			projectThread: strPtr("99"),
+			wantChat:      "-1001",
+			wantThread:    "99",
+		},
+		{
+			name:          "project chat and project thread",
+			globalChat:    "-1001",
+			globalThread:  "42",
+			projectChat:   strPtr("-2002"),
+			projectThread: strPtr("7"),
+			wantChat:      "-2002",
+			wantThread:    "7",
+		},
+		{
+			name:         "invalid global thread is omitted",
+			globalChat:   "-1001",
+			globalThread: "not-a-number",
+			wantChat:     "-1001",
+			wantThread:   "",
+		},
+		{
+			name:          "invalid project thread is omitted",
+			globalChat:    "-1001",
+			globalThread:  "42",
+			projectThread: strPtr("abc"),
+			wantChat:      "-1001",
+			wantThread:    "",
+		},
+		{
+			name:          "whitespace-only project chat is treated as unset",
+			globalChat:    "-1001",
+			globalThread:  "42",
+			projectChat:   strPtr("   "),
+			projectThread: strPtr(" 99 "),
+			wantChat:      "-1001",
+			wantThread:    "99",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chatID, threadID := resolveTelegramDestination(
+				tt.globalChat,
+				tt.globalThread,
+				tt.projectChat,
+				tt.projectThread,
+			)
+			assert.Equal(t, tt.wantChat, chatID)
+			assert.Equal(t, tt.wantThread, threadID)
+		})
+	}
+}
+
+func TestRenderTelegramAlert_Payload(t *testing.T) {
+	base := Alert{
+		Name:   "Deploy",
+		Author: "Ann",
+		Task: alertTask{
+			ID:      "12",
+			URL:     "https://example.test/task/12",
+			Result:  "success",
+			Desc:    "ok",
+			Version: "1.0",
+		},
+		Chat: alertChat{
+			ID: "-1001",
+		},
+	}
+
+	t.Run("without thread id", func(t *testing.T) {
+		body, err := renderTelegramAlert(base)
+		require.NoError(t, err)
+
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(body, &payload))
+		assert.Equal(t, "-1001", payload["chat_id"])
+		_, hasThread := payload["message_thread_id"]
+		assert.False(t, hasThread)
+		assert.NotContains(t, string(body), "message_thread_id")
+	})
+
+	t.Run("with thread id as json number", func(t *testing.T) {
+		alert := base
+		alert.Chat.ThreadID = "42"
+
+		body, err := renderTelegramAlert(alert)
+		require.NoError(t, err)
+
+		assert.Contains(t, string(body), `"message_thread_id": 42`)
+
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(body, &payload))
+		assert.Equal(t, "-1001", payload["chat_id"])
+		assert.Equal(t, float64(42), payload["message_thread_id"])
+	})
 }

--- a/services/tasks/alert_test_sender.go
+++ b/services/tasks/alert_test_sender.go
@@ -31,9 +31,10 @@ func SendProjectTestAlerts(project db.Project, store db.Store) (err error) {
 			Name:      "Test Notification",
 			Type:      db.TemplateTask,
 		},
-		users:     userIDs,
-		alert:     project.Alert,
-		alertChat: project.AlertChat,
+		users:       userIDs,
+		alert:       project.Alert,
+		alertChat:   project.AlertChat,
+		alertThread: project.AlertThread,
 		pool: &TaskPool{
 			logger: make(chan logRecord, 100),
 			store:  store,

--- a/services/tasks/templates/telegram.tmpl
+++ b/services/tasks/templates/telegram.tmpl
@@ -1,8 +1,0 @@
-{
-    "chat_id": "{{ .Chat.ID }}",
-    {{- if .Chat.ThreadID }}
-    "message_thread_id": {{ .Chat.ThreadID }},
-    {{- end }}
-    "parse_mode": "HTML",
-    "text": "<code>{{ .Name }}</code>\n#{{ .Task.ID }} <b>{{ .Task.Result }}</b> <code>{{ .Task.Version }}</code> - {{ .Task.Desc }}\nby {{ .Author }}\n{{ .Task.URL }}"
-}

--- a/services/tasks/templates/telegram.tmpl
+++ b/services/tasks/templates/telegram.tmpl
@@ -1,5 +1,8 @@
 {
     "chat_id": "{{ .Chat.ID }}",
+    {{- if .Chat.ThreadID }}
+    "message_thread_id": {{ .Chat.ThreadID }},
+    {{- end }}
     "parse_mode": "HTML",
     "text": "<code>{{ .Name }}</code>\n#{{ .Task.ID }} <b>{{ .Task.Result }}</b> <code>{{ .Task.Version }}</code> - {{ .Task.Desc }}\nby {{ .Author }}\n{{ .Task.URL }}"
 }

--- a/util/config.go
+++ b/util/config.go
@@ -625,7 +625,7 @@ type ConfigType struct {
 	// Telegram, Slack, Rocket.Chat, Microsoft Teams, DingTalk, and Gotify alerting
 	TelegramAlert       bool   `json:"telegram_alert,omitempty" env:"SEMAPHORE_TELEGRAM_ALERT"`
 	TelegramChat        string `json:"telegram_chat,omitempty" env:"SEMAPHORE_TELEGRAM_CHAT"`
-	TelegramThread      string `json:"telegram_thread,omitempty" env:"SEMAPHORE_TELEGRAM_THREAD"`
+	TelegramThread      string `json:"telegram_thread,omitempty" env:"SEMAPHORE_TELEGRAM_THREAD"` // forum topic ID (message_thread_id)
 	TelegramToken       string `json:"telegram_token,omitempty" env:"SEMAPHORE_TELEGRAM_TOKEN,sensitive"`
 	SlackAlert          bool   `json:"slack_alert,omitempty" env:"SEMAPHORE_SLACK_ALERT"`
 	SlackUrl            string `json:"slack_url,omitempty" env:"SEMAPHORE_SLACK_URL"`

--- a/util/config.go
+++ b/util/config.go
@@ -625,6 +625,7 @@ type ConfigType struct {
 	// Telegram, Slack, Rocket.Chat, Microsoft Teams, DingTalk, and Gotify alerting
 	TelegramAlert       bool   `json:"telegram_alert,omitempty" env:"SEMAPHORE_TELEGRAM_ALERT"`
 	TelegramChat        string `json:"telegram_chat,omitempty" env:"SEMAPHORE_TELEGRAM_CHAT"`
+	TelegramThread      string `json:"telegram_thread,omitempty" env:"SEMAPHORE_TELEGRAM_THREAD"`
 	TelegramToken       string `json:"telegram_token,omitempty" env:"SEMAPHORE_TELEGRAM_TOKEN,sensitive"`
 	SlackAlert          bool   `json:"slack_alert,omitempty" env:"SEMAPHORE_SLACK_ALERT"`
 	SlackUrl            string `json:"slack_url,omitempty" env:"SEMAPHORE_SLACK_URL"`

--- a/web/src/components/ProjectForm.vue
+++ b/web/src/components/ProjectForm.vue
@@ -42,6 +42,10 @@
       :label="$t('telegramThreadIdOptional')"
       :hint="$t('telegramThreadIdHint')"
       persistent-hint
+      :rules="[
+        (v) => v == null || v === '' || /^\d+$/.test(String(v)) || $t('mustBeInteger'),
+        (v) => v == null || v === '' || Number(v) >= 1 || $t('mustBe1OrGreater'),
+      ]"
       :disabled="formSaving"
       data-testid="newProject-tg-thread"
       outlined

--- a/web/src/components/ProjectForm.vue
+++ b/web/src/components/ProjectForm.vue
@@ -37,6 +37,17 @@
       dense
     ></v-text-field>
 
+    <v-text-field
+      v-model="item.alert_thread"
+      :label="$t('telegramThreadIdOptional')"
+      :hint="$t('telegramThreadIdHint')"
+      persistent-hint
+      :disabled="formSaving"
+      data-testid="newProject-tg-thread"
+      outlined
+      dense
+    ></v-text-field>
+
     <v-checkbox
       class="mt-0"
       v-model="item.alert"

--- a/web/src/components/ProjectForm.vue
+++ b/web/src/components/ProjectForm.vue
@@ -92,6 +92,10 @@ export default {
       if (this.item.max_parallel_tasks === '') {
         this.item.max_parallel_tasks = 0;
       }
+      if (typeof this.item.alert_thread === 'string') {
+        const thread = this.item.alert_thread.trim();
+        this.item.alert_thread = thread === '' ? null : thread;
+      }
     },
   },
 };

--- a/web/src/lang/cs.js
+++ b/web/src/lang/cs.js
@@ -261,6 +261,7 @@ export default {
   isRequired: 'je povinné',
   mustBeInteger: 'Musí být celé číslo',
   mustBe0OrGreater: 'Musí být 0 nebo více',
+  mustBe1OrGreater: 'Musí být 1 nebo více',
   start_version_required: 'Počáteční verze je povinná',
   playbook_filename_required: 'Název souboru playbooku je povinný',
   inventory_required: 'Inventář je povinný',

--- a/web/src/lang/cs.js
+++ b/web/src/lang/cs.js
@@ -111,6 +111,8 @@ export default {
   projectName: 'Název projektu',
   allowAlertsForThisProject: 'Povolit upozornění pro tento projekt',
   telegramChatIdOptional: 'ID chatu Telegramu (volitelné)',
+  telegramThreadIdOptional: 'ID vlákna Telegramu (volitelné)',
+  telegramThreadIdHint: 'Volitelné ID tématu fóra. Vyžaduje Telegram chat ID (projekt nebo globální).',
   maxNumberOfParallelTasksOptional: 'Maximální počet paralelních úloh (volitelné)',
   deleteRepository: 'Odstranit repozitář',
   newRepository: 'Nový repozitář',

--- a/web/src/lang/de.js
+++ b/web/src/lang/de.js
@@ -266,6 +266,7 @@ export default {
   isRequired: 'ist erforderlich',
   mustBeInteger: 'Muss eine ganze Zahl sein',
   mustBe0OrGreater: 'Muss >= 0 sein',
+  mustBe1OrGreater: 'Muss >= 1 sein',
   start_version_required: 'Startversion ist erforderlich',
   playbook_filename_required: 'Playbook-Dateiname ist erforderlich',
   inventory_required: 'Inventory ist erforderlich',

--- a/web/src/lang/de.js
+++ b/web/src/lang/de.js
@@ -109,6 +109,8 @@ export default {
   projectName: 'Projektname',
   allowAlertsForThisProject: 'Benachrichtigungen für dieses Projekt erlauben',
   telegramChatIdOptional: 'Telegram Chat ID (optional)',
+  telegramThreadIdOptional: 'Telegram Thread-ID (optional)',
+  telegramThreadIdHint: 'Optionale Forum-Topic-ID. Erfordert eine Telegram-Chat-ID (Projekt oder global).',
   maxNumberOfParallelTasksOptional: 'Max. Anzahl paralleler Tasks (optional)',
   deleteRepository: 'Repository löschen',
   newRepository: 'Neues Repository',

--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -123,6 +123,8 @@ export default {
   projectName: 'Project Name',
   allowAlertsForThisProject: 'Allow alerts for this project',
   telegramChatIdOptional: 'Telegram Chat ID (Optional)',
+  telegramThreadIdOptional: 'Telegram Thread ID (Optional)',
+  telegramThreadIdHint: 'Optional forum topic ID. Requires a Telegram chat ID (project or global).',
   maxNumberOfParallelTasksOptional: 'Max number of parallel tasks (Optional)',
   deleteRepository: 'Delete repository',
   newRepository: 'New Repository',

--- a/web/src/lang/en.js
+++ b/web/src/lang/en.js
@@ -291,6 +291,7 @@ export default {
   isRequired: 'is required',
   mustBeInteger: 'Must be integer',
   mustBe0OrGreater: 'Must be 0 or greater',
+  mustBe1OrGreater: 'Must be 1 or greater',
   start_version_required: 'Start version is required',
   playbook_filename_required: 'Playbook filename is required',
   working_directory_required: 'Working directory is required',

--- a/web/src/lang/es.js
+++ b/web/src/lang/es.js
@@ -105,6 +105,8 @@ export default {
   projectName: 'Nombre del Proyecto',
   allowAlertsForThisProject: 'Permitir alertas para este proyecto',
   telegramChatIdOptional: 'ID de Chat de Telegram (Opcional)',
+  telegramThreadIdOptional: 'ID de hilo de Telegram (Opcional)',
+  telegramThreadIdHint: 'ID opcional del tema del foro. Requiere un ID de chat de Telegram (proyecto o global).',
   maxNumberOfParallelTasksOptional: 'Número máximo de tareas paralelas (Opcional)',
   deleteRepository: 'Eliminar repositorio',
   newRepository: 'Nuevo Repositorio',

--- a/web/src/lang/es.js
+++ b/web/src/lang/es.js
@@ -257,6 +257,7 @@ export default {
   isRequired: 'es requerido',
   mustBeInteger: 'Debe ser un número entero',
   mustBe0OrGreater: 'Debe ser 0 o mayor',
+  mustBe1OrGreater: 'Debe ser 1 o mayor',
   start_version_required: 'Se requiere versión inicial',
   playbook_filename_required: 'Se requiere nombre de archivo de playbook',
   inventory_required: 'Se requiere inventario',

--- a/web/src/lang/fr.js
+++ b/web/src/lang/fr.js
@@ -257,6 +257,7 @@ export default {
   isRequired: 'est requis',
   mustBeInteger: 'Doit être un entier',
   mustBe0OrGreater: 'Doit être 0 ou plus',
+  mustBe1OrGreater: 'Doit être 1 ou plus',
   start_version_required: 'La version de départ est requise',
   playbook_filename_required: 'Le nom du fichier playbook est requis',
   inventory_required: 'L\'inventaire est requis',

--- a/web/src/lang/fr.js
+++ b/web/src/lang/fr.js
@@ -105,6 +105,8 @@ export default {
   projectName: 'Nom du projet',
   allowAlertsForThisProject: 'Autoriser les alertes pour ce projet',
   telegramChatIdOptional: 'ID de chat Telegram (optionnel)',
+  telegramThreadIdOptional: 'ID de fil Telegram (optionnel)',
+  telegramThreadIdHint: 'ID de sujet de forum optionnel. Nécessite un ID de chat Telegram (projet ou global).',
   maxNumberOfParallelTasksOptional: 'Nombre maximum de tâches parallèles (optionnel)',
   deleteRepository: 'Supprimer le dépôt',
   newRepository: 'Nouveau dépôt',

--- a/web/src/lang/it.js
+++ b/web/src/lang/it.js
@@ -257,6 +257,7 @@ export default {
   isRequired: 'è obbligatorio',
   mustBeInteger: 'Deve essere un intero',
   mustBe0OrGreater: 'Deve essere 0 o maggiore',
+  mustBe1OrGreater: 'Deve essere 1 o maggiore',
   start_version_required: 'La versione di partenza è obbligatoria',
   playbook_filename_required: 'Il nome del file playbook è obbligatorio',
   inventory_required: 'L\'inventario è obbligatorio',

--- a/web/src/lang/it.js
+++ b/web/src/lang/it.js
@@ -105,6 +105,8 @@ export default {
   projectName: 'Nome progetto',
   allowAlertsForThisProject: 'Consenti avvisi per questo progetto',
   telegramChatIdOptional: 'ID chat Telegram (Opzionale)',
+  telegramThreadIdOptional: 'ID thread Telegram (Opzionale)',
+  telegramThreadIdHint: 'ID argomento forum opzionale. Richiede un ID chat Telegram (progetto o globale).',
   maxNumberOfParallelTasksOptional: 'Numero massimo di compiti paralleli (Opzionale)',
   deleteRepository: 'Elimina repository',
   newRepository: 'Nuovo repository',

--- a/web/src/lang/ja.js
+++ b/web/src/lang/ja.js
@@ -257,6 +257,7 @@ export default {
   isRequired: 'は必須です',
   mustBeInteger: '整数でなければなりません',
   mustBe0OrGreater: '0以上でなければなりません',
+  mustBe1OrGreater: '1以上でなければなりません',
   start_version_required: '開始バージョンは必須です',
   playbook_filename_required: 'プレイブックファイル名は必須です',
   inventory_required: 'インベントリは必須です',

--- a/web/src/lang/ja.js
+++ b/web/src/lang/ja.js
@@ -105,6 +105,8 @@ export default {
   projectName: 'プロジェクト名',
   allowAlertsForThisProject: 'このプロジェクトのアラートを許可',
   telegramChatIdOptional: 'TelegramチャットID（オプション）',
+  telegramThreadIdOptional: 'TelegramスレッドID（オプション）',
+  telegramThreadIdHint: '任意のフォーラムトピックID。TelegramチャットID（プロジェクトまたはグローバル）が必要です。',
   maxNumberOfParallelTasksOptional: '最大並列タスク数（オプション）',
   deleteRepository: 'リポジトリを削除',
   newRepository: '新しいリポジトリ',

--- a/web/src/lang/ko.js
+++ b/web/src/lang/ko.js
@@ -105,6 +105,8 @@ export default {
   projectName: '프로젝트 이름',
   allowAlertsForThisProject: '이 프로젝트에 대한 알림 허용',
   telegramChatIdOptional: '텔레그램 채팅 ID (선택 사항)',
+  telegramThreadIdOptional: '텔레그램 스레드 ID (선택 사항)',
+  telegramThreadIdHint: '선택적 포럼 주제 ID. 텔레그램 채팅 ID가 필요합니다(프로젝트 또는 전역).',
   maxNumberOfParallelTasksOptional: '최대 병렬 작업 수 (선택 사항)',
   deleteRepository: '리포지토리 삭제',
   newRepository: '새 리포지토리',

--- a/web/src/lang/ko.js
+++ b/web/src/lang/ko.js
@@ -257,6 +257,7 @@ export default {
   isRequired: '필수입니다',
   mustBeInteger: '정수여야 합니다',
   mustBe0OrGreater: '0 이상이어야 합니다',
+  mustBe1OrGreater: '1 이상이어야 합니다',
   start_version_required: '시작 버전은 필수입니다',
   playbook_filename_required: '플레이북 파일 이름은 필수입니다',
   inventory_required: '인벤토리는 필수입니다',

--- a/web/src/lang/nl.js
+++ b/web/src/lang/nl.js
@@ -257,6 +257,7 @@ export default {
   isRequired: 'is vereist',
   mustBeInteger: 'Moet een geheel getal zijn',
   mustBe0OrGreater: 'Moet 0 of groter zijn',
+  mustBe1OrGreater: 'Moet 1 of groter zijn',
   start_version_required: 'Startversie is vereist',
   playbook_filename_required: 'Playbook-bestandsnaam is vereist',
   inventory_required: 'Inventaris is vereist',

--- a/web/src/lang/nl.js
+++ b/web/src/lang/nl.js
@@ -105,6 +105,8 @@ export default {
   projectName: 'Projectnaam',
   allowAlertsForThisProject: 'Sta waarschuwingen voor dit project toe',
   telegramChatIdOptional: 'Telegram Chat ID (Optioneel)',
+  telegramThreadIdOptional: 'Telegram Thread ID (Optioneel)',
+  telegramThreadIdHint: 'Optionele forum-topic-ID. Vereist een Telegram-chat-ID (project of globaal).',
   maxNumberOfParallelTasksOptional: 'Maximaal aantal parallelle taken (Optioneel)',
   deleteRepository: 'Repository Verwijderen',
   newRepository: 'Nieuwe Repository',

--- a/web/src/lang/pl.js
+++ b/web/src/lang/pl.js
@@ -105,6 +105,8 @@ export default {
   projectName: 'Nazwa projektu',
   allowAlertsForThisProject: 'Zezwól na alerty dla tego projektu',
   telegramChatIdOptional: 'ID czatu Telegram (opcjonalnie)',
+  telegramThreadIdOptional: 'ID wątku Telegram (opcjonalnie)',
+  telegramThreadIdHint: 'Opcjonalne ID tematu forum. Wymaga ID czatu Telegram (projekt lub globalne).',
   maxNumberOfParallelTasksOptional: 'Maksymalna liczba równoległych zadań (opcjonalnie)',
   deleteRepository: 'Usuń repozytorium',
   newRepository: 'Nowe repozytorium',

--- a/web/src/lang/pl.js
+++ b/web/src/lang/pl.js
@@ -257,6 +257,7 @@ export default {
   isRequired: 'jest wymagane',
   mustBeInteger: 'Musi być liczbą całkowitą',
   mustBe0OrGreater: 'Musi być 0 lub większa',
+  mustBe1OrGreater: 'Musi być 1 lub większa',
   start_version_required: 'Wersja początkowa jest wymagana',
   playbook_filename_required: 'Nazwa pliku playbook jest wymagana',
   inventory_required: 'Inwentarz jest wymagany',

--- a/web/src/lang/pt.js
+++ b/web/src/lang/pt.js
@@ -105,6 +105,8 @@ export default {
   projectName: 'Nome do Projeto',
   allowAlertsForThisProject: 'Permitir alertas para este projeto',
   telegramChatIdOptional: 'ID do Chat do Telegram (Opcional)',
+  telegramThreadIdOptional: 'ID do tópico do Telegram (Opcional)',
+  telegramThreadIdHint: 'ID opcional do tópico do fórum. Requer um ID de chat do Telegram (projeto ou global).',
   maxNumberOfParallelTasksOptional: 'Número máximo de tarefas paralelas (Opcional)',
   deleteRepository: 'Excluir repositório',
   newRepository: 'Novo Repositório',

--- a/web/src/lang/pt.js
+++ b/web/src/lang/pt.js
@@ -257,6 +257,7 @@ export default {
   isRequired: 'é obrigatório',
   mustBeInteger: 'Deve ser um número inteiro',
   mustBe0OrGreater: 'Deve ser 0 ou maior',
+  mustBe1OrGreater: 'Deve ser 1 ou maior',
   start_version_required: 'Versão inicial é obrigatória',
   playbook_filename_required: 'Nome do arquivo do playbook é obrigatório',
   inventory_required: 'Inventário é obrigatório',

--- a/web/src/lang/pt_br.js
+++ b/web/src/lang/pt_br.js
@@ -257,6 +257,7 @@ export default {
   isRequired: 'é obrigatório',
   mustBeInteger: 'Deve ser um número inteiro',
   mustBe0OrGreater: 'Deve ser 0 ou maior',
+  mustBe1OrGreater: 'Deve ser 1 ou maior',
   start_version_required: 'Versão inicial é obrigatória',
   playbook_filename_required: 'Nome do arquivo playbook é obrigatório',
   inventory_required: 'Inventário é obrigatório',

--- a/web/src/lang/pt_br.js
+++ b/web/src/lang/pt_br.js
@@ -105,6 +105,8 @@ export default {
   projectName: 'Nome do Projeto',
   allowAlertsForThisProject: 'Permitir alertas para este projeto',
   telegramChatIdOptional: 'ID do Chat do Telegram (Opcional)',
+  telegramThreadIdOptional: 'ID do tópico do Telegram (Opcional)',
+  telegramThreadIdHint: 'ID opcional do tópico do fórum. Requer um ID de chat do Telegram (projeto ou global).',
   maxNumberOfParallelTasksOptional: 'Número máximo de tarefas paralelas (Opcional)',
   deleteRepository: 'Excluir repositório',
   newRepository: 'Novo Repositório',

--- a/web/src/lang/ru.js
+++ b/web/src/lang/ru.js
@@ -113,6 +113,8 @@ export default {
   projectName: 'Имя проекта',
   allowAlertsForThisProject: 'Разрешить оповещения для этого проекта',
   telegramChatIdOptional: 'Telegram Chat ID (необязательно)',
+  telegramThreadIdOptional: 'Telegram Thread ID (необязательно)',
+  telegramThreadIdHint: 'Необязательный ID темы форума. Требуется Telegram Chat ID (проекта или глобальный).',
   maxNumberOfParallelTasksOptional: 'Максимальное количество параллельных задач (необязательно)',
   deleteRepository: 'Удалить репозиторий',
   newRepository: 'Новый репозиторий',

--- a/web/src/lang/ru.js
+++ b/web/src/lang/ru.js
@@ -265,6 +265,7 @@ export default {
   isRequired: 'обязательно',
   mustBeInteger: 'Должно быть целым числом',
   mustBe0OrGreater: 'Должно быть 0 или больше',
+  mustBe1OrGreater: 'Должно быть 1 или больше',
   start_version_required: 'Начальная версия обязательна',
   playbook_filename_required: 'Имя файла плейбука обязательно',
   inventory_required: 'Инвентарь обязателен',

--- a/web/src/lang/uk.js
+++ b/web/src/lang/uk.js
@@ -258,6 +258,7 @@ export default {
   isRequired: 'обов’язково',
   mustBeInteger: 'Має бути ціле число',
   mustBe0OrGreater: 'Має бути 0 або більше',
+  mustBe1OrGreater: 'Має бути 1 або більше',
   start_version_required: 'Початкова версія обов’язкова',
   playbook_filename_required: 'Потрібно вказати playbook',
   inventory_required: 'Необхідно вказати інвентар',

--- a/web/src/lang/uk.js
+++ b/web/src/lang/uk.js
@@ -106,6 +106,8 @@ export default {
   projectName: 'Назва проєкту',
   allowAlertsForThisProject: 'Дозволити сповіщення для цього проєкту',
   telegramChatIdOptional: 'Telegram Chat ID (необов’язково)',
+  telegramThreadIdOptional: 'Telegram Thread ID (необов’язково)',
+  telegramThreadIdHint: 'Необов’язковий ID теми форуму. Потрібен Telegram Chat ID (проєкту або глобальний).',
   maxNumberOfParallelTasksOptional: 'Максимальна кількість паралельних завдань (необов’язково)',
   deleteRepository: 'Видалити репозиторій',
   newRepository: 'Новий репозиторій',

--- a/web/src/lang/zh_cn.js
+++ b/web/src/lang/zh_cn.js
@@ -105,6 +105,8 @@ export default {
   projectName: '项目名称',
   allowAlertsForThisProject: '允许此项目的警报',
   telegramChatIdOptional: 'Telegram 聊天 ID（可选）',
+  telegramThreadIdOptional: 'Telegram 话题 ID（可选）',
+  telegramThreadIdHint: '可选的论坛话题 ID。需要 Telegram 聊天 ID（项目或全局）。',
   maxNumberOfParallelTasksOptional: '最大并行任务数（可选）',
   deleteRepository: '删除仓库',
   newRepository: '新仓库',

--- a/web/src/lang/zh_cn.js
+++ b/web/src/lang/zh_cn.js
@@ -257,6 +257,7 @@ export default {
   isRequired: '是必需的',
   mustBeInteger: '必须是整数',
   mustBe0OrGreater: '必须是 0 或更大',
+  mustBe1OrGreater: '必须是 1 或更大',
   start_version_required: '起始版本是必需的',
   playbook_filename_required: '剧本文件名是必需的',
   inventory_required: '库存是必需的',

--- a/web/src/lang/zh_tw.js
+++ b/web/src/lang/zh_tw.js
@@ -259,6 +259,7 @@ export default {
   isRequired: '是必填的',
   mustBeInteger: '必須是整數',
   mustBe0OrGreater: '必須大於或等於 0',
+  mustBe1OrGreater: '必須大於或等於 1',
   start_version_required: '起始版本是必填的',
   playbook_filename_required: 'Playbook 檔案名稱是必填的',
   inventory_required: '清單是必填的',

--- a/web/src/lang/zh_tw.js
+++ b/web/src/lang/zh_tw.js
@@ -106,6 +106,8 @@ export default {
   projectName: '專案名稱',
   allowAlertsForThisProject: '啟用此專案的警報',
   telegramChatIdOptional: 'Telegram 聊天 ID（選填）',
+  telegramThreadIdOptional: 'Telegram 主題 ID（選填）',
+  telegramThreadIdHint: '選填的論壇主題 ID。需要 Telegram 聊天 ID（專案或全域）。',
   maxNumberOfParallelTasksOptional: '最大平行任務數（選填）',
   deleteRepository: '刪除儲存庫',
   newRepository: '新增儲存庫',


### PR DESCRIPTION
## Summary
- Add optional Telegram forum topic support via Bot API `message_thread_id`.
- Global default: `telegram_thread` / `SEMAPHORE_TELEGRAM_THREAD` (CLI setup, config schema).
- Per-project override: `alert_thread` in the project form, API, backup/restore, and SQL migration `v2.20.6`.
- Destination rules: if the project sets its own chat, only the project thread is used (no fallback to the global thread). Empty or invalid thread IDs are omitted so the message goes to General.

Fixes #1456
Fixes #3493

## Test plan
- [ ] Global chat only → alert arrives in that chat without a topic
- [ ] Global chat + global thread → alert arrives in that topic
- [ ] Same group, different topic per project: leave project chat empty, set project thread
- [ ] Different group: set project chat and optional project thread; global thread must not apply
- [ ] Clear or invalid thread ID → send without `message_thread_id`
- [ ] Project test notification uses the same chat/thread as task alerts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Telegram forum thread IDs for global and project alert settings.
  - Project alerts can now target specific Telegram topics.
  - Added setup prompts, configuration support, API documentation, and database persistence.
  - Added validation requiring thread IDs to be positive integers.
  - Added localized labels, hints, and validation messages across supported languages.

- **Bug Fixes**
  - Improved Telegram alert payload formatting and HTML escaping.
  - Added clearer handling and logging for unsuccessful Telegram responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->